### PR TITLE
pass validate() as prop

### DIFF
--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -17,6 +17,7 @@ class ConfigManager extends React.Component {
       }),
     }).isRequired,
     label: PropTypes.string.isRequired,
+    validate: PropTypes.func,
     configName: PropTypes.string.isRequired,
     moduleName: PropTypes.string.isRequired,
     onBeforeSave: PropTypes.func,

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -92,6 +92,7 @@ class ConfigManager extends React.Component {
     return (
       <ConfigFormComponent
         onSubmit={this.onSave}
+        validate={this.props.validate}
         initialValues={initialValues}
         label={label}
       >{children}


### PR DESCRIPTION
redux-form can accept `validate` as a prop on the the FormComponent, or as a stand-alone function. To have access to `this.props.stripes`, it needs to be the former. This PR enables that.