### PR TITLE
STCOM-164: Move SearchAndSort search field into an accordion

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -1,0 +1,9 @@
+@import '@folio/stripes-components/lib/variables.css';
+
+.resetButton {
+    background-color: transparent;
+    border: 1px solid transparent;
+    cursor: pointer;
+    color: var(--secondary);
+    padding: 4px;
+}

--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -1,9 +1,0 @@
-@import '@folio/stripes-components/lib/variables.css';
-
-.resetButton {
-    background-color: transparent;
-    border: 1px solid transparent;
-    cursor: pointer;
-    color: var(--secondary);
-    padding: 4px;
-}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -249,6 +249,12 @@ class SearchAndSort extends React.Component {
     this.transitionToParams({ query: '', qindex: '' });
   }
 
+  onClearSearchQuery = () => {
+    this.log('action', 'cleared search query');
+    this.setState({ locallyChangedSearchTerm: undefined });
+    this.transitionToParams({ query: ''});
+  }
+
   onSort = (e, meta) => {
     const newOrder = meta.alias;
     const oldOrder = this.queryParam('sort');
@@ -464,7 +470,7 @@ class SearchAndSort extends React.Component {
           >
             <Button buttonStyle="link" hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
               <Icon size="small" icon="clearX" />
-              <span>Reset all filters</span>
+              <span>Reset all</span>
             </Button>
             <Accordion
               label="Search"
@@ -480,7 +486,7 @@ class SearchAndSort extends React.Component {
                 selectedIndex={this.props.selectedIndex}
                 onChangeIndex={this.props.onChangeIndex}
                 onChange={this.onChangeSearch}
-                onClear={this.onClearSearch}
+                onClear={this.onClearSearchQuery}
                 value={searchTerm}
                 placeholder={stripes.intl.formatMessage({ id: `ui-${moduleName}.search` })}
                 loading={(resource && searchTerm) ? resource.isPending : false}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -9,6 +9,7 @@ import { withRouter } from 'react-router';
 import { stripesShape } from '@folio/stripes-core/src/Stripes';
 import queryString from 'query-string';
 import FilterGroups, { filterState, handleFilterChange, handleFilterClear } from '@folio/stripes-components/lib/FilterGroups';
+import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
 import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
@@ -245,7 +246,7 @@ class SearchAndSort extends React.Component {
   onClearSearch = () => {
     this.log('action', 'cleared search');
     this.setState({ locallyChangedSearchTerm: undefined });
-    this.transitionToParams({ query: '' });
+    this.transitionToParams({ query: '', qindex: '' });
   }
 
   onSort = (e, meta) => {
@@ -465,17 +466,26 @@ class SearchAndSort extends React.Component {
               <Icon size="small" icon="clearX" />
               <span>Reset all filters</span>
             </Button>
-            <SearchField
-              id={`input-${objectName}-search`}
-              searchableIndexes={this.props.searchableIndexes}
-              selectedIndex={this.props.selectedIndex}
-              onChangeIndex={this.props.onChangeIndex}
-              onChange={this.onChangeSearch}
-              onClear={this.onClearSearch}
-              value={searchTerm}
-              placeholder={stripes.intl.formatMessage({ id: `ui-${moduleName}.search` })}
-              loading={(resource && searchTerm) ? resource.isPending : false}
-            />
+            <Accordion
+              label="Search"
+              name="Search"
+              separator={false}
+              header={FilterAccordionHeader}
+              displayClearButton={searchTerm !== ''}
+              onClearFilter={this.onClearSearch}
+            >
+              <SearchField
+                id={`input-${objectName}-search`}
+                searchableIndexes={this.props.searchableIndexes}
+                selectedIndex={this.props.selectedIndex}
+                onChangeIndex={this.props.onChangeIndex}
+                onChange={this.onChangeSearch}
+                onClear={this.onClearSearch}
+                value={searchTerm}
+                placeholder={stripes.intl.formatMessage({ id: `ui-${moduleName}.search` })}
+                loading={(resource && searchTerm) ? resource.isPending : false}
+              />
+            </Accordion>
             <FilterGroups
               config={filterConfig}
               filters={filters}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -23,7 +23,6 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import SearchField from '@folio/stripes-components/lib/structures/SearchField';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 import Notes from '../Notes';
-import css from './SearchAndSort.css';
 
 
 function noRecordsMessage(r, searchTerm) {
@@ -476,7 +475,7 @@ class SearchAndSort extends React.Component {
             paneTitle="Search & Filter"
             onClose={this.toggleFilterPane}
           >
-            <Button buttonStyle={css.resetButton} hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
+            <Button buttonStyle="none" paddingSide0 onClick={this.onClearSearchAndFilters} style={{ fontWeight: 'bold' }}>
               <Icon size="small" icon="clearX" />
               <span>Reset all</span>
             </Button>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -383,6 +383,7 @@ class SearchAndSort extends React.Component {
     const resource = parentResources.records;
     const records = (resource || {}).records || [];
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
+    const searchIndex = this.queryParam('qindex') || '';
     const filters = filterState(this.queryParam('filters'));
 
     const newRecordButton = !newRecordPerms ? '' : (
@@ -477,7 +478,7 @@ class SearchAndSort extends React.Component {
               name="Search"
               separator={false}
               header={FilterAccordionHeader}
-              displayClearButton={searchTerm !== ''}
+              displayClearButton={searchTerm !== '' || searchIndex !== ''}
               onClearFilter={this.onClearSearch}
             >
               <SearchField

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -23,6 +23,7 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import SearchField from '@folio/stripes-components/lib/structures/SearchField';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 import Notes from '../Notes';
+import css from './SearchAndSort.css';
 
 
 function noRecordsMessage(r, searchTerm) {
@@ -247,6 +248,10 @@ class SearchAndSort extends React.Component {
     this.log('action', 'cleared search');
     this.setState({ locallyChangedSearchTerm: undefined });
     this.transitionToParams({ query: '', qindex: '' });
+
+    // This allows the parent to reset other parameters like query index to
+    // something that it may prefer instead of an empty qindex.
+    if (this.props.filterChangeCallback) this.props.filterChangeCallback({});
   }
 
   onClearSearchQuery = () => {
@@ -284,8 +289,10 @@ class SearchAndSort extends React.Component {
   }
 
   onClearSearchAndFilters = () => {
+    this.log('action', 'cleared search and filters');
+
     this.setState({ locallyChangedSearchTerm: undefined });
-    this.transitionToParams({ filters: this.props.initialFilters || '', query: '' });
+    this.transitionToParams({ filters: this.props.initialFilters || '', query: '', qindex: '' });
 
     if (this.props.filterChangeCallback) this.props.filterChangeCallback({});
   }
@@ -469,7 +476,7 @@ class SearchAndSort extends React.Component {
             paneTitle="Search & Filter"
             onClose={this.toggleFilterPane}
           >
-            <Button buttonStyle="link" hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
+            <Button buttonStyle={css.resetButton} hollow paddingSide0 onClick={this.onClearSearchAndFilters}>
               <Icon size="small" icon="clearX" />
               <span>Reset all</span>
             </Button>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -252,7 +252,7 @@ class SearchAndSort extends React.Component {
   onClearSearchQuery = () => {
     this.log('action', 'cleared search query');
     this.setState({ locallyChangedSearchTerm: undefined });
-    this.transitionToParams({ query: ''});
+    this.transitionToParams({ query: '' });
   }
 
   onSort = (e, meta) => {


### PR DESCRIPTION
- Moved the SearchField at the top of the Search & Filter pane into an accordion.
- The clear X by the accordion title resets the query index and the query.
- The clear X inside the SearchField resets just the query.
- Changed the top button's label back to "Reset all"

- Styling on that button has **not** been changed from the `link` styling. The various changes in the Button component re:styling have made getting back to the previous styling (grey with no border) not possible (AFAIK) without adding more CSS styles, which I thought we were trying to avoid. @JohnC-80 and @rasmuswoelk feel free to advise otherwise.