### PR TITLE
ControlledVocab: Added readOnlyFields prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * Always display sole hit when narrowing down to one result. Fixes STSMACOM-98.
 * Adjust buttons on location lookup popup. Fixes STSMACOM-96.
 * Add extra validation for users not allowed to request. Fixes STSMACOM-101.
+* Added to `<ControlledVocab>` a `readOnlyFields` prop.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -48,6 +48,7 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
+    readOnlyFields: PropTypes.arrayOf(PropTypes.string),
     columnMapping: PropTypes.object,
     itemTemplate: PropTypes.object,
     nameKey: PropTypes.string,
@@ -63,6 +64,7 @@ class ControlledVocab extends React.Component {
   static defaultProps = {
     visibleFields: ['name', 'description'],
     hiddenFields: [],
+    readOnlyFields: [],
     columnMapping: {},
     itemTemplate: {},
     nameKey: undefined,
@@ -303,7 +305,11 @@ class ControlledVocab extends React.Component {
               },
               ...this.props.formatter,
             }}
-            readOnlyFields={['lastUpdated', 'numberOfObjects']}
+            readOnlyFields={[
+              ...this.props.readOnlyFields,
+              'lastUpdated',
+              'numberOfObjects',
+            ]}
             actionSuppression={this.props.actionSuppressor}
             actionProps={this.props.actionProps}
             onUpdate={this.onUpdateItem}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Will eventually be used by UIIN-150, UIIN-151 and UIIN-152 to prevent editing of the "Source" field. [UIIN-152's mockup](https://issues.folio.org/browse/UIIN-152) has been updated to show how it'll be used.