### PR TITLE
Filters for ControlledVocab rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Introduced a new `<LocationSelection>` component. Fixes STSMACOM-82. Available from v1.4.10.
 * Added a more user friendly empty message to the results list
 * Improve search field in `<SearchAndSort>` component. Fixes STSMACOM-81.
+* `<ControlledVocab>` rows may be filtered. Available from v1.4.11.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -52,11 +52,8 @@ class ControlledVocab extends React.Component {
     formatter: PropTypes.object,
     actionSuppressor: PropTypes.object,
     actionProps: PropTypes.object,
-    rowFilter: PropTypes.shape({
-      component: PropTypes.func.isRequired,
-      componentProps: PropTypes.object.isRequired,
-      rowFilter: PropTypes.func.isRequired,
-    }),
+    rowFilter: PropTypes.element,
+    rowFilterFunction: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
   };
@@ -70,7 +67,6 @@ class ControlledVocab extends React.Component {
     formatter: {
       numberOfObjects: () => '-',
     },
-    rowFilter: undefined,
     preCreateHook: (row) => row,
     preUpdateHook: (row) => row,
   };
@@ -88,7 +84,8 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=1000'
+        // FIXME we seriously don't want hard-coded limits in our queries
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=100'
       }
     },
     activeRecord: {},
@@ -102,7 +99,6 @@ class ControlledVocab extends React.Component {
       showItemInUseDialog: false,
       selectedItem: {},
       primaryField: props.visibleFields[0],
-      filterValue: '',
     };
 
     this.validate = this.validate.bind(this);
@@ -145,12 +141,12 @@ class ControlledVocab extends React.Component {
   }
 
   onCreateItem(item) {
-    return this.props.mutator.values.POST(this.props.preCreateHook(item, this.state.filterValue));
+    return this.props.mutator.values.POST(this.props.preCreateHook(item));
   }
 
   onUpdateItem(item) {
     this.props.mutator.activeRecord.update({ id: item.id });
-    return this.props.mutator.values.PUT(this.props.preUpdateHook(item, this.state.filterValue));
+    return this.props.mutator.values.PUT(this.props.preUpdateHook(item));
   }
 
   onDeleteItem() {
@@ -265,16 +261,12 @@ class ControlledVocab extends React.Component {
     );
   }
 
-  onChangeRowFilter = (e) => {
-    this.setState({ filterValue: e.target.value });
-  }
-
   filteredRows(rows) {
-    if (!this.state.filterValue) {
+    if (!this.props.rowFilterFunction) {
       return rows;
     }
 
-    return rows.filter(row => this.props.rowFilter.rowFilter(row, this.state.filterValue));
+    return rows.filter(row => this.props.rowFilterFunction(row));
   }
 
   render() {
@@ -293,18 +285,10 @@ class ControlledVocab extends React.Component {
 
     const rows = this.filteredRows(this.props.resources.values.records || []);
 
-    let filterElement = null;
-    if (this.props.rowFilter) {
-      filterElement = React.createElement(this.props.rowFilter.component, {
-        ...this.props.rowFilter.componentProps,
-        onChange: this.onChangeRowFilter,
-      });
-    }
-
     return (
       <Paneset>
         <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
-          {filterElement}
+          {this.props.rowFilter}
           <EditableList
             {...this.props}
             // TODO: not sure why we need this OR if there are no groups

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -52,6 +52,13 @@ class ControlledVocab extends React.Component {
     formatter: PropTypes.object,
     actionSuppressor: PropTypes.object,
     actionProps: PropTypes.object,
+    rowFilter: PropTypes.shape({
+      component: PropTypes.func.isRequired,
+      componentProps: PropTypes.object.isRequired,
+      rowFilter: PropTypes.func.isRequired,
+    }),
+    preCreateHook: PropTypes.func,
+    preUpdateHook: PropTypes.func,
   };
 
   static defaultProps = {
@@ -63,6 +70,9 @@ class ControlledVocab extends React.Component {
     formatter: {
       numberOfObjects: () => '-',
     },
+    rowFilter: undefined,
+    preCreateHook: (row) => row,
+    preUpdateHook: (row) => row,
   };
 
   static manifest = Object.freeze({
@@ -77,6 +87,9 @@ class ControlledVocab extends React.Component {
       DELETE: {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
+      GET: {
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=1000'
+      }
     },
     activeRecord: {},
   });
@@ -89,6 +102,7 @@ class ControlledVocab extends React.Component {
       showItemInUseDialog: false,
       selectedItem: {},
       primaryField: props.visibleFields[0],
+      filterValue: '',
     };
 
     this.validate = this.validate.bind(this);
@@ -131,12 +145,12 @@ class ControlledVocab extends React.Component {
   }
 
   onCreateItem(item) {
-    return this.props.mutator.values.POST(item);
+    return this.props.mutator.values.POST(this.props.preCreateHook(item, this.state.filterValue));
   }
 
   onUpdateItem(item) {
     this.props.mutator.activeRecord.update({ id: item.id });
-    return this.props.mutator.values.PUT(item);
+    return this.props.mutator.values.PUT(this.props.preUpdateHook(item, this.state.filterValue));
   }
 
   onDeleteItem() {
@@ -251,6 +265,18 @@ class ControlledVocab extends React.Component {
     );
   }
 
+  onChangeRowFilter = (e) => {
+    this.setState({ filterValue: e.target.value });
+  }
+
+  filteredRows(rows) {
+    if (!this.state.filterValue) {
+      return rows;
+    }
+
+    return rows.filter(row => this.props.rowFilter.rowFilter(row, this.state.filterValue));
+  }
+
   render() {
     if (!this.props.resources.values) return <div />;
 
@@ -265,15 +291,26 @@ class ControlledVocab extends React.Component {
       />
     );
 
+    const rows = this.filteredRows(this.props.resources.values.records || []);
+
+    let filterElement = null;
+    if (this.props.rowFilter) {
+      filterElement = React.createElement(this.props.rowFilter.component, {
+        ...this.props.rowFilter.componentProps,
+        onChange: this.onChangeRowFilter,
+      });
+    }
+
     return (
       <Paneset>
         <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
+          {filterElement}
           <EditableList
             {...this.props}
             // TODO: not sure why we need this OR if there are no groups
             // Seems to load this once before the groups data from the manifest
             // is pulled in. This still causes a JS warning, but not an error
-            contentData={this.props.resources.values.records || []}
+            contentData={rows}
             createButtonLabel={formatMessage({ id: 'stripes-core.button.new' })}
             itemTemplate={this.props.itemTemplate}
             visibleFields={[

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
## Objective
Allow the rows of a `<ControlledVocab>` table to be filtered, e.g. so that only rows with an attribute matching the value of a `<select>` are displayed. 

## Approach
Accept four new props: 
1. `rowFilter` a component to be rendered above the rows; used to provide the value to filter against.
1. `rowFilterFunction` a callback to handle row filtering; receives one row at a time and should return true IFF the row should be displayed and false otherwise. 
1. `preCreateHook` a callback that receives a row-object immediately before it is created; it should return a copy of the object. 
1. `preUpdateHook` a callback that receives a row-object immediately before it is updated; it should return a copy of the object. 

The calling component should put an `onChange` handler on the `rowFilter` component that stores its value in state and then access the state in `rowFilterFunction`. For example: 
```
onChangeHandler = (e) => {
    this.setState({ campusId: e.target.value }); 
}

rowFilter = <Select id="campusId" dataOptions={...} onChange={this.onChangeHandler} />;
rowFilterFunction = (row) => row.campusId === this.state.campusId; 
```

Refs [UIORG-61](https://issues.folio.org/browse/UIORG-61), [UIORG-65](https://issues.folio.org/browse/UIORG-65)