### PR TITLE
Always display sole hit when narrowing down to one result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Rename ResourcesAnalyzer to ConnectedSource. Fixes STSMACOM-95.
 * Break ConnectedSource into multiple source files. Fixes STSMACOM-97.
 * Support paging in `<SearchAndSort>`'s use of GraphQL. Fixes STSMACOM-72.
+* Always display sole hit when narrowing down to one result. Fixes STSMACOM-98.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -190,6 +190,7 @@ class SearchAndSort extends React.Component {
     this.connectedViewRecord = context.stripes.connect(props.viewRecordComponent);
     this.connectedNotes = context.stripes.connect(Notes);
     this.SRStatus = null;
+    this.lastNonNullReaultCount = undefined;
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
 
@@ -238,8 +239,12 @@ class SearchAndSort extends React.Component {
     // if the results list is winnowed down to a single record, display the record.
     if (nextProps.showSingleResult &&
         newState.totalCount() === 1 &&
-        oldState.totalCount() > 1) {
+        this.lastNonNullReaultCount > 1) {
       this.onSelectRow(null, newState.records()[0]);
+    }
+
+    if (newState.totalCount() !== null) {
+      this.lastNonNullReaultCount = newState.totalCount();
     }
   }
 


### PR DESCRIPTION
This wasn't working consistently when using GraphQL, because Apollo briefly sets result-count to `null` while it's in the process of running a search, so we weren't seeing the expected transition between a hit-count of more than one and a hit-count of exactly one. (It was still working _sometimes_ because if the single-hit search is in the cache from earlier, Apollo leaps straight to it without going through an in-progress stage.)

This was fixed by remembering the last _non-null_ result-count, and showing the full record when _that_ goes from greater than one to exactly one.

Fixes STSMACOM-98.
