### PR TITLE
Search and Sort: Conditional render of detail pain

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -137,7 +137,7 @@ class SearchAndSort extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-
+    
     let initiallySelected = {};
     const match = this.props.location.pathname.match('/[^/]*/view/');
     if (match && match.index === 0) {
@@ -409,8 +409,10 @@ class SearchAndSort extends React.Component {
             containerRef={(ref) => { this.resultsList = ref; }}
           />
         </Pane>
-
-        {detailsPane}
+        {
+          this.props.onSelectRow ? '' :
+          detailsPane
+        }
         {
           !this.props.editRecordComponent ? '' :
           <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false} label={`Add New ${objectNameUC} Dialog`}>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -137,7 +137,7 @@ class SearchAndSort extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    
+
     let initiallySelected = {};
     const match = this.props.location.pathname.match('/[^/]*/view/');
     if (match && match.index === 0) {


### PR DESCRIPTION
Resolves UIREQ-38:

This places logic in the render method of search and sort which conditions the inclusion of the details pain on the absence of `this.props.onSelectRow`. Now, if an embedded instance of search and sort has had the behavior of onSelectRow overwritten, the detail pane will not be initialized, and therefore not incur the errors that have been reported. 