### PR TITLE
STSMACOM-99 ControlledVocab: Truncate username when it doesn't fit

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.css
+++ b/lib/ControlledVocab/ControlledVocab.css
@@ -1,0 +1,5 @@
+.lastUpdated {
+  width: -moz-available;
+  width: -webkit-fill-available;
+  width: fill-available;
+}

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -13,6 +13,7 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import UserLink from '../UserLink';
+import css from './ControlledVocab.css';
 
 class ControlledVocab extends React.Component {
   static propTypes = {
@@ -285,13 +286,15 @@ class ControlledVocab extends React.Component {
               lastUpdated: (item) => {
                 if (item.metadata) {
                   return (
-                    <FormattedMessage
-                      id="stripes-smart-components.cv.updatedAtAndBy"
-                      values={{
-                        date: <FormattedDate value={item.metadata.updatedDate} />,
-                        user: <UserLink stripes={this.props.stripes} id={item.metadata.updatedByUserId} />
-                      }}
-                    />
+                    <div className={css.lastUpdated}>
+                      <FormattedMessage
+                        id="stripes-smart-components.cv.updatedAtAndBy"
+                        values={{
+                          date: <FormattedDate value={item.metadata.updatedDate} />,
+                          user: <UserLink stripes={this.props.stripes} id={item.metadata.updatedByUserId} displayBlock />
+                        }}
+                      />
+                    </div>
                   );
                 }
 

--- a/lib/UserLink/UserLink.css
+++ b/lib/UserLink/UserLink.css
@@ -1,0 +1,8 @@
+.userLink {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.displayBlock {
+  display: block;
+}

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -21,7 +21,7 @@ class UserLink extends React.Component {
 
   render() {
     const { displayBlock, ...props } = this.props;
-    const className = `${css.userLink} ${displayBlock ? css.displayBlock : ''}`
+    const className = `${css.userLink} ${displayBlock ? css.displayBlock : ''}`;
 
     return (
       <Link to={`/users/view/${props.id}`} className={className}>

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import UserName from '../UserName';
+import css from './UserLink.css';
 
 class UserLink extends React.Component {
   static propTypes = {
@@ -9,6 +10,7 @@ class UserLink extends React.Component {
     stripes: PropTypes.shape({
       connect: PropTypes.func,
     }).isRequired,
+    displayBlock: PropTypes.bool,
   };
 
   constructor(props) {
@@ -18,9 +20,12 @@ class UserLink extends React.Component {
   }
 
   render() {
+    const { displayBlock, ...props } = this.props;
+    const className = `${css.userLink} ${displayBlock ? css.displayBlock : ''}`
+
     return (
-      <Link to={`/users/view/${this.props.id}`}>
-        <this.connectedUserName {...this.props} />
+      <Link to={`/users/view/${props.id}`} className={className}>
+        <this.connectedUserName {...props} />
       </Link>
     );
   }

--- a/lib/UserName/UserName.js
+++ b/lib/UserName/UserName.js
@@ -23,7 +23,7 @@ class UserName extends React.Component {
     const { firstName, lastName } = user.records[0].personal;
     const displayName = firstName ? `${lastName}, ${firstName}` : lastName;
 
-    return <span to={`/users/view/${user.id}`}>{displayName}</span>;
+    return <span>{displayName}</span>;
   }
 }
 


### PR DESCRIPTION
Had to do some ✨ CSS ✨ here because we want to truncate the individual components of the name but still allow it to break onto multiple lines.

Keys are `fill-available` on the parent and `block` display on the `<a>`. Since we don't want to always `block` display on UserLink's I went ahead and made it an opt-in.