### PR TITLE
CDD: Always render warnings

### DIFF
--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -246,21 +246,20 @@ class ChangeDueDate extends React.Component {
 
     return (
       <div>
-        { loans.length > 1 ?
-          <p>
+        <p>
+          { loans.length > 1 ?
             <SafeHTMLMessage
               id="stripes-smart-components.cddd.itemsSelected"
               values={{ count: loans.length }}
-            />
-            {this.state.warnings.map((warning, i) => (
-              <span key={i} style={{ color: 'orange' }}>
-                <Icon size="medium" icon="validation-error" color="orange" />
-                {warning}
-              </span>
-            ))}
-          </p>
-          : null
-        }
+            /> : null
+          }
+          {this.state.warnings.map((warning, i) => (
+            <span key={i} style={{ color: 'orange' }}>
+              <Icon size="medium" icon="validation-error" color="orange" />
+              {warning}
+            </span>
+          ))}
+        </p>
         <DueDatePicker
           stripes={this.props.stripes}
           onChange={this.handleDateTimeChanged}


### PR DESCRIPTION
The warnings rendering was being done inside a ternary expression when it shouldn't have. Pulled it out to render unconditionally.