### PR TITLE
Prevents EditableListForm from re-rendering before confirming success

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -60,7 +60,7 @@ class ControlledVocab extends React.Component {
 
   onCreateType(type) {
     console.log('ui-items - settings - onCreateType called');
-    this.props.mutator.values.POST(type);
+    return this.props.mutator.values.POST(type);
   }
 
   onUpdateType(type) {
@@ -69,13 +69,13 @@ class ControlledVocab extends React.Component {
     // TODO: remove when back end PUT requests ignore read only properties
     // https://issues.folio.org/browse/RMB-92
     delete type.metadata;
-    this.props.mutator.values.PUT(type);
+    return this.props.mutator.values.PUT(type);
   }
 
   onDeleteType(typeId) {
     console.log('ui-items - settings - onDeleteType called');
     this.props.mutator.activeRecord.update({ id: typeId });
-    this.props.mutator.values.DELETE(this.props.resources.values.records.find(t => t.id === typeId));
+    return this.props.mutator.values.DELETE(this.props.resources.values.records.find(t => t.id === typeId));
   }
 
   render() {


### PR DESCRIPTION
Prevents EditableListForm from re-rendering before confirming success from the backend