### PR TITLE
<SearchAndSort> supports optional 'maxSortKeys' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `<SearchAndSort>`'s Filters pane can now be toggled between open and closed.
 * When a search result is winnowed to one record, show it. Fixes UIIN-58.
 * In record-display area, distinguish between loading, error and neither. Fixes STSMACOM-46.
+* In `<SearchAndSort>`, allow the maximum number of sort-keys to be specified by the new `maxSortKeys` property. Fixes STSMACOM-45.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -47,6 +47,7 @@ class SearchAndSort extends React.Component {
     ),
     selectedIndex: PropTypes.string,
     onChangeIndex: PropTypes.func,
+    maxSortKeys: PropTypes.number,
     filterConfig: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
@@ -238,7 +239,8 @@ class SearchAndSort extends React.Component {
       orders.unshift(newOrder);
     }
 
-    const sortOrder = orders.slice(0, 2).join(',');
+    const maxSortKeys = this.props.maxSortKeys || 2;
+    const sortOrder = orders.slice(0, maxSortKeys).join(',');
     this.log('action', `sorted by ${sortOrder}`);
     this.transitionToParams({ sort: sortOrder });
   }


### PR DESCRIPTION
Allows callers to limit the number of sort-keys to 1 (or indeed increase it to 3 or more). The immediately use-case for this is that mod-ebsco-ekb can't accept multple sort-keys, so ui-search needs to avoid sending such queries (see  UISE-47).

Fixes STSMACOM-45.
