### PR TITLE
STCOM-228: Add functionality to <ControlledVocab>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * Change `ResourcesAnalyzer` API so that constructor takes top-level props. Fixes STSMACOM-68.
 * Switch ResourcesAnalyzer API to use a factory method. Fixes STSMACOM-69.
 * Add optional `apolloResource` property to `<SearchAndSort>`, for use of resource analyzer. Fixes STSMACOM-70.
+* Added functionality to `<ControlledVocab>` to render updated metadata, usage counts and confirm deletion requests.
+* Added `<UserName>` and `<UserLink>` components to render names/links based on FOLIO User IDs.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -3,11 +3,20 @@ import PropTypes from 'prop-types';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import EditableList from '@folio/stripes-components/lib/structures/EditableList';
+import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import Callout from '@folio/stripes-components/lib/Callout';
 
 class ControlledVocab extends React.Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
-    resources: PropTypes.object.isRequired,
+    labelSingular: PropTypes.string.isRequired,
+    objectLabel: PropTypes.string.isRequired,
+    numberOfObjects: PropTypes.func.isRequired,
+    resources: PropTypes.shape({
+      values: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    }).isRequired,
     mutator: PropTypes.shape({
       activeRecord: PropTypes.shape({
         update: PropTypes.func,
@@ -18,19 +27,22 @@ class ControlledVocab extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    visibleFields: PropTypes.arrayOf(
-      PropTypes.string,
-    ),
+    visibleFields: PropTypes.arrayOf(PropTypes.string),
+    hiddenFields: PropTypes.arrayOf(PropTypes.string),
+    columnMapping: PropTypes.object,
     itemTemplate: PropTypes.object,
     nameKey: PropTypes.string,
-    additionalFields: PropTypes.object,
+    formatter: PropTypes.object,
+    actionSuppressor: PropTypes.object,
   };
 
   static defaultProps = {
-    visibleFields: ['name'],
-    itemTemplate: { name: 'string' },
+    visibleFields: ['name', 'description'],
+    hiddenFields: [],
+    columnMapping: {},
+    itemTemplate: {},
     nameKey: undefined,
-    additionalFields: {},
+    formatter: {},
   };
 
   static manifest = Object.freeze({
@@ -45,24 +57,35 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
     },
+    users: {
+      type: 'okapi',
+      resorces: 'users',
+      path: 'users?limit=0',
+      accumulate: true,
+    },
     activeRecord: {},
   });
 
   constructor(props) {
     super(props);
 
-    this.state = {};
+    this.state = {
+      showConfirmDialog: false,
+      selectedItem: {},
+    };
 
-    this.onCreateType = this.onCreateType.bind(this);
-    this.onUpdateType = this.onUpdateType.bind(this);
-    this.onDeleteType = this.onDeleteType.bind(this);
+    this.onCreateItem = this.onCreateItem.bind(this);
+    this.onUpdateItem = this.onUpdateItem.bind(this);
+    this.onDeleteItem = this.onDeleteItem.bind(this);
+    this.showConfirmDialog = this.showConfirmDialog.bind(this);
+    this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
   }
 
-  onCreateType(type) {
+  onCreateItem(type) {
     return this.props.mutator.values.POST(type);
   }
 
-  onUpdateType(type) {
+  onUpdateItem(type) {
     this.props.mutator.activeRecord.update({ id: type.id });
     // TODO: remove when back end PUT requests ignore read only properties
     // https://issues.folio.org/browse/RMB-92
@@ -70,19 +93,51 @@ class ControlledVocab extends React.Component {
     return this.props.mutator.values.PUT(type);
   }
 
-  onDeleteType(typeId) {
-    this.props.mutator.activeRecord.update({ id: typeId });
-    return this.props.mutator.values.DELETE(this.props.resources.values.records.find(t => t.id === typeId));
+  onDeleteItem() {
+    const { selectedItem } = this.state;
+    this.props.mutator.activeRecord.update({ id: selectedItem.id });
+    return this.props.mutator.values.DELETE(selectedItem)
+      .then(() => this.deleteItemResolve())
+      .then(() => this.showDeletionSuccessCallout(selectedItem))
+      .catch(() => this.deleteItemReject())
+      .finally(() => this.hideConfirmDialog());
+  }
+
+  showDeletionSuccessCallout(name) {
+    const message = (
+      <span>
+        The material type <strong>{name.name}</strong> was successfully <strong>deleted</strong>.
+      </span>
+    );
+
+    this.callout.sendCallout({ message });
+  }
+
+  showConfirmDialog(itemId) {
+    const selectedItem = this.props.resources.values.records.find(t => t.id === itemId);
+
+    this.setState({
+      showConfirmDialog: true,
+      selectedItem,
+    });
+
+    return new Promise((resolve, reject) => {
+      this.deleteItemResolve = resolve;
+      this.deleteItemReject = reject;
+    });
+  }
+
+  hideConfirmDialog() {
+    this.setState({
+      showConfirmDialog: false,
+      selectedItem: {},
+    });
   }
 
   render() {
     if (!this.props.resources.values) return <div />;
 
-    const suppressor = {
-      // If a suppressor returns true, the control for that action will not appear
-      delete: () => true,
-      edit: () => false,
-    };
+    const modalMessage = <span>The {this.props.labelSingular.toLowerCase()} <strong>{this.state.selectedItem.name}</strong> will be <strong>deleted.</strong></span>;
 
     return (
       <Paneset>
@@ -94,16 +149,45 @@ class ControlledVocab extends React.Component {
             // is pulled in. This still causes a JS warning, but not an error
             contentData={this.props.resources.values.records || []}
             createButtonLabel="+ Add new"
-            visibleFields={this.props.visibleFields}
             itemTemplate={this.props.itemTemplate}
-            actionSuppression={suppressor}
-            onUpdate={this.onUpdateType}
-            onCreate={this.onCreateType}
-            onDelete={this.onDeleteType}
-            isEmptyMessage={`There are no ${this.props.label}`}
-            nameKey={this.props.nameKey}
-            additionalFields={this.props.additionalFields}
+            visibleFields={[
+              ...this.props.visibleFields,
+              'lastUpdated',
+              'numberOfObjects',
+            ].filter(field => !this.props.hiddenFields.includes(field))}
+            columnMapping={{
+              name: this.props.labelSingular,
+              lastUpdated: 'Last Updated',
+              numberOfObjects: `# of ${this.props.objectLabel}`,
+              ...this.props.columnMapping,
+            }}
+            formatter={{
+              lastUpdated: (item) => {
+                if (item.metadata && item.metadata.updatedDate) {
+                  return item.metadata.updatedDate;
+                }
+
+                return 'Unknown';
+              },
+              numberOfObjects: this.props.numberOfObjects,
+              ...this.props.formatter,
+            }}
+            readOnlyFields={['lastUpdated', 'numberOfObjects']}
+            actionSuppression={this.props.actionSuppressor}
+            onUpdate={this.onUpdateItem}
+            onCreate={this.onCreateItem}
+            onDelete={this.showConfirmDialog}
+            isEmptyMessage={`There are no ${this.props.label.toLowerCase()}`}
           />
+          <ConfirmationModal
+            open={this.state.showConfirmDialog}
+            heading={`Delete ${this.props.labelSingular.toLowerCase()}?`}
+            message={modalMessage}
+            onConfirm={this.onDeleteItem}
+            onCancel={this.hideConfirmDialog}
+            confirmLabel="Delete"
+          />
+          <Callout ref={(ref) => { this.callout = ref; }} />
         </Pane>
       </Paneset>
     );

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -51,7 +51,7 @@ class ControlledVocab extends React.Component {
     itemTemplate: {},
     nameKey: undefined,
     formatter: {
-      numberOfObjects: () => 'N/A',
+      numberOfObjects: () => '-',
     },
   };
 
@@ -66,12 +66,6 @@ class ControlledVocab extends React.Component {
       DELETE: {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
-    },
-    users: {
-      type: 'okapi',
-      resorces: 'users',
-      path: 'users?limit=0',
-      accumulate: true,
     },
     activeRecord: {},
   });
@@ -91,16 +85,13 @@ class ControlledVocab extends React.Component {
     this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
   }
 
-  onCreateItem(type) {
-    return this.props.mutator.values.POST(type);
+  onCreateItem(item) {
+    return this.props.mutator.values.POST(item);
   }
 
-  onUpdateItem(type) {
-    this.props.mutator.activeRecord.update({ id: type.id });
-    // TODO: remove when back end PUT requests ignore read only properties
-    // https://issues.folio.org/browse/RMB-92
-    delete type.metadata;
-    return this.props.mutator.values.PUT(type);
+  onUpdateItem(item) {
+    this.props.mutator.activeRecord.update({ id: item.id });
+    return this.props.mutator.values.PUT(item);
   }
 
   onDeleteItem() {
@@ -183,7 +174,7 @@ class ControlledVocab extends React.Component {
                   );
                 }
 
-                return 'Unknown';
+                return '-';
               },
               ...this.props.formatter,
             }}

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,17 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedDate } from 'react-intl';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import EditableList from '@folio/stripes-components/lib/structures/EditableList';
 import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
 import Callout from '@folio/stripes-components/lib/Callout';
 
+import UserLink from '../UserLink';
+
 class ControlledVocab extends React.Component {
   static propTypes = {
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    }).isRequired,
     label: PropTypes.string.isRequired,
     labelSingular: PropTypes.string.isRequired,
     objectLabel: PropTypes.string.isRequired,
-    numberOfObjects: PropTypes.func.isRequired,
+    baseUrl: PropTypes.string.isRequired,
+    records: PropTypes.string.isRequired,
     resources: PropTypes.shape({
       values: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -34,6 +41,7 @@ class ControlledVocab extends React.Component {
     nameKey: PropTypes.string,
     formatter: PropTypes.object,
     actionSuppressor: PropTypes.object,
+    actionProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -42,7 +50,9 @@ class ControlledVocab extends React.Component {
     columnMapping: {},
     itemTemplate: {},
     nameKey: undefined,
-    formatter: {},
+    formatter: {
+      numberOfObjects: () => 'N/A',
+    },
   };
 
   static manifest = Object.freeze({
@@ -163,17 +173,23 @@ class ControlledVocab extends React.Component {
             }}
             formatter={{
               lastUpdated: (item) => {
-                if (item.metadata && item.metadata.updatedDate) {
-                  return item.metadata.updatedDate;
+                if (item.metadata) {
+                  return (
+                    <span>
+                      <FormattedDate value={item.metadata.updatedDate} />
+                      <span> by </span>
+                      <UserLink stripes={this.props.stripes} id={item.metadata.updatedByUserId} />
+                    </span>
+                  );
                 }
 
                 return 'Unknown';
               },
-              numberOfObjects: this.props.numberOfObjects,
               ...this.props.formatter,
             }}
             readOnlyFields={['lastUpdated', 'numberOfObjects']}
             actionSuppression={this.props.actionSuppressor}
+            actionProps={this.props.actionProps}
             onUpdate={this.onUpdateItem}
             onCreate={this.onCreateItem}
             onDelete={this.showConfirmDialog}

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import UserName from '../UserName';
+
+class UserLink extends React.Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func,
+    }).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.connectedUserName = props.stripes.connect(UserName);
+  }
+
+  render() {
+    return (
+      <Link to={`/users/view/${this.props.id}`}>
+        <this.connectedUserName {...this.props} />
+      </Link>
+    );
+  }
+}
+
+export default UserLink;

--- a/lib/UserLink/index.js
+++ b/lib/UserLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './UserLink';

--- a/lib/UserName/UserName.js
+++ b/lib/UserName/UserName.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class UserName extends React.Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired, // eslint-disable-line
+    resources: PropTypes.shape({
+      user: PropTypes.object,
+    }).isRequired,
+  };
+
+  static manifest = Object.freeze({
+    user: {
+      type: 'okapi',
+      path: 'users/!{id}',
+    },
+  });
+
+  render() {
+    let { user } = this.props.resources;
+    if (!user || !user.hasLoaded || user.records.length !== 1) return null;
+
+    user = user.records[0];
+
+    return <span to={`/users/view/${user.id}`}>{user.personal.lastName}, {user.personal.firstName}</span>;
+  }
+}
+
+export default UserName;

--- a/lib/UserName/index.js
+++ b/lib/UserName/index.js
@@ -1,0 +1,1 @@
+export { default } from './UserName';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react-bootstrap": "^0.32.0",
+    "react-intl": "^2.4.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"


### PR DESCRIPTION
Several settings pages were moving away from ControlledVocab and adding their own confirmation dialogs and custom renderers. This centralises that code into the ControlledVocab component.

- A default schema is expected but can be overridden.
- Updated metadata, when available, will be rendered as a date and a link to the user who made that update.
- Count columns can be shown and take a custom renderer from the parent. PatronGroupsSettings is currently the only user of this, though AddressTypesSettings will likely as well.

This will be used in forthcoming PRs in ui-users and ui-inventory to transition their CV settings pages to this.