### PR TITLE
Optionally derive some props from props.packageInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Update `<SearchAndSort>` documentation for eight new properties. Fixes STSMACOM-63.
 * Autocomplete @mentioned usernames in notes. STSMACOM-4. Available from v1.4.1.
 * Happy lint, happy life. Refs STSMACOM-56. Available from v1.4.2. 
+* Optionally derive some SearchAndSort params from props.packageInfo. Refs STSMACOM-64. Available from v1.4.3. 
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -149,7 +149,7 @@ class SearchAndSort extends React.Component {
       moduleTitle: PropTypes.string,    // human-readable
       stripes: PropTypes.shape({
         route: PropTypes.string,        // base route; used to construct URLs
-      })
+      }),
     }),
   };
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -141,6 +141,16 @@ class SearchAndSort extends React.Component {
 
     // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
+
+    // values pulled from the provider's package.json config object
+    packageInfo: PropTypes.shape({
+      initialFilters: PropTypes.string, // default filters
+      moduleName: PropTypes.string,     // machine-readable, for HTML ids and translation keys
+      moduleTitle: PropTypes.string,    // human-readable
+      stripes: PropTypes.shape({
+        route: PropTypes.string,        // base route; used to construct URLs
+      })
+    }),
   };
 
   static defaultProps = {
@@ -184,6 +194,18 @@ class SearchAndSort extends React.Component {
     this.SRStatus = null;
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
+
+    if (props.packageInfo) {
+      const initialPath = (_.get(props.packageInfo, ['stripes', 'home']) || _.get(props.packageInfo, ['stripes', 'route']));
+      const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
+        initialPath.substr(initialPath.indexOf('?') + 1);
+      const initialQuery = queryString.parse(initialSearch);
+      this.initialFilters = initialQuery.filters;
+    }
+
+    if (!this.initialFilters) {
+      this.initialFilters = props.initialFilters;
+    }
 
     const logger = context.stripes.logger;
     this.log = logger.log.bind(logger);
@@ -292,7 +314,7 @@ class SearchAndSort extends React.Component {
     this.log('action', 'cleared search and filters');
 
     this.setState({ locallyChangedSearchTerm: undefined });
-    this.transitionToParams({ filters: this.props.initialFilters || '', query: '', qindex: '' });
+    this.transitionToParams({ filters: this.initialFilters || '', query: '', qindex: '' });
 
     if (this.props.filterChangeCallback) this.props.filterChangeCallback({});
   }
@@ -308,7 +330,9 @@ class SearchAndSort extends React.Component {
     }
     this.log('action', `clicked ${meta.id}, selected record =`, meta);
     this.setState({ selectedItem: meta });
-    this.transitionToParams({ _path: `${this.props.baseRoute}/view/${meta.id}` });
+
+    const _path = this.props.packageInfo ? `${this.props.packageInfo.stripes.route}/view/${meta.id}` : `${this.props.baseRoute}/view/${meta.id}`;
+    this.transitionToParams({ _path });
   }
 
   addNewRecord = (e) => {
@@ -336,7 +360,8 @@ class SearchAndSort extends React.Component {
 
   collapseDetails = () => {
     this.setState({ selectedItem: {} });
-    this.transitionToParams({ _path: `${this.props.baseRoute}/view` });
+    const _path = this.props.packageInfo ? `${this.props.packageInfo.stripes.route}/view` : `${this.props.baseRoute}/view`;
+    this.transitionToParams({ _path });
   }
 
   getRowURL(id) {
@@ -383,7 +408,7 @@ class SearchAndSort extends React.Component {
   }
 
   renderResetButton = () => {
-    const initialFilters = this.props.initialFilters || '';
+    const initialFilters = this.initialFilters || '';
     const filtersHaveChanged = this.queryParam('filters') !== initialFilters;
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';
@@ -400,7 +425,7 @@ class SearchAndSort extends React.Component {
   }
 
   render() {
-    const { parentResources, filterConfig, disableFilters, moduleName, newRecordPerms, viewRecordPerms, objectName, detailProps } = this.props;
+    const { parentResources, filterConfig, disableFilters, newRecordPerms, viewRecordPerms, objectName, detailProps, packageInfo } = this.props;
     const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
@@ -409,6 +434,9 @@ class SearchAndSort extends React.Component {
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';
     const filters = filterState(this.queryParam('filters'));
+
+    const moduleName = packageInfo ? packageInfo.name.replace(/.*\//, '') : this.props.moduleName;
+    const moduleTitle = packageInfo ? packageInfo.stripes.displayName : this.props.moduleTitle;
 
     const newRecordButton = !newRecordPerms ? '' : (
       <IfPermission perm={newRecordPerms}>
@@ -530,14 +558,14 @@ class SearchAndSort extends React.Component {
           padContent={false}
           id="pane-results"
           defaultWidth="fill"
-          paneTitle={this.props.moduleTitle}
+          paneTitle={moduleTitle}
           paneSub={stripes.intl.formatMessage({ id: `ui-${moduleName}.resultCount` }, { count })}
           lastMenu={!this.props.disableRecordCreation ? newRecordButton : null}
           firstMenu={resultsFirstMenu}
           noOverflow
         >
           <MultiColumnList
-            id={`list-${this.props.moduleName}`}
+            id={`list-${moduleName}`}
             contentData={records}
             selectedRow={this.state.selectedItem}
             formatter={this.props.resultsFormatter}
@@ -582,7 +610,7 @@ class SearchAndSort extends React.Component {
             render={props => <this.connectedNotes
               stripes={stripes}
               onToggle={this.toggleNotes}
-              link={`${this.props.moduleName}/${props.match.params.id}`}
+              link={`${moduleName}/${props.match.params.id}`}
               {...props}
             />}
           />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Many values used in SearchAndSort are derived from values in the calling
module's `package.json` file. This update adds support for passing in
those values (via `props.packageInfo`) and deriving them, rather than
repeating that code in every single module that calls SearchAndSort.

Refs [STSMACOM-64](https://issues.folio.org/browse/STSMACOM-64)