### PR TITLE
ChangeDueDateDialog now fetches its own loans list

### DIFF
--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -231,16 +231,18 @@ class ChangeDueDate extends React.Component {
   }
 
   toggleBulkLoanSelection() {
-    const { loanSelection } = this.state;
+    const loanSelection = {};
 
-    const someLoansUnselected = Object.values(loanSelection).includes(false);
-    Object.keys(loanSelection).forEach(key => { loanSelection[key] = someLoansUnselected; });
+    const someLoansUnselected = Object.values(this.state.loanSelection).includes(false);
+    Object.keys(this.state.loanSelection).forEach(key => { loanSelection[key] = someLoansUnselected; });
 
     this.setState({ loanSelection });
   }
 
   render() {
     const { loans } = this.props;
+
+    if (!loans.length) return null;
 
     return (
       <div>
@@ -281,7 +283,11 @@ class ChangeDueDate extends React.Component {
           <Button onClick={this.props.onCancel}>
             <FormattedMessage id="stripes-core.button.cancel" />
           </Button>
-          <Button buttonStyle="primary" onClick={this.changeDueDate}>
+          <Button
+            buttonStyle="primary"
+            onClick={this.changeDueDate}
+            disabled={this.state.datetime === 'Invalid date' || Object.values(this.state.loanSelection).includes(true) === false}
+          >
             <FormattedMessage id="stripes-core.button.saveAndClose" />
           </Button>
         </Layout>

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import Icon from '@folio/stripes-components/lib/Icon';
@@ -9,6 +10,18 @@ import ChangeDueDate from './ChangeDueDate';
 import ChangeDueDateSuccess from './ChangeDueDateSuccess';
 
 class ChangeDueDateDialog extends React.Component {
+  static manifest = {
+    loans: {
+      type: 'okapi',
+      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)',
+      throwErrors: false,
+      accumulate: true,
+      PUT: {
+        path: 'circulation/loans/%{loanId}',
+      },
+    },
+  }
+
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func,
@@ -18,6 +31,38 @@ class ChangeDueDateDialog extends React.Component {
     }),
     onClose: PropTypes.func,
     open: PropTypes.bool,
+    mutator: PropTypes.shape({
+      loans: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+    resources: PropTypes.shape({ // eslint-disable-line
+      loans: PropTypes.shape({
+        records: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.string,
+            itemId: PropTypes.string,
+            loanDate: PropTypes.string,
+            dueDate: PropTypes.string,
+          })
+        )
+      })
+    }).isRequired,
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (!state.open && props.open) {
+      ChangeDueDateDialog.fetchLoans(props);
+      return { open: true };
+    }
+
+    return null;
+  }
+
+  static fetchLoans(props) {
+    props.mutator.loans.reset();
+    props.mutator.loans.GET();
   }
 
   constructor(props) {
@@ -26,6 +71,7 @@ class ChangeDueDateDialog extends React.Component {
     this.state = {
       succeeded: false,
       alerts: {},
+      open: false, // eslint-disable-line react/no-unused-state
     };
 
     this.handleCancel = this.handleCancel.bind(this);
@@ -59,6 +105,8 @@ class ChangeDueDateDialog extends React.Component {
       succeeded: true,
       alerts,
     });
+
+    ChangeDueDateDialog.fetchLoans(this.props);
   }
 
   handleDueDateChangeFailed(alerts) {
@@ -66,6 +114,8 @@ class ChangeDueDateDialog extends React.Component {
       succeeded: false,
       alerts,
     });
+
+    ChangeDueDateDialog.fetchLoans(this.props);
   }
 
   render() {
@@ -88,11 +138,12 @@ class ChangeDueDateDialog extends React.Component {
         label={modalLabel}
       >
         <BodyComponent
+          {...this.props}
           alerts={this.state.alerts}
           onDueDateChanged={this.handleDueDateChanged}
           onDueDateChangeFailed={this.handleDueDateChangeFailed}
           onCancel={this.handleCancel}
-          {...this.props}
+          loans={get(this.props, ['resources', 'loans', 'records', 0, 'loans'], [])}
         />
       </Modal>
     );

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import Icon from '@folio/stripes-components/lib/Icon';
@@ -29,6 +29,11 @@ class ChangeDueDateDialog extends React.Component {
         formatMessage: PropTypes.func,
       }),
     }),
+    loanIds: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+      }),
+    ),
     onClose: PropTypes.func,
     open: PropTypes.bool,
     mutator: PropTypes.shape({
@@ -51,11 +56,23 @@ class ChangeDueDateDialog extends React.Component {
     }).isRequired,
   }
 
+  static defaultProps = {
+    loanIds: [],
+  }
+
   static getDerivedStateFromProps(props, state) {
+    const newState = {};
     if (!state.open && props.open) {
       ChangeDueDateDialog.fetchLoans(props);
-      return { open: true };
+      newState.open = true;
     }
+
+    const loanIds = props.loanIds.map(l => l.id);
+    if (isEqual(loanIds, state.loanIds) === false) {
+      newState.loanIds = loanIds;
+    }
+
+    if (Object.keys(newState).length) return newState;
 
     return null;
   }
@@ -72,12 +89,18 @@ class ChangeDueDateDialog extends React.Component {
       succeeded: false,
       alerts: {},
       open: false, // eslint-disable-line react/no-unused-state
+      loanIds: [], // eslint-disable-line react/no-unused-state
     };
 
     this.handleCancel = this.handleCancel.bind(this);
     this.handleDueDateChanged = this.handleDueDateChanged.bind(this);
     this.handleDueDateChangeFailed = this.handleDueDateChangeFailed.bind(this);
     this.connectedChangeDueDate = props.stripes.connect(ChangeDueDate);
+  }
+
+  loans() {
+    const userLoans = get(this.props, ['resources', 'loans', 'records', 0, 'loans'], []);
+    return userLoans.filter(l => this.state.loanIds.includes(l.id));
   }
 
   handleCancel() {
@@ -103,6 +126,7 @@ class ChangeDueDateDialog extends React.Component {
 
     this.setState({
       succeeded: true,
+      dueDatesChanged: loans.count,
       alerts,
     });
 
@@ -143,7 +167,8 @@ class ChangeDueDateDialog extends React.Component {
           onDueDateChanged={this.handleDueDateChanged}
           onDueDateChangeFailed={this.handleDueDateChangeFailed}
           onCancel={this.handleCancel}
-          loans={get(this.props, ['resources', 'loans', 'records', 0, 'loans'], [])}
+          loans={this.loans()}
+          dueDatesChanged={this.state.dueDatesChanged}
         />
       </Modal>
     );

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -126,7 +126,7 @@ class ChangeDueDateDialog extends React.Component {
 
     this.setState({
       succeeded: true,
-      dueDatesChanged: loans.count,
+      dueDatesChanged: loans.length,
       alerts,
     });
 

--- a/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
@@ -13,6 +13,7 @@ class ChangeDueDateSuccess extends React.Component {
   static propTypes = {
     stripes: PropTypes.object,
     alerts: PropTypes.object,
+    dueDatesChanged: PropTypes.number,
     loans: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
@@ -35,16 +36,14 @@ class ChangeDueDateSuccess extends React.Component {
   }
 
   render() {
-    const { loans } = this.props;
-
     return (
       <div>
-        { loans.length > 1 ?
+        { this.props.dueDatesChanged > 1 ?
           <p>
             <Icon size="medium" icon="validation-check" color="green" />
             <SafeHTMLMessage
               id="stripes-smart-components.cddd.changeSucceededWithCount"
-              values={{ count: loans.length }}
+              values={{ count: this.props.dueDatesChanged }}
             />
           </p>
           : null
@@ -53,7 +52,7 @@ class ChangeDueDateSuccess extends React.Component {
           stripes={this.props.stripes}
           alerts={this.props.alerts}
           allowSelection={false}
-          loans={loans}
+          loans={this.props.loans}
         />
         <Layout className="textRight">
           <Button buttonStyle="primary" onClick={this.props.onCancel}>


### PR DESCRIPTION
Getting all the components that use `ChangeDueDateDialog` to properly update their list of loans and always pass it down correctly is:

1. Pretty unwieldy. It was fine with `OpenLoans` and the Users code, but the structure of the Check Out module makes it a stretch. 
1. While the above is possible, it's also not intuitive _why_ the parent components are fetching and refreshing the loans list.

Because of that and since CDDD has the best hooks on _when_ to execute refreshes, it now does the fetching itself. Upcoming PRs to ui-users and ui-checkout to handle this new setup.