### PR TITLE
ControlledVocab: Switched from fill-available to stretch

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.css
+++ b/lib/ControlledVocab/ControlledVocab.css
@@ -1,5 +1,5 @@
 .lastUpdated {
   width: -moz-available;
   width: -webkit-fill-available;
-  width: fill-available;
+  width: stretch;
 }


### PR DESCRIPTION
Just supporting the eventual value for the behaviour we want here. Doesn't really do anything currently, since only prefixed values are used by browsers.