### PR TITLE
support optional path prop. Refs UIIN-34

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -113,6 +113,12 @@ class SearchAndSort extends React.Component {
       }),
     }).isRequired,
 
+    // collection to be exploded and passed on to the detail view
+    detailProps: PropTypes.object,
+
+    // URL path to parse for detail views
+    path: PropTypes.string,
+
     // react-route properties provided by withRouter
     location: PropTypes.shape({
       pathname: PropTypes.string.isRequired,
@@ -121,7 +127,6 @@ class SearchAndSort extends React.Component {
     match: PropTypes.shape({
       path: PropTypes.string.isRequired,
     }).isRequired,
-    detailProps: PropTypes.object,
   };
 
   static manifest = Object.freeze({
@@ -347,7 +352,7 @@ class SearchAndSort extends React.Component {
     const detailsPane = (
       stripes.hasPerm(viewRecordPerms) ?
         (<Route
-          path={`${this.props.match.path}/view/:id`}
+          path={this.props.path ? this.props.path : `${this.props.match.path}/view/:id`}
           render={props => <this.connectedViewRecord
             stripes={stripes}
             paneWidth="44%"
@@ -438,6 +443,7 @@ class SearchAndSort extends React.Component {
               onCancel={this.closeNewRecord}
               parentResources={this.props.parentResources}
               parentMutator={this.props.parentMutator}
+              {...detailProps}
             />
           </Layer>
           }


### PR DESCRIPTION
Support optional "path" prop in addition to default `.../view/:id`.
This allows detail views to use parameters defined in the `<Route>`.