### PR TITLE
Pass new `selectedIndex` parameter through to <FilterPaneSearch>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Correctly reset query value when clearing search results. Fixes STSMACOM-39.
 * Pass requested props on through to the detail view. Toward UIIN-34.
 * Support the `<MultiColumnList>` property `columnWidths`. Fixes STSMACOM-40.
-* `<SearchAndSort>` passes `searchableFields` and `onChangeField` through to `<FilterPaneSearch>`. Fixes STSMACOM-41.
+* `<SearchAndSort>` passes `searchableIndexes`, `selectedIndex` and `onChangeIndex` through to `<FilterPaneSearch>`. Fixes STSMACOM-41.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -45,10 +45,11 @@ class SearchAndSort extends React.Component {
     objectName: PropTypes.string.isRequired, // machine-readable
     baseRoute: PropTypes.string.isRequired,
     initialPath: PropTypes.string.isRequired,
-    searchableFields: PropTypes.arrayOf(
+    searchableIndexes: PropTypes.arrayOf(
       PropTypes.object,
     ),
-    onChangeField: PropTypes.func,
+    selectedIndex: PropTypes.string,
+    onChangeIndex: PropTypes.func,
     filterConfig: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
@@ -330,8 +331,9 @@ class SearchAndSort extends React.Component {
     /* searchHeader is a 'custom pane header */
     const searchHeader = (<FilterPaneSearch
       searchFieldId={`input-${objectName}-search`}
-      searchableFields={this.props.searchableFields}
-      onChangeField={this.props.onChangeField}
+      searchableIndexes={this.props.searchableIndexes}
+      selectedIndex={this.props.selectedIndex}
+      onChangeIndex={this.props.onChangeIndex}
       onChange={this.onChangeSearch}
       onClear={this.onClearSearch}
       resultsList={this.resultsList}


### PR DESCRIPTION
Part of the UISE-38 work.

Related to this, the recently-introduced `searchableFields` property is renamed `searchableIndexes`, as it should have been all along; and `onChangeField` is renamed `onChangeIndex`. This fixes up the work done for STSMACOM-41.
