### PR TITLE
Get records and totalCount from correct places

### DIFF
--- a/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/ApolloConnectedSource.js
@@ -12,7 +12,8 @@ export default class ApolloConnectedSource {
   }
 
   records() {
-    const res = this.recordsObj.records || [];
+    const key = this.props.apolloRecordsKey;
+    const res = this.recordsObj[key] || [];
     this.logger.log('source', 'records:', res);
     return res;
   }
@@ -28,7 +29,7 @@ export default class ApolloConnectedSource {
 
   // Number of records in the result-set, available to be retrieved
   totalCount() {
-    const res = this.pending() ? null : this.recordsObj.totalCount;
+    const res = this.pending() ? null : this.recordsObj.totalRecords;
     this.logger.log('source', 'totalCount:', res);
     return res;
   }


### PR DESCRIPTION
The GraphQL resolvers autogenerated from RAMLs do things slighly
differently from the ones we wrote by hand. This change allows for
that, so that the `graphql` branch of ui-inventory will be able to run
against the auto-generated resolvers instead of the old hand-crafted
ones.