### PR TITLE
Updating search and sort component to fit PaneHeader changes

### DIFF
--- a/lib/Notes/Notes.js
+++ b/lib/Notes/Notes.js
@@ -87,15 +87,6 @@ class Notes extends React.Component {
     const { stripes, link } = this.props;
     const notes = (this.props.resources.notes || {}).records || [];
 
-    const notesPaneTitle = (
-      <div style={{ textAlign: 'center' }}>
-        <strong>Notes</strong>
-        <div>
-          <em>{notes.length} Note{notes.length === 1 ? '' : 's'}</em>
-        </div>
-      </div>
-    );
-
     const notesQueryString = queryString.parse(this.props.location.search || '').notes;
 
     const noteList = notes.map((note, i) => (
@@ -112,7 +103,8 @@ class Notes extends React.Component {
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={notesPaneTitle}
+        paneTitle="Notes"
+        paneSub={`${notes.length} Note${notes.length === 1 ? '' : 's'}`}
         dismissible
         onClose={this.props.onToggle}
       >

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -379,6 +379,7 @@ class SearchAndSort extends React.Component {
         </Pane>
         {/* Results Pane */}
         <Pane
+          padContent={false}
           id="pane-results"
           defaultWidth="fill"
           paneTitle={

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -13,6 +13,7 @@ import FilterPaneSearch from '@folio/stripes-components/lib/FilterPaneSearch';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import Layer from '@folio/stripes-components/lib/Layer';
 import Button from '@folio/stripes-components/lib/Button';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
@@ -317,7 +318,7 @@ class SearchAndSort extends React.Component {
     const records = (resource || {}).records || [];
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
 
-    /* searchHeader is a 'custom pane header' */
+    /* searchHeader is a 'custom pane header */
     const searchHeader = (<FilterPaneSearch
       searchFieldId={`input-${objectName}-search`}
       onChange={this.onChangeSearch}
@@ -333,6 +334,14 @@ class SearchAndSort extends React.Component {
           <Button id={`clickable-new${objectName}`} title={`Add New ${objectNameUC}`} onClick={this.addNewRecord} buttonStyle="primary paneHeaderNewButton">+ New</Button>
         </PaneMenu>
       </IfPermission>
+    );
+
+    const resultsFirstMenu = (
+      <PaneMenu>
+        <IconButton
+          icon="search"
+        />
+      </PaneMenu>
     );
 
     const detailsPane = (
@@ -379,7 +388,7 @@ class SearchAndSort extends React.Component {
       <Paneset>
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
         {/* Filter Pane */}
-        <Pane id="pane-filter" defaultWidth="16%" header={searchHeader}>
+        <Pane id="pane-filter" dismissible defaultWidth="16%" paneTitle="Search & Filter" header={searchHeader}>
           <FilterGroups config={filterConfig} filters={filters} onChangeFilter={this.onChangeFilter} />
         </Pane>
         {/* Results Pane */}
@@ -387,15 +396,10 @@ class SearchAndSort extends React.Component {
           padContent={false}
           id="pane-results"
           defaultWidth="fill"
-          paneTitle={
-            <div style={{ textAlign: 'center' }}>
-              <strong>{this.props.moduleTitle}</strong>
-              <div>
-                <em>{stripes.intl.formatMessage({ id: `ui-${moduleName}.resultCount` }, { count })}</em>
-              </div>
-            </div>
-          }
+          paneTitle={this.props.moduleTitle}
+          paneSub={stripes.intl.formatMessage({ id: `ui-${moduleName}.resultCount` }, { count })}
           lastMenu={!this.props.disableRecordCreation ? newRecordButton : null}
+          firstMenu={resultsFirstMenu}
           noOverflow
         >
           <MultiColumnList


### PR DESCRIPTION
In this pull request I have primarily been focusing on fitting the SearchAndSort component to use the new PaneHeader.

I also added a search icon in the results-pane which isn't active yet but should be in the future:

![image](https://user-images.githubusercontent.com/640976/34159075-2328e952-e4c8-11e7-985c-001b4f11765f.png)

For now I have left the search bar in the PaneHeader but this will be deprecated in the future and replaced with a search field in the search/filter pane content like so:

![image](https://user-images.githubusercontent.com/640976/34159133-6da352b0-e4c8-11e7-8ea2-c694bc4e84ad.png)

(See http://ux.folio.org/prototype/en/inventory)
