### PR TITLE
SearchAndSort: Added ability to toggle visibility of Filters pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `<SearchAndSort>` passes `searchableIndexes`, `selectedIndex` and `onChangeIndex` through to `<FilterPaneSearch>`. Fixes STSMACOM-41.
 * `<SearchAndSort>`'s clear-search button now clears only the query, leaving the filters and sort-order untouched. Fixes STSMACOM-42.
 * Cleanup `<EntryForm>`. Fixes STSMACOM-43.
+* `<SearchAndSort>`'s Filters pane can now be toggled between open and closed.
  
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -354,7 +354,7 @@ class SearchAndSort extends React.Component {
 
     const { filterPaneIsVisible } = this.state;
     const filterCount = Object.keys(filters).length;
-    const toggleFilterPaneMessage = `${filterPaneIsVisible ? 'Hide' : 'Show'} Search and Filters pane.\n\n${filterCount} applied filter${filterCount > 1 ? 's' : ''}.`;
+    const toggleFilterPaneMessage = `${filterPaneIsVisible ? 'Hide' : 'Show'} Search and Filters pane.\n\n${filterCount} applied filter${filterCount !== 1 ? 's' : ''}.`;
 
     const resultsFirstMenu = (
       <PaneMenu>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -150,6 +150,7 @@ class SearchAndSort extends React.Component {
 
     this.state = {
       selectedItem: initiallySelected,
+      filterPaneIsVisible: true,
     };
 
     this.transitionToParams = values => this.props.parentMutator.query.update(values);
@@ -267,6 +268,10 @@ class SearchAndSort extends React.Component {
     });
   }
 
+  toggleFilterPane = () => {
+    this.setState(prevState => ({ filterPaneIsVisible: !prevState.filterPaneIsVisible }));
+  }
+
   collapseDetails = () => {
     this.setState({ selectedItem: {} });
     this.transitionToParams({ _path: `${this.props.baseRoute}/view` });
@@ -324,6 +329,7 @@ class SearchAndSort extends React.Component {
     const resource = parentResources.records;
     const records = (resource || {}).records || [];
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
+    const filters = filterState(this.queryParam('filters'));
 
     /* searchHeader is a 'custom pane header */
     const searchHeader = (<FilterPaneSearch
@@ -346,10 +352,18 @@ class SearchAndSort extends React.Component {
       </IfPermission>
     );
 
+    const { filterPaneIsVisible } = this.state;
+    const filterCount = Object.keys(filters).length;
+    const toggleFilterPaneMessage = `${filterPaneIsVisible ? 'Hide' : 'Show'} Search and Filters pane.\n\n${filterCount} applied filter${filterCount > 1 ? 's' : ''}.`;
+
     const resultsFirstMenu = (
       <PaneMenu>
         <IconButton
           icon="search"
+          ariaLabel={toggleFilterPaneMessage}
+          title={toggleFilterPaneMessage}
+          onClick={this.toggleFilterPane}
+          badgeCount={filterPaneIsVisible ? undefined : filterCount}
         />
       </PaneMenu>
     );
@@ -392,22 +406,25 @@ class SearchAndSort extends React.Component {
     const message = !(resource && resource.hasLoaded) ? 'Loading...' :
           `No results found${maybeTerm}. Please check your ${maybeSpelling}filters.`;
     const sortOrder = this.queryParam('sort') || '';
-    const filters = filterState(this.queryParam('filters'));
 
     return (
       <Paneset>
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
         {/* Filter Pane */}
-        <Pane id="pane-filter" dismissible defaultWidth="16%" paneTitle="Search & Filter" header={searchHeader}>
-          <FilterGroups
-            config={filterConfig}
-            filters={filters}
-            onChangeFilter={this.onChangeFilter}
-            onClearFilter={this.onClearFilter}
-            onClearAllFilters={this.onClearAllFilters}
-            disableNames={disableFilters}
-          />
-        </Pane>
+        { filterPaneIsVisible ?
+          <Pane id="pane-filter" dismissible defaultWidth="16%" paneTitle="Search & Filter" header={searchHeader}>
+            <FilterGroups
+              config={filterConfig}
+              filters={filters}
+              onChangeFilter={this.onChangeFilter}
+              onClearFilter={this.onClearFilter}
+              onClearAllFilters={this.onClearAllFilters}
+              disableNames={disableFilters}
+            />
+          </Pane>
+          :
+          null
+        }
         {/* Results Pane */}
         <Pane
           padContent={false}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -363,7 +363,7 @@ class SearchAndSort extends React.Component {
           ariaLabel={toggleFilterPaneMessage}
           title={toggleFilterPaneMessage}
           onClick={this.toggleFilterPane}
-          badgeCount={filterPaneIsVisible ? undefined : filterCount}
+          badgeCount={!filterPaneIsVisible && filterCount ? filterCount : undefined}
         />
       </PaneMenu>
     );


### PR DESCRIPTION
- More work for [STCOM-164](https://issues.folio.org/browse/STCOM-164). 
- The magnifying glass in the header of the search results pane toggles the visibility of the filters/search pane. 
- When the pane is closed, a badge appears on the magnifying glass icon showing the number of active filters.

No animations on this pass per discussion on Slack.