### PR TITLE
STCOM-237 ControlledVocab: Show modal when deletion fails

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate } from 'react-intl';
+
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import EditableList from '@folio/stripes-components/lib/structures/EditableList';
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import Button from '@folio/stripes-components/lib/Button';
 import Callout from '@folio/stripes-components/lib/Callout';
+import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import Modal from '@folio/stripes-components/lib/Modal';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 
 import UserLink from '../UserLink';
 
@@ -75,6 +79,7 @@ class ControlledVocab extends React.Component {
 
     this.state = {
       showConfirmDialog: false,
+      showItemInUseDialog: false,
       selectedItem: {},
       primaryField: props.visibleFields[0],
     };
@@ -85,6 +90,7 @@ class ControlledVocab extends React.Component {
     this.onDeleteItem = this.onDeleteItem.bind(this);
     this.showConfirmDialog = this.showConfirmDialog.bind(this);
     this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
+    this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -128,12 +134,41 @@ class ControlledVocab extends React.Component {
 
   onDeleteItem() {
     const { selectedItem } = this.state;
+
     this.props.mutator.activeRecord.update({ id: selectedItem.id });
-    return this.props.mutator.values.DELETE(selectedItem)
-      .then(() => this.deleteItemResolve())
-      .then(() => this.showDeletionSuccessCallout(selectedItem))
-      .catch(() => this.deleteItemReject())
+
+    return this.deleteItem(selectedItem.id)
+      .then(() => {
+        this.showDeletionSuccessCallout(selectedItem);
+        this.deleteItemResolve();
+      })
+      .catch(() => {
+        this.setState({ showItemInUseDialog: true });
+        this.deleteItemReject();
+      })
       .finally(() => this.hideConfirmDialog());
+  }
+
+  // TODO: Refactor this to use the mutator when errors generated in mutators
+  // can be intercepted to prevent throwing the alert() in connectErrorEpic.js
+  deleteItem(itemId) {
+    const { baseUrl, stripes } = this.props;
+
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'X-Okapi-Tenant': stripes.okapi.tenant,
+        'X-Okapi-Token': stripes.store.getState().okapi.token,
+        'Content-Type': 'application/json',
+      }
+    };
+
+    return fetch(`${stripes.okapi.url}/${baseUrl}/${itemId}`, options)
+      .then((resp) => {
+        if (resp.status === 400) {
+          throw Error('Cannot delete item because it is in use');
+        }
+      });
   }
 
   showDeletionSuccessCallout(item) {
@@ -165,6 +200,34 @@ class ControlledVocab extends React.Component {
       showConfirmDialog: false,
       selectedItem: {},
     });
+  }
+
+  hideItemInUseDialog() {
+    this.setState({
+      showItemInUseDialog: false,
+      selectedItem: {},
+    });
+  }
+
+  renderItemInUseDialog() {
+    return (
+      <Modal
+        open={this.state.showItemInUseDialog}
+        label={`Cannot delete ${this.props.labelSingular.toLowerCase()}`}
+        size="small"
+      >
+        <Row>
+          <Col xs>
+            This {this.props.labelSingular.toLowerCase()} cannot be deleted, as it is in use by one or more records.
+          </Col>
+        </Row>
+        <Row>
+          <Col xs>
+            <Button buttonStyle="primary" onClick={this.hideItemInUseDialog}>Okay</Button>
+          </Col>
+        </Row>
+      </Modal>
+    );
   }
 
   render() {
@@ -227,6 +290,7 @@ class ControlledVocab extends React.Component {
             onCancel={this.hideConfirmDialog}
             confirmLabel="Delete"
           />
+          { this.renderItemInUseDialog() }
           <Callout ref={(ref) => { this.callout = ref; }} />
         </Pane>
       </Paneset>


### PR DESCRIPTION
Making the error deletion failures a bit nicer. This'll eventually get tweaked with whatever we decide to do with the new mutator/stripes-connect v2/GraphQL API but I wanted to get it working now.