### PR TITLE
show details pane for one-item search results. Fixes UIIN-58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * `<SearchAndSort>` passes `searchableIndexes`, `selectedIndex` and `onChangeIndex` through to `<FilterPaneSearch>`. Fixes STSMACOM-41.
 * `<SearchAndSort>`'s clear-search button now clears only the query, leaving the filters and sort-order untouched. Fixes STSMACOM-42.
 * Cleanup `<EntryForm>`. Fixes STSMACOM-43.
+* When a search result is winnowed to one record, show it. Fixes UIIN-58.
  
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -184,6 +184,14 @@ class SearchAndSort extends React.Component {
       const resultAmount = nextProps.parentResources.records.other.totalRecords;
       this.SRStatus.sendMessage(`Search returned ${resultAmount} result${resultAmount !== 1 ? 's' : ''}`);
     }
+
+    // if the results list is winnowed down to a single record, display the record.
+    const oldCount = recordResource && recordResource.hasLoaded ? recordResource.other.totalRecords : '';
+    const resource = nextProps.parentResources.records;
+    const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
+    if (count === 1 && oldCount > 1) {
+      this.onSelectRow(null, resource.records[0]);
+    }
   }
 
   queryParam(name) {


### PR DESCRIPTION
When a results list is narrowed to a single item, show the details pane automatically. Fixes [UIIN-58](https://issues.folio.org/browse/UIIN-58). 