### PR TITLE
autocomplete @mentioned usernames. Fixes STSMACOM-4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Appease eslint-config-stripes. Fixes STSMACOM-56.
 * Support `searchableIndexesPlaceholder` property. Fixes STSMACOM-62.
 * Update `<SearchAndSort>` documentation for eight new properties. Fixes STSMACOM-63.
+* Autocomplete @mentioned usernames in notes. STSMACOM-4. Available from v1.4.1.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/Notes/AtMentionTextArea.js
+++ b/lib/Notes/AtMentionTextArea.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextArea from '@folio/stripes-components/lib/TextArea';
+import separateComponentProps from '@folio/stripes-components/util/separateComponentProps';
+import { MentionWrapper, MentionMenu } from '@folio/react-githubish-mentions';
+import css from './Notes.css';
+
+const MenuItem = (props) => {
+  const { active, value } = props;
+  const customStyle = {
+    background: active ? '#106c9e' : '#fff',
+    color: active ? '#efefef' : '#333',
+    display: 'block',
+  };
+  return <span style={customStyle}>{value}</span>;
+};
+
+MenuItem.propTypes = {
+  active: PropTypes.bool,
+  value: PropTypes.string,
+};
+
+class AtMentionTextArea extends React.Component {
+  static contextTypes = {
+    stripes: PropTypes.object,
+  }
+
+  static propTypes = {
+    resources: PropTypes.shape({
+      users: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    }).isRequired,
+    mutator: PropTypes.shape({
+      username: PropTypes.object,
+      users: PropTypes.shape({
+        GET: PropTypes.func,
+      }),
+    }),
+    input: PropTypes.shape({
+      onChange: PropTypes.func,
+    }),
+    dataKey: PropTypes.string,
+    okapi: PropTypes.object,
+    refreshRemote: PropTypes.func,
+    meta: PropTypes.object,
+  }
+
+  static manifest = Object.freeze({
+    users: {
+      type: 'okapi',
+      path: 'users',
+      records: 'users',
+      accumulate: true,
+    },
+    username: {},
+  });
+
+  constructor(props) {
+    super(props);
+    this.atQuery = this.atQuery.bind(this);
+    this.onChange = this.onChange.bind(this);
+  }
+
+  atQuery = async (username) => {
+    if (username.length >= 2) {
+      const query = `query=username=^${username}* sortby username`;
+      return this.props.mutator.users.GET({ params: { query } })
+        .then(records => records.map(u => ({ value: u.username })));
+    }
+
+    return [];
+  }
+
+  onChange(e, v) {
+    this.props.input.onChange(v);
+  }
+
+  render() {
+    const [, inputProps] = separateComponentProps(this.props, AtMentionTextArea.propTypes);
+    return (
+      <MentionWrapper {...inputProps} component={TextArea} onChange={this.onChange} bottomMargin0 >
+        <MentionMenu className={css.atMentionMenu} trigger="@" item={MenuItem} resolve={this.atQuery} />
+      </MentionWrapper>
+    );
+  }
+}
+
+export default AtMentionTextArea;

--- a/lib/Notes/Notes.css
+++ b/lib/Notes/Notes.css
@@ -23,3 +23,10 @@
 .byLine {
   font-weight: bold;
 }
+
+.atMentionMenu {
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+}

--- a/lib/Notes/Notes.js
+++ b/lib/Notes/Notes.js
@@ -9,7 +9,9 @@ import css from './Notes.css';
 
 class Notes extends React.Component {
   static propTypes = {
-    stripes: PropTypes.object.isRequired,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    }),
     onToggle: PropTypes.func,
     resources: PropTypes.shape({
       notes: PropTypes.shape({
@@ -103,6 +105,7 @@ class Notes extends React.Component {
             initialValues={{ link }}
             form="newNote"
             onSubmit={this.handleSubmit}
+            stripes={stripes}
           />
         </IfPermission>
       </Pane>

--- a/lib/Notes/NotesForm.js
+++ b/lib/Notes/NotesForm.js
@@ -2,74 +2,75 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 import stripesForm from '@folio/stripes-form';
-import Pluggable from '@folio/stripes-components/lib/Pluggable';
-import TextArea from '@folio/stripes-components/lib/TextArea';
 import Button from '@folio/stripes-components/lib/Button';
+import AtMentionTextArea from './AtMentionTextArea';
 
-const renderTextArea = props => (
-  <Pluggable type="text-editor" {...props}>
-    <TextArea {...props} bottomMargin0 />
-  </Pluggable>
-);
+class NotesForm extends React.Component {
+  static propTypes = {
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    }).isRequired,
+    editMode: PropTypes.bool,
+    onCancel: PropTypes.func,
+    textRows: PropTypes.string,
+    form: PropTypes.string,
+    handleSubmit: PropTypes.func,
+    reset: PropTypes.func,
+    submitting: PropTypes.bool,
+    values: PropTypes.object,
+    pristine: PropTypes.bool,
+  }
 
-const propTypes = {
-  editMode: PropTypes.bool,
-  onCancel: PropTypes.func,
-  textRows: PropTypes.string,
-  form: PropTypes.string,
-  handleSubmit: PropTypes.func,
-  reset: PropTypes.func,
-  submitting: PropTypes.bool,
-  values: PropTypes.object,
-  pristine: PropTypes.bool,
-};
+  constructor(props) {
+    super(props);
+    this.connectedAtMentionTextArea = props.stripes.connect(AtMentionTextArea);
+  }
 
-function NotesForm(props) {
-  const {
-    form,
-    handleSubmit,
-    pristine,
-    submitting,
-    textRows,
-    editMode,
-    onCancel,
-  } = props;
+  render() {
+    const {
+      form,
+      handleSubmit,
+      pristine,
+      submitting,
+      textRows,
+      editMode,
+      onCancel,
+    } = this.props;
 
-  const handleKeyDown = (e, handler) => {
-    if (e.key === 'Enter' && e.shiftKey === false) {
-      e.preventDefault();
-      handler(props.values);
-    }
-  };
+    const handleKeyDown = (e, handler) => {
+      if (e.key === 'Enter' && e.shiftKey === false) {
+        e.preventDefault();
+        handler(this.props.values);
+      }
+    };
 
-  const handleClickSubmit = () => {
-    handleSubmit();
-    props.reset();
-  };
+    const handleClickSubmit = () => {
+      handleSubmit();
+      this.props.reset();
+    };
 
-  return (
-    <form>
-      <Field
-        name="text"
-        placeholder="Enter a note."
-        aria-label="Note Textarea"
-        fullWidth
-        id="note_textarea"
-        component={renderTextArea}
-        onKeyDown={(e) => { handleKeyDown(e, handleClickSubmit); }}
-        rows={textRows}
-      />
-      <div style={{ textAlign: 'right' }}>
-        {editMode &&
-          <Button buttonStyle="hover" onClick={onCancel} title="Cancel Edit">Cancel</Button>
-        }
-        <Button buttonStyle="primary" disabled={pristine || submitting} onClick={handleClickSubmit} title="Post Note">Post</Button>
-      </div>
-    </form>
-  );
+    return (
+      <form>
+        <Field
+          name="text"
+          placeholder="Enter a note."
+          aria-label="Note Textarea"
+          fullWidth
+          id="note_textarea"
+          component={this.connectedAtMentionTextArea}
+          onKeyDown={(e) => { handleKeyDown(e, handleClickSubmit); }}
+          rows={textRows}
+        />
+        <div style={{ textAlign: 'right' }}>
+          {editMode &&
+            <Button buttonStyle="hover" onClick={onCancel} title="Cancel Edit">Cancel</Button>
+          }
+          <Button disabled={pristine || submitting} onClick={handleClickSubmit} title="Post Note">Post</Button>
+        </div>
+      </form>
+    );
+  }
 }
-
-NotesForm.propTypes = propTypes;
 
 export default stripesForm({
   form: 'NotesForm',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {
@@ -86,6 +86,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
+    "@folio/react-githubish-mentions": "^1.2.1",
     "@folio/stripes-components": "^2.0.0",
     "@folio/stripes-form": "^0.8.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Fixes [STSMACOM-4](https://issues.folio.org/browse/STSMACOM-4). Provide autocompletion of usernames in `<Notes>` fields. 

This is more or less a replay #66 which was reverted in #79 due to build issues since resolved by https://github.com/folio-org/stripes-core/pull/161. 