### PR TITLE
STCOM-222 SearchAndSort: Handle undefined filters query param

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -409,7 +409,8 @@ class SearchAndSort extends React.Component {
 
   renderResetButton = () => {
     const initialFilters = this.initialFilters || '';
-    const filtersHaveChanged = this.queryParam('filters') !== initialFilters;
+    const currentFilters = this.queryParam('filters') || '';
+    const filtersHaveChanged = currentFilters !== initialFilters;
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';
     const searchHasChanged = searchTerm !== '' || searchIndex !== '';


### PR DESCRIPTION
[This fixes STCOM-222 where the "Reset all" button was visible on initial load of Users.](https://issues.folio.org/browse/STCOM-222) 

The cause was a change in how the Users app provided and handled the intialFilters in ui-users/#262. SAS is now more permissive in handling the initialFilters.