### PR TITLE
UIU-497: Tweaked ChangeDueDate default date selection

### DIFF
--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -165,6 +165,10 @@ class ChangeDueDate extends React.Component {
       return loanDueDate.isAfter(latestDate) ? loanDueDate : latestDate;
     }, moment(0));
 
+    if (lastDueDate.isBefore(moment())) {
+      return '';
+    }
+
     return lastDueDate.format('YYYY-MM-DD');
   }
 

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -163,7 +163,7 @@ class ChangeDueDate extends React.Component {
     const lastDueDate = loans.reduce((latestDate, loan) => {
       const loanDueDate = moment(loan.dueDate);
       return loanDueDate.isAfter(latestDate) ? loanDueDate : latestDate;
-    }, moment());
+    }, moment(0));
 
     return lastDueDate.format('YYYY-MM-DD');
   }


### PR DESCRIPTION
Previously, if the selected loan(s) due date was in the past, the current date was used as the default due date in the Date picker. Changed this to leave the date field blank initially if all the due dates are in the past. This also implicitly disables the **Save** button until a date is selected.