### PR TITLE
ControlledVocab: Handle own mutator errors

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -77,6 +77,7 @@ class ControlledVocab extends React.Component {
       path: '!{baseUrl}',
       records: '!{records}',
       accumulate: 'true',
+      throwErrors: false,
       PUT: {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
@@ -154,44 +155,16 @@ class ControlledVocab extends React.Component {
 
     this.props.mutator.activeRecord.update({ id: selectedItem.id });
 
-    return this.deleteItem(selectedItem.id)
+    return this.props.mutator.values.DELETE({ id: selectedItem.id })
       .then(() => {
         this.showDeletionSuccessCallout(selectedItem);
         this.deleteItemResolve();
-
-        // We're currently not using the mutator for DELETE operations
-        // so that we can catch Okapi errors so we manually GET here to
-        // fetch the updated list.
-        this.props.mutator.values.reset();
-        this.props.mutator.values.GET();
       })
       .catch(() => {
         this.setState({ showItemInUseDialog: true });
         this.deleteItemReject();
       })
       .finally(() => this.hideConfirmDialog());
-  }
-
-  // TODO: Refactor this to use the mutator when errors generated in mutators
-  // can be intercepted to prevent throwing the alert() in connectErrorEpic.js
-  deleteItem(itemId) {
-    const { baseUrl, stripes } = this.props;
-
-    const options = {
-      method: 'DELETE',
-      headers: {
-        'X-Okapi-Tenant': stripes.okapi.tenant,
-        'X-Okapi-Token': stripes.store.getState().okapi.token,
-        'Content-Type': 'application/json',
-      }
-    };
-
-    return fetch(`${stripes.okapi.url}/${baseUrl}/${itemId}`, options)
-      .then((resp) => {
-        if (resp.status === 400) {
-          throw Error('Cannot delete item because it is in use');
-        }
-      });
   }
 
   showDeletionSuccessCallout(item) {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes-connect": "^3.0.0",
+    "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-core": "^2.8.0",
     "@folio/stripes-logger": "^0.0.2",
     "react": "*"


### PR DESCRIPTION
Use that fancy new STCON-67 functionality to catch errors thrown by mutator calls, rather than writing our own `fetch`.