### PR TITLE
Towards abstracting analysis of search responses

### DIFF
--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -29,13 +29,13 @@ class ResourcesAnalyzer {
   }
 
   failure() {
-    let res = this.recordsObj.failed;
+    const res = this.recordsObj.failed;
     this.logger.log('analyze', 'ResourcesAnalyzer:failure', res);
     return res;
   }
 
   loaded() {
-    let res = this.recordsObj.hasLoaded;
+    const res = this.recordsObj.hasLoaded;
     this.logger.log('analyze', 'ResourcesAnalyzer:loaded', res);
     return res;
   }

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -33,6 +33,12 @@ class ResourcesAnalyzer {
     this.logger.log('analyze', 'ResourcesAnalyzer:failure', res);
     return res;
   }
+
+  loaded() {
+    let res = this.recordsObj.hasLoaded;
+    this.logger.log('analyze', 'ResourcesAnalyzer:loaded', res);
+    return res;
+  }
 }
 
 export default ResourcesAnalyzer;

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -3,12 +3,15 @@
 // stripes-connect or GraphQL.
 
 class ResourcesAnalyzer {
-  constructor(resources) {
+  constructor(resources, logger) {
     this.resources = resources;
+    this.logger = logger;
   }
 
   records() {
-    return this.resources.records;
+    const records = this.resources.records;
+    this.logger.log('analyze', 'ResourcesAnalyzer:records');
+    return records;
   }
 }
 

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -11,13 +11,13 @@ class ResourcesAnalyzer {
 
   records() {
     const res = this.recordsObj.records || [];
-    this.logger.log('analyze', 'ResourcesAnalyzer:records:', res.length);
+    this.logger.log('analyze-all', 'ResourcesAnalyzer:records:', res.length);
     return res;
   }
 
   totalCount() {
     const res = this.recordsObj.hasLoaded ? this.recordsObj.other.totalRecords : null;
-    this.logger.log('analyze', 'ResourcesAnalyzer:totalCount:', res);
+    this.logger.log('analyze-all', 'ResourcesAnalyzer:totalCount:', res);
     return res;
   }
 

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -1,0 +1,15 @@
+// Simple class that knows how to answer certain questions about a
+// Stripes module's resources based on whether they were populated by
+// stripes-connect or GraphQL.
+
+class ResourcesAnalyzer {
+  constructor(resources) {
+    this.resources = resources;
+  }
+
+  records() {
+    return this.resources.records;
+  }
+}
+
+export default ResourcesAnalyzer;

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -9,8 +9,8 @@ class ResourcesAnalyzer {
   }
 
   records() {
-    const records = this.resources.records;
-    this.logger.log('analyze', 'ResourcesAnalyzer:records');
+    const records = (this.resources.records || {}).records || [];
+    this.logger.log('analyze', 'ResourcesAnalyzer:records: ', records.length);
     return records;
   }
 }

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -20,6 +20,13 @@ class ResourcesAnalyzer {
     this.logger.log('analyze', 'ResourcesAnalyzer:totalCount:', count);
     return count;
   }
+
+  pending() {
+    let res = this.recordsObj.isPending;
+    if (res === undefined) res = true;
+    this.logger.log('analyze', 'ResourcesAnalyzer:pending:', res);
+    return res;
+  }
 }
 
 export default ResourcesAnalyzer;

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -24,7 +24,13 @@ class ResourcesAnalyzer {
   pending() {
     let res = this.recordsObj.isPending;
     if (res === undefined) res = true;
-    this.logger.log('analyze', 'ResourcesAnalyzer:pending:', res);
+    this.logger.log('analyze-all', 'ResourcesAnalyzer:pending:', res);
+    return res;
+  }
+
+  failure() {
+    let res = this.recordsObj.failed;
+    this.logger.log('analyze', 'ResourcesAnalyzer:failure', res);
     return res;
   }
 }

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -4,14 +4,21 @@
 
 class ResourcesAnalyzer {
   constructor(resources, logger) {
-    this.resources = resources;
+    this.resources = resources || {};
+    this.recordsObj = resources.records || {};
     this.logger = logger;
   }
 
   records() {
-    const records = (this.resources.records || {}).records || [];
-    this.logger.log('analyze', 'ResourcesAnalyzer:records: ', records.length);
+    const records = this.recordsObj.records || [];
+    this.logger.log('analyze', 'ResourcesAnalyzer:records:', records.length);
     return records;
+  }
+
+  totalCount() {
+    const count = this.recordsObj.hasLoaded ? this.recordsObj.other.totalRecords : null;
+    this.logger.log('analyze', 'ResourcesAnalyzer:totalCount:', count);
+    return count;
   }
 }
 

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -10,15 +10,15 @@ class ResourcesAnalyzer {
   }
 
   records() {
-    const records = this.recordsObj.records || [];
-    this.logger.log('analyze', 'ResourcesAnalyzer:records:', records.length);
-    return records;
+    const res = this.recordsObj.records || [];
+    this.logger.log('analyze', 'ResourcesAnalyzer:records:', res.length);
+    return res;
   }
 
   totalCount() {
-    const count = this.recordsObj.hasLoaded ? this.recordsObj.other.totalRecords : null;
-    this.logger.log('analyze', 'ResourcesAnalyzer:totalCount:', count);
-    return count;
+    const res = this.recordsObj.hasLoaded ? this.recordsObj.other.totalRecords : null;
+    this.logger.log('analyze', 'ResourcesAnalyzer:totalCount:', res);
+    return res;
   }
 
   pending() {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -421,8 +421,8 @@ class SearchAndSort extends React.Component {
     const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
-    const resource = analyzer.records();
-    const records = (resource || {}).records || [];
+    const resource = parentResources.records; // ### this is to be removed
+    const records = analyzer.records();
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';
     const filters = filterState(this.queryParam('filters'));

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -31,7 +31,7 @@ function noRecordsMessage(r, analyzer, searchTerm) {
   if (analyzer.pending()) return 'Loading...';
   const failure = analyzer.failure();
   if (failure) return <div><h2>Error {failure.httpStatus}</h2><p>{failure.message}</p></div>;
-  if (!r.hasLoaded) return '';
+  if (!analyzer.loaded()) return '';
   if (!searchTerm) return 'No results found. Please check your filters.';
   return `No results found for "${searchTerm}". Please check your spelling and filters.`;
 }

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -602,7 +602,7 @@ class SearchAndSort extends React.Component {
           !this.props.browseOnly && createRecordLayer
         }
         {
-          _.get(this.props.parentResources.query, 'notes') &&
+          this.queryParam('notes') &&
           <Route
             path={`${this.props.match.path}/view/:id`}
             render={props => <this.connectedNotes

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -588,7 +588,7 @@ class SearchAndSort extends React.Component {
             isEmptyMessage={message}
             columnWidths={this.props.columnWidths}
             columnMapping={this.props.columnMapping}
-            loading={resource ? resource.isPending : false}
+            loading={analyzer.pending()}
             autosize
             virtualize
             ariaLabel={`${objectNameUC} search results`}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -27,8 +27,8 @@ import css from './SearchAndSort.css';
 import ResourcesAnalyzer from './ResourcesAnalyzer';
 
 
-function noRecordsMessage(r, searchTerm) {
-  if (!r || r.isPending) return 'Loading...';
+function noRecordsMessage(r, analyzer, searchTerm) {
+  if (analyzer.pending()) return 'Loading...';
   if (r.failed) return <div><h2>Error {r.failed.httpStatus}</h2><p>{r.failed.message}</p></div>;
   if (!r.hasLoaded) return '';
   if (!searchTerm) return 'No results found. Please check your filters.';
@@ -501,7 +501,7 @@ class SearchAndSort extends React.Component {
           </div>));
 
     const count = analyzer.totalCount();
-    const message = noRecordsMessage(resource, searchTerm);
+    const message = noRecordsMessage(resource, analyzer, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 
     const createRecordLayer = (!this.props.editRecordComponent ? '' :

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -500,7 +500,7 @@ class SearchAndSort extends React.Component {
             <p>Sorry - your permissions do not allow access to this page.</p>
           </div>));
 
-    const count = resource && resource.hasLoaded ? resource.other.totalRecords : '';
+    const count = analyzer.totalCount();
     const message = noRecordsMessage(resource, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -29,7 +29,8 @@ import ResourcesAnalyzer from './ResourcesAnalyzer';
 
 function noRecordsMessage(r, analyzer, searchTerm) {
   if (analyzer.pending()) return 'Loading...';
-  if (r.failed) return <div><h2>Error {r.failed.httpStatus}</h2><p>{r.failed.message}</p></div>;
+  const failure = analyzer.failure();
+  if (failure) return <div><h2>Error {failure.httpStatus}</h2><p>{failure.message}</p></div>;
   if (!r.hasLoaded) return '';
   if (!searchTerm) return 'No results found. Please check your filters.';
   return `No results found for "${searchTerm}". Please check your spelling and filters.`;

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -422,7 +422,6 @@ class SearchAndSort extends React.Component {
     const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
-    const resource = parentResources.records; // ### this is to be removed
     const records = analyzer.records();
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -548,7 +548,7 @@ class SearchAndSort extends React.Component {
                 onChange={this.onChangeSearch}
                 onClear={this.onClearSearchQuery}
                 value={searchTerm}
-                loading={(resource && searchTerm) ? resource.isPending : false}
+                loading={analyzer.pending()}
               />
             </Accordion>
             <FilterGroups

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -417,7 +417,7 @@ class SearchAndSort extends React.Component {
 
   render() {
     const { parentResources, filterConfig, disableFilters, newRecordPerms, viewRecordPerms, objectName, detailProps, packageInfo } = this.props;
-    const analyzer = new ResourcesAnalyzer(parentResources);
+    const analyzer = new ResourcesAnalyzer(parentResources, this.context.stripes.logger);
     const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -27,7 +27,7 @@ import css from './SearchAndSort.css';
 import ResourcesAnalyzer from './ResourcesAnalyzer';
 
 
-function noRecordsMessage(r, analyzer, searchTerm) {
+function noRecordsMessage(analyzer, searchTerm) {
   if (analyzer.pending()) return 'Loading...';
   const failure = analyzer.failure();
   if (failure) return <div><h2>Error {failure.httpStatus}</h2><p>{failure.message}</p></div>;
@@ -502,7 +502,7 @@ class SearchAndSort extends React.Component {
           </div>));
 
     const count = analyzer.totalCount();
-    const message = noRecordsMessage(resource, analyzer, searchTerm);
+    const message = noRecordsMessage(analyzer, searchTerm);
     const sortOrder = this.queryParam('sort') || '';
 
     const createRecordLayer = (!this.props.editRecordComponent ? '' :

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -24,6 +24,7 @@ import SearchField from '@folio/stripes-components/lib/structures/SearchField';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 import Notes from '../Notes';
 import css from './SearchAndSort.css';
+import ResourcesAnalyzer from './ResourcesAnalyzer';
 
 
 function noRecordsMessage(r, searchTerm) {
@@ -416,10 +417,11 @@ class SearchAndSort extends React.Component {
 
   render() {
     const { parentResources, filterConfig, disableFilters, newRecordPerms, viewRecordPerms, objectName, detailProps, packageInfo } = this.props;
+    const analyzer = new ResourcesAnalyzer(parentResources);
     const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
-    const resource = parentResources.records;
+    const resource = analyzer.records();
     const records = (resource || {}).records || [];
     const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
     const searchIndex = this.queryParam('qindex') || '';


### PR DESCRIPTION
Rather than poking around in the stripes-connect response structure, `<SearchAndSort>`'s `render` method now creates a `ResourcesAnalyzer` object on that structure and invokes methods on that object to obtains records, hit-counts, pending status, etc.

This fixes much of STSMACOM-65 and clears the way for STSMACOM-66 in which I will make the analyzer class smart enough to extract analogous information from GraphQL responses, thereby making SearchAndSort bilingual.

*Note 1* I will similarly need to convert the other `<SearchAndSort>` methods as well as `render`.

*Note 2* This only covers `<SearchAndSort>` itself: down the line, we will similarly need to convert the ViewRecord and EditComponent for each of the modules that use it.

So we have a ways to go yet.