### PR TITLE
`<SearchAndSort>` sets both `query` and `search`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "stripes",
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "rules": {
+    "react/jsx-wrap-multilines": [ "warn", { "arrow": false } ],
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Status of notes pane is now reflected in the URL: the `notes` part of the query may be absent for no notes pane, `true` to display it, or the UUID of a specific note. Fixes STSMACOM-19.
 * `<SearchAndSort>` made less stringent in which properties are required, so that it now supports read-only modules with no need for editing or new-record creation. Fixes STSMACOM-24.
+* `<SearchAndSort>` temporarily sets both `query` and `search` URL parameters. Fixes STSMACOM-25; see rationale in comments to  UISE-13.
 
 ## 1.2.0 (https://github.com/folio-org/stripes-smart-components/tree/v1.2.0) (2017-11-23)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.1.0...v1.2.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -190,7 +190,7 @@ class SearchAndSort extends React.Component {
   // eslint-disable-next-line react/sort-comp
   performSearch = _.debounce((query) => {
     this.log('action', `searched for '${query}'`);
-    this.transitionToParams({ search: query });
+    this.transitionToParams({ query, search: query });
   }, 350);
 
   onClearSearch = () => {


### PR DESCRIPTION
Both these URL parameters are presently needed, as discussed in comments to UISE-13. This change will eventually be undone, moving to `query` alone: see STSMACOM-27.

Fixes STSMACOM-25.
