### PR TITLE
Improve button style consistency

### DIFF
--- a/lib/Notes/NoteRenderer.js
+++ b/lib/Notes/NoteRenderer.js
@@ -110,7 +110,7 @@ class NoteRenderer extends React.Component {
                 open={this.state.dropDownOpen}
                 onToggle={this.onToggleDropDown}
               >
-                <Button buttonStyle="transparent slim" title="Edit or delete this note" bsRole="toggle" >
+                <Button buttonStyle="link slim" title="Edit or delete this note" bsRole="toggle" >
                   <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
                 </Button>
                 <DropdownMenu

--- a/lib/Notes/NotesForm.js
+++ b/lib/Notes/NotesForm.js
@@ -63,7 +63,7 @@ function NotesForm(props) {
         {editMode &&
           <Button buttonStyle="hover" onClick={onCancel} title="Cancel Edit">Cancel</Button>
         }
-        <Button disabled={pristine || submitting} onClick={handleClickSubmit} title="Post Note">Post</Button>
+        <Button buttonStyle="primary" disabled={pristine || submitting} onClick={handleClickSubmit} title="Post Note">Post</Button>
       </div>
     </form>
   );

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -461,7 +461,7 @@ class SearchAndSort extends React.Component {
             paneTitle="Search & Filter"
             onClose={this.toggleFilterPane}
           >
-            <Button buttonStyle="transparent" hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
+            <Button buttonStyle="link" hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
               <Icon size="small" icon="clearX" />
               <span>Reset all filters</span>
             </Button>


### PR DESCRIPTION
Follow-up to https://github.com/folio-org/stripes-components/pull/209.

1. `transparent` is no longer an available button style; replaced with `link`
2. Now that `primary` is no longer the default button style (now `default` is), a couple of primary action buttons needed that style applied.