### PR TITLE
Tidy 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.5.0 (IN PROGRESS)
 
 * Removed unused packages from package.json. Refs STRIPES-490.
-* Upgrade <SearchAndSort> to use new filter-related APIs. Fixes STSMACOM-35 and resolves STRIPES-493.
+* Upgrade `<SearchAndSort>` to use new filter-related APIs. Fixes STSMACOM-35 and resolves STRIPES-493.
 * Store local changes to search term in component state, and render from that. Fixes STSMACOM-33.
 * Fix regression: reset-search button had stopped working. Fixes STSMACOM-36.
 * Emit "Loading..." message rather than "no hits" before search-results arrive. Fixes STSMACOM-38.


### PR DESCRIPTION
Escape angle brackets in Markdown.

EditorConfig: Allow markdown trailing whitespace