### PR TITLE
pass stripes in props

### DIFF
--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -18,6 +18,7 @@ class ConfigManager extends React.Component {
     }).isRequired,
     label: PropTypes.string.isRequired,
     validate: PropTypes.func,
+    stripes: PropTypes.object,
     configName: PropTypes.string.isRequired,
     moduleName: PropTypes.string.isRequired,
     onBeforeSave: PropTypes.func,

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -96,6 +96,7 @@ class ConfigManager extends React.Component {
         validate={this.props.validate}
         initialValues={initialValues}
         label={label}
+        stripes={this.props.stripes}
       >{children}
       </ConfigFormComponent>
     );


### PR DESCRIPTION
Follow-on to https://github.com/folio-org/stripes-smart-components/pull/128; the FormComponent needs access to `this.props.stripes`.