### PR TITLE
show-single-result should be optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Support the optional `filterChangeCallback` property, a function that is passed the filter state when it changes. Fixes STSMACOM-47.
 * Fall back to rendering full record if onSelectRow function returns null. Fixes STSMACOM-49.
 * Introduce `<ConfigManager>` component. Fixes STSMACOM-51.
+* UIIN-58's show-single-result feature should be optional and default to false. Refs UIREQ-60, UICHKOUT-54, UIU-373; fixes STSMACOM-52.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -136,6 +136,13 @@ class SearchAndSort extends React.Component {
       path: PropTypes.string.isRequired,
     }).isRequired,
     onComponentWillUnmount: PropTypes.func,
+
+    // whether to auto-show the details record when a search returns a single row
+    showSingleResult: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    showSingleResult: false,
   };
 
   static manifest = Object.freeze({
@@ -202,11 +209,13 @@ class SearchAndSort extends React.Component {
     }
 
     // if the results list is winnowed down to a single record, display the record.
-    const oldCount = recordResource && recordResource.hasLoaded ? recordResource.other.totalRecords : '';
-    const resource = nextProps.parentResources.records;
-    const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
-    if (count === 1 && oldCount > 1) {
-      this.onSelectRow(null, resource.records[0]);
+    if (nextProps.showSingleResult) {
+      const oldCount = recordResource && recordResource.hasLoaded ? recordResource.other.totalRecords : '';
+      const resource = nextProps.parentResources.records;
+      const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
+      if (count === 1 && oldCount > 1) {
+        this.onSelectRow(null, resource.records[0]);
+      }
     }
   }
 


### PR DESCRIPTION
The show-single-result behavior should be optional and default to false.
This restores the previous behavior by default and gives apps the
option of using it on request.

It causes problems in the ui-plugin-find-user context where winnowing a
search in a modal window causes the parent window to redirect to the
entry's detail record when, instead, we simply want to indicate that the
search returned a single record and the user should click it to select
it.

Fixes [STSMACOM-52](https://issues.folio.org/browse/STSMACOM-52). Refs [UIIN-58](https://issues.folio.org/browse/UIIN-58), [UIREQ-60](https://issues.folio.org/browse/UIREQ-60), [UICHKOUT-54](https://issues.folio.org/browse/UICHKOUT-54), [UIU-373](https://issues.folio.org/browse/UIU-373).