### PR TITLE
Support the optional `filterChangeCallback` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * When a search result is winnowed to one record, show it. Fixes UIIN-58.
 * In record-display area, distinguish between loading, error and neither. Fixes STSMACOM-46.
 * In `<SearchAndSort>`, allow the maximum number of sort-keys to be specified by the new `maxSortKeys` property. Fixes STSMACOM-45.
+* Support the optional `filterChangeCallback` property, a function that is passed the filter state when it changes. Fixes STSMACOM-47.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -66,6 +66,7 @@ class SearchAndSort extends React.Component {
     ).isRequired,
     initialFilters: PropTypes.string,
     disableFilters: PropTypes.object,
+    filterChangeCallback: PropTypes.func,
     initialResultCount: PropTypes.number.isRequired,
     resultCountIncrement: PropTypes.number.isRequired,
     viewRecordComponent: PropTypes.func.isRequired,
@@ -247,15 +248,18 @@ class SearchAndSort extends React.Component {
 
   onChangeFilter = (e) => {
     this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
-    this.handleFilterChange(e);
+    const newFilters = this.handleFilterChange(e);
+    if (this.props.filterChangeCallback) this.props.filterChangeCallback(newFilters);
   }
 
   onClearFilter = (e) => {
-    this.handleFilterClear(e);
+    const newFilters = this.handleFilterClear(e);
+    if (this.props.filterChangeCallback) this.props.filterChangeCallback(newFilters);
   }
 
   onClearAllFilters = () => {
     this.handleClearAllFilters();
+    if (this.props.filterChangeCallback) this.props.filterChangeCallback({});
   }
 
   onNeedMore = () => {


### PR DESCRIPTION
This is a function that is passed the filter state when it changes.

Fixes STSMACOM-47.