### PR TITLE
STSMACOM-103 ControlledVocab: Prevent edit/delete on readOnly records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 * Adjust buttons on location lookup popup. Fixes STSMACOM-96.
 * Add extra validation for users not allowed to request. Fixes STSMACOM-101.
 * Added to `<ControlledVocab>` a `readOnlyFields` prop.
-* `<ControlledVocab>` now (by default) suppresses edit/delete actions on records that have a truthy `readOnly` prop.
+* `<ControlledVocab>` now (by default) suppresses edit/delete actions on records that have a truthy `readOnly` prop. Fixes STSMACOM-103.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Adjust buttons on location lookup popup. Fixes STSMACOM-96.
 * Add extra validation for users not allowed to request. Fixes STSMACOM-101.
 * Added to `<ControlledVocab>` a `readOnlyFields` prop.
+* `<ControlledVocab>` now (by default) suppresses edit/delete actions on records that have a truthy `readOnly` prop.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -119,7 +119,7 @@ class ControlledVocab extends React.Component {
     this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  getDerivedStateFromProps(nextProps) {
     if (nextProps.visibleFields[0] !== this.state.primaryField) {
       this.setState({
         primaryField: nextProps.visibleFields[0],

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -71,6 +71,10 @@ class ControlledVocab extends React.Component {
     formatter: {
       numberOfObjects: () => '-',
     },
+    actionSuppressor: {
+      edit: item => item.readOnly,
+      delete: item => item.readOnly,
+    },
     preCreateHook: (row) => row,
     preUpdateHook: (row) => row,
   };

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -119,12 +119,14 @@ class ControlledVocab extends React.Component {
     this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
   }
 
-  getDerivedStateFromProps(nextProps) {
-    if (nextProps.visibleFields[0] !== this.state.primaryField) {
-      this.setState({
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.visibleFields[0] !== prevState.primaryField) {
+      return {
         primaryField: nextProps.visibleFields[0],
-      });
+      };
     }
+
+    return null;
   }
 
   validate({ items }) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Some CV records are semi-permanently stored in Folio and shouldn't be edited by the user, even if they're a privileged user with access to the settings. Examples of these records would be RDA Content Types or RDA Carrier Types mentioned in [UIIN-150](https://issues.folio.org/browse/UIIN-150), -151, -152, etc.

A generic way of marking records as readonly is preferable to every settings page defining their own standard and their own action suppressors.

This action suppression is now implemented in CV via `defaultProps` so that it can be overridden if the component using `<ControlledVocab>` wants to.