### PR TITLE
Use Datepicker and Timepicker timeZone props

### DIFF
--- a/lib/ChangeDueDateDialog/DueDatePickerForm.js
+++ b/lib/ChangeDueDateDialog/DueDatePickerForm.js
@@ -22,7 +22,7 @@ class DueDatePickerForm extends React.Component {
           <Field
             name="date"
             component={Datepicker}
-            ignoreLocalOffset
+            timeZone="UTC"
             {...dateProps}
           />
         </Col>
@@ -30,7 +30,7 @@ class DueDatePickerForm extends React.Component {
           <Field
             name="time"
             component={Timepicker}
-            timezone="UTC"
+            timeZone="UTC"
             {...timeProps}
           />
         </Col>

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
-    "@folio/stripes-components": "^2.0.18",
+    "@folio/stripes-components": "^2.0.22",
     "@folio/stripes-form": "^0.8.2",
     "lodash": "^4.17.4",
     "moment": "^2.22.1",


### PR DESCRIPTION
Related to https://github.com/folio-org/stripes-components/pull/424

Overriding the context's `timeZone` should be a clearer pattern than `ignoreLocalOffset`.