### PR TITLE
Back-end-agnostic generation of error-messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * `<ControlledVocab>` rows may be filtered. Available from v1.4.12.
 * Enable correct error-handling when using GraphQL. Fixes STSMACOM-74.
 * Add support for inactive location confirmation. Refs UIIN-121.
+* `<NoResultsMessage>` now uses the new resources-analyzer method `failureMessage` when reporting errors. Fixes STSMACOM-88.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/ResourcesAnalyzer.js
+++ b/lib/SearchAndSort/ResourcesAnalyzer.js
@@ -62,6 +62,13 @@ class GraphQLResourcesAnalyzer {
     return res;
   }
 
+  failureMessage() {
+    // react-apollo failure object has: extraInfo, graphQLErrors, message, networkError, stack
+    const res = `GraphQL error: ${this.data.error.message}`;
+    this.logger.log('analyze-all', 'failureMessage', res);
+    return res;
+  }
+
   successfulMutations() { // TODO once we have mutations happening via GraphQL
     const res = this.recordsObj.successfulMutations || [];
     this.logger.log('analyze-all', 'successfulMutations', res);
@@ -111,6 +118,14 @@ class StripesConnectResourcesAnalyzer {
   failure() {
     const res = this.recordsObj.failed;
     this.logger.log('analyze-all', 'failure', res);
+    return res;
+  }
+
+  failureMessage() {
+    const failed = this.recordsObj.failed;
+    // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors
+    const res = `Stripes-connect error ${failed.httpStatus}: ${failed.message.replace(/.*:\s*/, '')}`;
+    this.logger.log('analyze-all', 'failureMessage', res);
     return res;
   }
 

--- a/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
+++ b/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
@@ -37,19 +37,7 @@ const NoResultsMessage = ({ analyzer, searchTerm, filterPaneIsVisible, toggleFil
   // Request failure
   if (failure) {
     icon = 'validation-error';
-
-    // XXX clearly this branching should be in the analyzer
-    // object. But we'll need to design an API for how that looks --
-    // most likely, just a failureMessage() or similar. And to do
-    // that, we need to better understand what the POs want displayed
-    // when an error occurs.
-    if (failure.httpStatus !== undefined) {
-      // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors
-      label = `Error ${failure.httpStatus}`;
-    } else {
-      // react-apollo failure object has: extraInfo, graphQLErrors, message, networkError, stack
-      label = `Error: ${failure.message}`;
-    }
+    label = analyzer.failureMessage();
   }
 
   return (


### PR DESCRIPTION
`<NoResultsMessage>` now uses the new resources-analyzer method `failureMessage` when reporting errors.

Fixes STSMACOM-88.