### PR TITLE
fix autoprefixer console warning

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.css
+++ b/lib/ControlledVocab/ControlledVocab.css
@@ -1,6 +1,4 @@
 .lastUpdated {
-  width: -moz-available;
-  width: -webkit-fill-available;
   width: stretch;
 }
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -4,10 +4,10 @@ import { FormattedMessage } from 'react-intl';
 
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import EditableList from '@folio/stripes-components/lib/structures/EditableList';
+import EditableList from '@folio/stripes-components/lib/EditableList/EditableList';
 import Button from '@folio/stripes-components/lib/Button';
 import Callout from '@folio/stripes-components/lib/Callout';
-import ConfirmationModal from '@folio/stripes-components/lib/structures/ConfirmationModal';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal/ConfirmationModal';
 import Modal from '@folio/stripes-components/lib/Modal';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';


### PR DESCRIPTION
[STSMACOM-102](https://issues.folio.org/browse/STSMACOM-102)
- autoprefixer adds the vendor labels for us and complained that we added them; figured it out from this [comment](https://github.com/postcss/autoprefixer/issues/1035#issuecomment-387247093)
- update component path ([STCOM-277](https://issues.folio.org/browse/STCOM-277))