### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-util-notes
 
+## 1.0.1 (https://github.com/folio-org/stripes-smart-components/tree/v1.0.1) (2017-10-11)
+[Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v0.3.0...v1.0.1)
+
+* Change NPM module name to stripes-smart-components. Fixes STSMACOM-7.
+
 ## 0.3.0 (https://github.com/folio-org/stripes-util-notes/tree/v0.3.0) (2017-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v0.2.0...v0.3.0)
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@folio/util-notes",
-  "version": "0.3.0",
-  "description": "Notes management",
-  "repository": "folio-org/stripes-util-notes",
+  "name": "@folio/stripes-smart-components",
+  "version": "1.0.1",
+  "description": "Connected Stripes components",
+  "repository": "folio-org/stripes-smart-components",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
@@ -12,7 +12,7 @@
   },
   "stripes": {
     "type": "app",
-    "displayName": "Notes",
+    "displayName": "Stripes Smart Components",
     "okapiInterfaces": {
       "notes": "1.0"
     },


### PR DESCRIPTION
Update `package.json` details from util-notes to stripes-smart-components. 

No, there wasn't a v1.0.0. Don't ask. 