### PR TITLE
dataKey is required to de-dupe names. Fixes STSMACOM-20

### DIFF
--- a/lib/Notes/NoteRenderer.js
+++ b/lib/Notes/NoteRenderer.js
@@ -32,7 +32,7 @@ class NoteRenderer extends React.Component {
     this.handleFormCancel = this.handleFormCancel.bind(this);
     this.handleFormSubmit = this.handleFormSubmit.bind(this);
     this.handleClickDelete = this.handleClickDelete.bind(this);
-    this.connectedNoteCreator = props.stripes.connect(NoteCreator);
+    this.connectedNoteCreator = props.stripes.connect(NoteCreator, { dataKey: props.note.id });
   }
 
   onToggleDropDown() {


### PR DESCRIPTION
The NoteRenderer component will be used multiple times here so we need
to pass a unique dataKey element to the `connect()` call to be sure that
each instance recieves distinct data.