### PR TITLE
`<SearchAndSort>`'s clear-search button clears only the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Pass requested props on through to the detail view. Toward UIIN-34.
 * Support the `<MultiColumnList>` property `columnWidths`. Fixes STSMACOM-40.
 * `<SearchAndSort>` passes `searchableIndexes`, `selectedIndex` and `onChangeIndex` through to `<FilterPaneSearch>`. Fixes STSMACOM-41.
+* `<SearchAndSort>`'s clear-search button now clears only the query, leaving the filters and sort-order untouched. Fixes STSMACOM-42.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -22,17 +22,6 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import Notes from '../Notes';
 
 
-function parsePath(s) {
-  const i = s.indexOf('?');
-
-  const path = (i < 0) ? s : s.substring(0, i);
-  const search = (i < 0) ? '' : s.substring(i);
-  const query = queryString.parse(search);
-  query._path = path;
-  return query;
-}
-
-
 class SearchAndSort extends React.Component {
   static contextTypes = {
     stripes: stripesShape.isRequired,
@@ -44,7 +33,6 @@ class SearchAndSort extends React.Component {
     moduleTitle: PropTypes.string.isRequired, // human-readable
     objectName: PropTypes.string.isRequired, // machine-readable
     baseRoute: PropTypes.string.isRequired,
-    initialPath: PropTypes.string.isRequired,
     searchableIndexes: PropTypes.arrayOf(
       PropTypes.object,
     ),
@@ -214,10 +202,7 @@ class SearchAndSort extends React.Component {
   onClearSearch = () => {
     this.log('action', 'cleared search');
     this.setState({ locallyChangedSearchTerm: undefined });
-    const newParams = Object.assign({},
-                                    { query: '', filters: '', sort: '', layer: null, notes: null },
-                                    parsePath(this.props.initialPath));
-    this.props.parentMutator.query.replace(newParams);
+    this.transitionToParams({ query: '' });
   }
 
   onSort = (e, meta) => {


### PR DESCRIPTION
It now leaves the filters and sort-order untouched.

Fixes STSMACOM-42.