### PR TITLE
Status of notes pane is now reflected in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util-notes
 
+## 1.3.0 (IN PROGRESS)
+
+* Status of notes pane is now reflected in the URL: the `notes` part of the query may be absent for no notes pane, `true` to display it, or the UUID of a specific note. Fixes STSMACOM-19.
+
 ## 1.2.0 (https://github.com/folio-org/stripes-smart-components/tree/v1.2.0) (2017-11-23)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.1.0...v1.2.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -68,6 +68,10 @@ class SearchAndSort extends React.Component {
     parentResources: PropTypes.shape({
       query: PropTypes.shape({
         filters: PropTypes.string.isRequired,
+        notes: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.bool,
+        ]),
       }),
       resultCount: PropTypes.number,
       records: PropTypes.shape({
@@ -137,7 +141,6 @@ class SearchAndSort extends React.Component {
       selectedItem: initiallySelected,
       searchTerm: queryResource.query || '',
       sortOrder: queryResource.sort || '',
-      showNotesPane: queryString.parse(this.props.location.search || '').notes,
     };
 
     this.transitionToParams = values => this.props.parentMutator.query.update(values);
@@ -251,11 +254,9 @@ class SearchAndSort extends React.Component {
   }
 
   toggleNotes = () => {
-    this.setState((curState) => {
-      const show = !curState.showNotesPane;
-      return {
-        showNotesPane: show,
-      };
+    const show = _.get(this.props.parentResources.query, 'notes');
+    this.props.parentMutator.query.update({
+      notes: show ? null : true,
     });
   }
 
@@ -430,7 +431,7 @@ class SearchAndSort extends React.Component {
           />
         </Layer>
         {
-          this.state.showNotesPane &&
+          _.get(this.props.parentResources.query, 'notes') &&
           <Route
             path={`${this.props.match.path}/view/:id`}
             render={props => <this.connectedNotes


### PR DESCRIPTION
The `notes` part of the query may be absent for no notes pane, `true`
to display it, or the UUID of a specific note.

Fixes STSMACOM-19.