### PR TITLE
Guard against selecting row when no mutations available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Introduced a new `<LocationSelection>` component. Fixes STSMACOM-82. Available from v1.4.10.
 * Added a more user friendly empty message to the results list
 * Improve search field in `<SearchAndSort>` component. Fixes STSMACOM-81.
+* Guard against selecting new-record row when no mutations available. Fixes STSMACOM-83.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -219,7 +219,7 @@ class SearchAndSort extends React.Component {
         const finishedResourceNextSM = finishedNewAnalyzer.successfulMutations();
         if (finishedResourceNextSM.length > finishedOldAnalyzer.successfulMutations().length) {
           const sm = newAnalyzer.successfulMutations();
-          this.onSelectRow(undefined, { id: sm[0].record.id });
+          if (sm[0]) this.onSelectRow(undefined, { id: sm[0].record.id });
         }
       }
     }


### PR DESCRIPTION
I don't understand why the `successfulMutations` array would be empty after creating a user, and indeed I never see this condition on my development box -- which makes it very hard to debug -- but it does happen on folio-testing and snapshot. So I've added a guard, whose effect I can't observe on my own box, in the hope that it will make the public boxes work right when it gets uploaded.

Yeah, I know.

Should fix STSMACOM-83.
