### PR TITLE
require props.packageInfo. Refs STSMACOM-64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Autocomplete @mentioned usernames in notes. STSMACOM-4. Available from v1.4.1.
 * Happy lint, happy life. Refs STSMACOM-56. Available from v1.4.2. 
 * Optionally derive some SearchAndSort params from props.packageInfo. Refs STSMACOM-64. Available from v1.4.3. 
+* Always derive some SearchAndSort params props.packageInfo. Refs STSMACOM-64. Available from v1.4.4.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -41,10 +41,7 @@ class SearchAndSort extends React.Component {
 
   static propTypes = {
     // parameter properties provided by caller
-    moduleName: PropTypes.string.isRequired, // machine-readable, for HTML ids and translation keys
-    moduleTitle: PropTypes.string.isRequired, // human-readable
     objectName: PropTypes.string.isRequired, // machine-readable
-    baseRoute: PropTypes.string.isRequired,
     searchableIndexes: PropTypes.arrayOf(
       PropTypes.object,
     ),
@@ -149,7 +146,7 @@ class SearchAndSort extends React.Component {
       moduleTitle: PropTypes.string,    // human-readable
       stripes: PropTypes.shape({
         route: PropTypes.string,        // base route; used to construct URLs
-      }),
+      }).isRequired,
     }),
   };
 
@@ -195,17 +192,11 @@ class SearchAndSort extends React.Component {
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
 
-    if (props.packageInfo) {
-      const initialPath = (_.get(props.packageInfo, ['stripes', 'home']) || _.get(props.packageInfo, ['stripes', 'route']));
-      const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
-        initialPath.substr(initialPath.indexOf('?') + 1);
-      const initialQuery = queryString.parse(initialSearch);
-      this.initialFilters = initialQuery.filters;
-    }
-
-    if (!this.initialFilters) {
-      this.initialFilters = props.initialFilters;
-    }
+    const initialPath = (_.get(props.packageInfo, ['stripes', 'home']) || _.get(props.packageInfo, ['stripes', 'route']));
+    const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
+      initialPath.substr(initialPath.indexOf('?') + 1);
+    const initialQuery = queryString.parse(initialSearch);
+    this.initialFilters = initialQuery.filters;
 
     const logger = context.stripes.logger;
     this.log = logger.log.bind(logger);
@@ -330,9 +321,7 @@ class SearchAndSort extends React.Component {
     }
     this.log('action', `clicked ${meta.id}, selected record =`, meta);
     this.setState({ selectedItem: meta });
-
-    const _path = this.props.packageInfo ? `${this.props.packageInfo.stripes.route}/view/${meta.id}` : `${this.props.baseRoute}/view/${meta.id}`;
-    this.transitionToParams({ _path });
+    this.transitionToParams({ _path: `${this.props.packageInfo.stripes.route}/view/${meta.id}` });
   }
 
   addNewRecord = (e) => {
@@ -360,8 +349,7 @@ class SearchAndSort extends React.Component {
 
   collapseDetails = () => {
     this.setState({ selectedItem: {} });
-    const _path = this.props.packageInfo ? `${this.props.packageInfo.stripes.route}/view` : `${this.props.baseRoute}/view`;
-    this.transitionToParams({ _path });
+    this.transitionToParams({ _path: `${this.props.packageInfo.stripes.route}/view` });
   }
 
   getRowURL(id) {
@@ -436,8 +424,8 @@ class SearchAndSort extends React.Component {
     const searchIndex = this.queryParam('qindex') || '';
     const filters = filterState(this.queryParam('filters'));
 
-    const moduleName = packageInfo ? packageInfo.name.replace(/.*\//, '') : this.props.moduleName;
-    const moduleTitle = packageInfo ? packageInfo.stripes.displayName : this.props.moduleTitle;
+    const moduleName = packageInfo.name.replace(/.*\//, '');
+    const moduleTitle = packageInfo.stripes.displayName;
 
     const newRecordButton = !newRecordPerms ? '' : (
       <IfPermission perm={newRecordPerms}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Now that all packages using `<SearchAndSort>` pass it their `packageInfo` values, we can deprecate the old props that were just derived from `packageInfo` before passing them as props. 

Refs [STSMACOM-64](https://issues.folio.org/browse/STSMACOM-64). 