### PR TITLE
STSMACOM-106: UserLink should only render a Link when the user has perms to follow that link

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.css
+++ b/lib/ControlledVocab/ControlledVocab.css
@@ -3,3 +3,9 @@
   width: -webkit-fill-available;
   width: stretch;
 }
+
+.lastUpdatedUser {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -13,6 +13,7 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import UserLink from '../UserLink';
+import UserName from '../UserName';
 import css from './ControlledVocab.css';
 
 class ControlledVocab extends React.Component {
@@ -119,6 +120,8 @@ class ControlledVocab extends React.Component {
       selectedItem: {},
       primaryField: props.visibleFields[0],
     };
+
+    this.connectedUserName = props.stripes.connect(UserName);
 
     this.validate = this.validate.bind(this);
     this.onCreateItem = this.onCreateItem.bind(this);
@@ -252,6 +255,28 @@ class ControlledVocab extends React.Component {
     return rows.filter(row => this.props.rowFilterFunction(row));
   }
 
+  renderLastUpdated(metadata) {
+    const UserComponent = this.props.stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
+    const User = (
+      <span className={css.lastUpdatedUser}>
+        <UserComponent stripes={this.props.stripes} id={metadata.updatedByUserId} />
+      </span>
+    );
+
+    return (
+      <div className={css.lastUpdated}>
+        <FormattedMessage
+          id="stripes-smart-components.cv.updatedAtAndBy"
+          values={{
+            date: this.props.stripes.formatDate(metadata.updatedDate),
+            user: User,
+          }}
+        />
+      </div>
+    );
+
+  }
+
   render() {
     if (!this.props.resources.values) return <div />;
 
@@ -294,17 +319,7 @@ class ControlledVocab extends React.Component {
             formatter={{
               lastUpdated: (item) => {
                 if (item.metadata) {
-                  return (
-                    <div className={css.lastUpdated}>
-                      <FormattedMessage
-                        id="stripes-smart-components.cv.updatedAtAndBy"
-                        values={{
-                          date: this.props.stripes.formatDate(item.metadata.updatedDate),
-                          user: <UserLink stripes={this.props.stripes} id={item.metadata.updatedByUserId} displayBlock />
-                        }}
-                      />
-                    </div>
-                  );
+                  return this.renderLastUpdated(item.metadata);
                 }
 
                 return '-';

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -27,7 +27,7 @@ class ControlledVocab extends React.Component {
     label: PropTypes.string.isRequired,
     labelSingular: PropTypes.string.isRequired,
     objectLabel: PropTypes.string.isRequired,
-    baseUrl: PropTypes.string.isRequired,
+    baseUrl: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
     records: PropTypes.string.isRequired,
     resources: PropTypes.shape({
       values: PropTypes.shape({
@@ -51,7 +51,7 @@ class ControlledVocab extends React.Component {
     readOnlyFields: PropTypes.arrayOf(PropTypes.string),
     columnMapping: PropTypes.object,
     itemTemplate: PropTypes.object,
-    nameKey: PropTypes.string,
+    nameKey: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
     formatter: PropTypes.object,
     actionSuppressor: PropTypes.object,
     actionProps: PropTypes.object,
@@ -100,6 +100,16 @@ class ControlledVocab extends React.Component {
     activeRecord: {},
   });
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.visibleFields[0] !== prevState.primaryField) {
+      return {
+        primaryField: nextProps.visibleFields[0],
+      };
+    }
+
+    return null;
+  }
+
   constructor(props) {
     super(props);
 
@@ -117,16 +127,6 @@ class ControlledVocab extends React.Component {
     this.showConfirmDialog = this.showConfirmDialog.bind(this);
     this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
     this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.visibleFields[0] !== prevState.primaryField) {
-      return {
-        primaryField: nextProps.visibleFields[0],
-      };
-    }
-
-    return null;
   }
 
   validate({ items }) {

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -20,6 +20,7 @@ class ControlledVocab extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
+      hasPerm: PropTypes.func.isRequired,
       formatDate: PropTypes.func.isRequired,
       intl: PropTypes.shape({
         formatMessage: PropTypes.func.isRequired,
@@ -274,7 +275,6 @@ class ControlledVocab extends React.Component {
         />
       </div>
     );
-
   }
 
   render() {

--- a/lib/UserLink/UserLink.css
+++ b/lib/UserLink/UserLink.css
@@ -1,8 +1,0 @@
-.userLink {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.displayBlock {
-  display: block;
-}

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -2,16 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import UserName from '../UserName';
-import css from './UserLink.css';
 
 class UserLink extends React.Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     stripes: PropTypes.shape({
-      hasPerm: PropTypes.func,
       connect: PropTypes.func,
     }).isRequired,
-    displayBlock: PropTypes.bool,
   };
 
   constructor(props) {
@@ -21,15 +18,10 @@ class UserLink extends React.Component {
   }
 
   render() {
-    const { displayBlock, ...props } = this.props;
-    const className = `${css.userLink} ${displayBlock ? css.displayBlock : ''}`;
-
-    const Container = this.props.stripes.hasPerm('ui-users.view') ? Link : 'span';
-
     return (
-      <Container to={`/users/view/${props.id}`} className={className}>
-        <this.connectedUserName {...props} />
-      </Container>
+      <Link to={`/users/view/${this.props.id}`}>
+        <this.connectedUserName {...this.props} />
+      </Link>
     );
   }
 }

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -8,6 +8,7 @@ class UserLink extends React.Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     stripes: PropTypes.shape({
+      hasPerm: PropTypes.func,
       connect: PropTypes.func,
     }).isRequired,
     displayBlock: PropTypes.bool,
@@ -23,10 +24,12 @@ class UserLink extends React.Component {
     const { displayBlock, ...props } = this.props;
     const className = `${css.userLink} ${displayBlock ? css.displayBlock : ''}`;
 
+    const Container = this.props.stripes.hasPerm('ui-users.view') ? Link : 'span';
+
     return (
-      <Link to={`/users/view/${props.id}`} className={className}>
+      <Container to={`/users/view/${props.id}`} className={className}>
         <this.connectedUserName {...props} />
-      </Link>
+      </Container>
     );
   }
 }


### PR DESCRIPTION
The background for this is [UIORG-76](https://issues.folio.org/browse/UIORG-76). I debated over a few ways of implementing this.

1. Putting the decision making in `<UserLink>`
👍: It's reusable everywhere and we won't accidentally render an unusable link. 
👎: UserLink doesn't render a link. That seems weird.

2. The solution I went with, putting the decision-making of rendering a UserLink vs UserName in ControlledVocab.
👍: Doesn't have the downside of the above solution.
👎: Doesn't have the upside of the above solution.

I went with what results in a more sane codebase that forces the programmer to be a bit more proactive in deciding whether they should be unconditionally rendering a UserLink and Link.