### PR TITLE
Default searchTerm to ''

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -310,7 +310,7 @@ class SearchAndSort extends React.Component {
     const objectNameUC = _.upperFirst(objectName);
     const records = (parentResources.records || {}).records || [];
     const resource = parentResources.records;
-    const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query');
+    const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
 
     /* searchHeader is a 'custom pane header' */
     const searchHeader = (<FilterPaneSearch


### PR DESCRIPTION
Avoids "FilterPaneSearch is changing an uncontrolled input of type
text to be controlled" warning. Thanks to Zak for spotting this.