### PR TITLE
Distinguish between loading, error and neither

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 * Cleanup `<EntryForm>`. Fixes STSMACOM-43.
 * `<SearchAndSort>`'s Filters pane can now be toggled between open and closed.
 * When a search result is winnowed to one record, show it. Fixes UIIN-58.
- 
+* In record-display area, distinguish between loading, error and neither. Fixes STSMACOM-46.
+
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -22,6 +22,16 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import Notes from '../Notes';
 
 
+function noRecordsMessage(r, searchTerm) {
+  if (!r || r.isPending) return 'Loading...';
+  // if (r.failed) return `Error ${r.failed.httpStatus}: ${r.failed.message}`;
+  if (r.failed) return <div><h2>Error {r.failed.httpStatus}</h2><p>{r.failed.message}</p></div>;
+  if (!r.hasLoaded) return '';
+  if (!searchTerm) return 'No results found. Please check your filters.';
+  return `No results found for "${searchTerm}". Please check your spelling and filters.`;
+}
+
+
 class SearchAndSort extends React.Component {
   static contextTypes = {
     stripes: stripesShape.isRequired,
@@ -182,7 +192,7 @@ class SearchAndSort extends React.Component {
     // If a search that was pending is now complete, notify the screen-reader
     if (recordResource && recordResource.isPending && !nextProps.parentResources.records.isPending) {
       this.log('event', 'new search-result');
-      const resultAmount = nextProps.parentResources.records.other.totalRecords;
+      const resultAmount = _.get(nextProps.parentResources.records, ['other', 'totalRecords']);
       this.SRStatus.sendMessage(`Search returned ${resultAmount} result${resultAmount !== 1 ? 's' : ''}`);
     }
 
@@ -408,11 +418,8 @@ class SearchAndSort extends React.Component {
           <p>Sorry - your permissions do not allow access to this page.</p>
         </div>));
 
-    const maybeTerm = searchTerm ? ` for "${searchTerm}"` : '';
-    const maybeSpelling = searchTerm ? 'spelling and ' : '';
     const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
-    const message = !(resource && resource.hasLoaded) ? 'Loading...' :
-          `No results found${maybeTerm}. Please check your ${maybeSpelling}filters.`;
+    const message = noRecordsMessage(resource, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 
     return (

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -24,7 +24,6 @@ import Notes from '../Notes';
 
 function noRecordsMessage(r, searchTerm) {
   if (!r || r.isPending) return 'Loading...';
-  // if (r.failed) return `Error ${r.failed.httpStatus}: ${r.failed.message}`;
   if (r.failed) return <div><h2>Error {r.failed.httpStatus}</h2><p>{r.failed.message}</p></div>;
   if (!r.hasLoaded) return '';
   if (!searchTerm) return 'No results found. Please check your filters.';


### PR DESCRIPTION
The record-display area now displays one of several possible messages, depending on the status information in the records resource. There are five possible states, so to keep the code clean I extracted the relevant logic out into a new `noRecordsMessage` function.

Fixes STSMACOM-46.
