### PR TITLE
Upgrade <SearchAndSort> to use new filter-related APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0 (IN PROGRESS)
 
 * Removed unused packages from package.json. Refs STRIPES-490.
+* Upgrade <SearchAndSort> to use new filter-related APIs. Fixes STSMACOM-35 and resolves STRIPES-493.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -8,7 +8,7 @@ import { withRouter } from 'react-router';
 // eslint-disable-next-line import/no-unresolved
 import { stripesShape } from '@folio/stripes-core/src/Stripes';
 import queryString from 'query-string';
-import FilterGroups, { initialFilterState, onChangeFilter as commonChangeFilter } from '@folio/stripes-components/lib/FilterGroups';
+import FilterGroups, { filterState, handleFilterChange } from '@folio/stripes-components/lib/FilterGroups';
 import FilterPaneSearch from '@folio/stripes-components/lib/FilterPaneSearch';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
@@ -150,7 +150,7 @@ class SearchAndSort extends React.Component {
     };
 
     this.transitionToParams = values => this.props.parentMutator.query.update(values);
-    this.commonChangeFilter = commonChangeFilter.bind(this);
+    this.handleFilterChange = handleFilterChange.bind(this);
     this.connectedViewRecord = context.stripes.connect(props.viewRecordComponent);
     this.connectedNotes = context.stripes.connect(Notes);
     this.SRStatus = null;
@@ -221,7 +221,7 @@ class SearchAndSort extends React.Component {
 
   onChangeFilter = (e) => {
     this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
-    this.commonChangeFilter(e);
+    this.handleFilterChange(e);
   }
 
   onNeedMore = () => {
@@ -256,10 +256,6 @@ class SearchAndSort extends React.Component {
   collapseDetails = () => {
     this.setState({ selectedItem: {} });
     this.transitionToParams({ _path: `${this.props.baseRoute}/view` });
-  }
-
-  updateFilters = (filters) => { // provided for onChangeFilter
-    this.transitionToParams({ filters: Object.keys(filters).filter(key => filters[key]).join(',') });
   }
 
   getRowURL(id) {
@@ -368,7 +364,7 @@ class SearchAndSort extends React.Component {
     const maybeSpelling = searchTerm ? 'spelling and ' : '';
     const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
     const sortOrder = this.queryParam('sort') || '';
-    const filters = initialFilterState(filterConfig, this.queryParam('filters'));
+    const filters = filterState(this.queryParam('filters'));
 
     return (
       <Paneset>


### PR DESCRIPTION
We are also therefore able to remove the mysterious invisibly-coupled
`updateFilters` callback.

Fixes STSMACOM-35 and so resolves the filter-resetting problem of
STRIPES-493.