### PR TITLE
Improve search field in SearchAndSort component. Fixes STSMACOM-81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Introduced a new `<LocationLookup>` component. Fixes STSMACOM-79. Available from v1.4.9.
 * Introduced a new `<LocationSelection>` component. Fixes STSMACOM-82. Available from v1.4.10.
 * Added a more user friendly empty message to the results list
+* Improve search field in `<SearchAndSort>` component. Fixes STSMACOM-81.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -233,6 +233,11 @@ class SearchAndSort extends React.Component {
     }
   }
 
+  componentDidMount() {
+    const query = this.queryParam('query');
+    this.setState({ locallyChangedSearchTerm: query });
+  }
+
   componentWillUnmount() {
     if (this.props.onComponentWillUnmount) {
       this.props.onComponentWillUnmount(this.props);
@@ -243,13 +248,14 @@ class SearchAndSort extends React.Component {
 
   onChangeSearch = (e) => {
     const query = e.target.value;
-    this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
+
     this.setState({ locallyChangedSearchTerm: query });
     this.performSearch(query);
   }
 
   // eslint-disable-next-line react/sort-comp
   performSearch = _.debounce((query) => {
+    this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
     this.log('action', `searched for '${query}'`);
     this.transitionToParams({ query });
   }, 350);
@@ -397,7 +403,7 @@ class SearchAndSort extends React.Component {
     const initialFilters = this.initialFilters || '';
     const currentFilters = this.queryParam('filters') || '';
     const filtersHaveChanged = currentFilters !== initialFilters;
-    const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
+    const searchTerm = this.state.locallyChangedSearchTerm || '';
     const searchIndex = this.queryParam('qindex') || '';
     const searchHasChanged = searchTerm !== '' || searchIndex !== '';
 
@@ -418,7 +424,7 @@ class SearchAndSort extends React.Component {
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
     const records = analyzer.records();
-    const searchTerm = this.state.locallyChangedSearchTerm || this.queryParam('query') || '';
+    const searchTerm = this.state.locallyChangedSearchTerm || '';
     const searchIndex = this.queryParam('qindex') || '';
     const filters = filterState(this.queryParam('filters'));
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -199,6 +199,12 @@ class SearchAndSort extends React.Component {
     this.log = logger.log.bind(logger);
   }
 
+  componentDidMount() {
+    const query = this.queryParam('query');
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ locallyChangedSearchTerm: query });
+  }
+
   componentWillReceiveProps(nextProps) {
     const logger = this.context.stripes.logger;
     const oldAnalyzer = makeResourcesAnalyzer(this.props, logger);
@@ -231,11 +237,6 @@ class SearchAndSort extends React.Component {
         oldAnalyzer.totalCount() > 1) {
       this.onSelectRow(null, newAnalyzer.records()[0]);
     }
-  }
-
-  componentDidMount() {
-    const query = this.queryParam('query');
-    this.setState({ locallyChangedSearchTerm: query });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-81

It looks like what was happening here is that `locallyChangedSearchTerm ` was fighting with `this.queryParam('query')`. Since setting `locallyChangedSearchTerm` is done outside of the `debounce` the local state would be cleaned up but the `this.queryParam('query')` would still hold the previous value. 