### PR TITLE
props.browseOnly prevents the create-object pane. Refs UIPFU-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Happy lint, happy life. Refs STSMACOM-56. Available from v1.4.2. 
 * Optionally derive some SearchAndSort params from props.packageInfo. Refs STSMACOM-64. Available from v1.4.3. 
 * Always derive some SearchAndSort params props.packageInfo. Refs STSMACOM-64. Available from v1.4.4.
+* Optionally prevent `<SearchAndSort>` from showing create or edit panes. Refs UIPFU-6. Available from v1.4.5. 
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -502,17 +502,18 @@ class SearchAndSort extends React.Component {
     const message = noRecordsMessage(resource, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 
-    const createRecordLayer = (!this.props.editRecordComponent ? '' : <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false} label={`Add New ${objectNameUC} Dialog`}>
-                <this.props.editRecordComponent
-                  id={`${objectName}form-add${objectName}`}
-                  initialValues={this.props.newRecordInitialValues}
-                  onSubmit={record => this.createRecord(record)}
-                  onCancel={this.closeNewRecord}
-                  parentResources={this.props.parentResources}
-                  parentMutator={this.props.parentMutator}
-                  {...detailProps}
-                />
-              </Layer>);
+    const createRecordLayer = (!this.props.editRecordComponent ? '' :
+    <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false} label={`Add New ${objectNameUC} Dialog`}>
+      <this.props.editRecordComponent
+        id={`${objectName}form-add${objectName}`}
+        initialValues={this.props.newRecordInitialValues}
+        onSubmit={record => this.createRecord(record)}
+        onCancel={this.closeNewRecord}
+        parentResources={this.props.parentResources}
+        parentMutator={this.props.parentMutator}
+        {...detailProps}
+      />
+    </Layer>);
 
     return (
       <Paneset>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -149,6 +149,8 @@ class SearchAndSort extends React.Component {
         route: PropTypes.string,        // base route; used to construct URLs
       }).isRequired,
     }),
+
+    browseOnly: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -500,6 +502,18 @@ class SearchAndSort extends React.Component {
     const message = noRecordsMessage(resource, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 
+    const createRecordLayer = (!this.props.editRecordComponent ? '' : <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false} label={`Add New ${objectNameUC} Dialog`}>
+                <this.props.editRecordComponent
+                  id={`${objectName}form-add${objectName}`}
+                  initialValues={this.props.newRecordInitialValues}
+                  onSubmit={record => this.createRecord(record)}
+                  onCancel={this.closeNewRecord}
+                  parentResources={this.props.parentResources}
+                  parentMutator={this.props.parentMutator}
+                  {...detailProps}
+                />
+              </Layer>);
+
     return (
       <Paneset>
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
@@ -582,19 +596,8 @@ class SearchAndSort extends React.Component {
           detailsPane
         }
         {
-          !this.props.editRecordComponent ? '' :
-          <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false} label={`Add New ${objectNameUC} Dialog`}>
-            <this.props.editRecordComponent
-              id={`${objectName}form-add${objectName}`}
-              initialValues={this.props.newRecordInitialValues}
-              onSubmit={record => this.createRecord(record)}
-              onCancel={this.closeNewRecord}
-              parentResources={this.props.parentResources}
-              parentMutator={this.props.parentMutator}
-              {...detailProps}
-            />
-          </Layer>
-          }
+          !this.props.browseOnly && createRecordLayer
+        }
         {
           _.get(this.props.parentResources.query, 'notes') &&
           <Route

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
`props.browseOnly` prevents the create-object pane

For when you really only want search-and-sort, not search-and-sort-and-edit-and-create, e.g. when you are accessing this in the context of ui-plugin-find-user which wants to search for users but disallow creating or editing them.
    
Refs [UIPFU-6](https://issues.folio.org/browse/UIPFU-6).
