### PR TITLE
Adding transitioning reset button to SearchAndSort

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -6,3 +6,8 @@
   .searchField {
     margin: 0 15px;
   }
+
+  /* reset button wrap - minor alignment adjustment */
+  .resetButtonWrap {
+    margin-left: -3px;
+  }

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -108,7 +108,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
         other: PropTypes.shape({
           totalRecords: PropTypes.number.isRequired,
         }),
-        isPending: PropTypes.bool.isPending,
+        isPending: PropTypes.bool,
         successfulMutations: PropTypes.arrayOf(
           PropTypes.shape({
             record: PropTypes.shape({

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -17,7 +17,6 @@ import Pane from '@folio/stripes-components/lib/Pane';
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import IconButton from '@folio/stripes-components/lib/IconButton';
-import Icon from '@folio/stripes-components/lib/Icon';
 import Layer from '@folio/stripes-components/lib/Layer';
 import Button from '@folio/stripes-components/lib/Button';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
@@ -29,6 +28,7 @@ import Notes from '../Notes';
 import css from './SearchAndSort.css';
 import makeConnectedSource from './ConnectedSource';
 import NoResultsMessage from './components/NoResultsMessage';
+import ResetButton from './components/ResetButton';
 
 class SearchAndSort extends React.Component {
   static manifest = Object.freeze({
@@ -418,13 +418,16 @@ class SearchAndSort extends React.Component {
     const searchIndex = this.queryParam('qindex') || '';
     const searchHasChanged = searchTerm !== '' || searchIndex !== '';
 
-    if (!filtersHaveChanged && !searchHasChanged) return null;
-
     return (
-      <Button buttonStyle="none" paddingSide0 onClick={this.onClearSearchAndFilters} id="clickable-reset-all">
-        <Icon size="small" icon="clearX" />
-        <FormattedMessage id="stripes-smart-components.resetAll" />
-      </Button>
+      <div className={css.resetButtonWrap}>
+        <ResetButton
+          className={css.resetButton}
+          visible={filtersHaveChanged || searchHasChanged}
+          onClick={this.onClearSearchAndFilters}
+          id="clickable-reset-all"
+          label={<FormattedMessage id="stripes-smart-components.resetAll" />}
+        />
+      </div>
     );
   }
 

--- a/lib/SearchAndSort/components/ResetButton/ResetButton.css
+++ b/lib/SearchAndSort/components/ResetButton/ResetButton.css
@@ -1,0 +1,33 @@
+/**
+ * Reset Button
+ */
+
+.resetButtonRoot .button {
+  padding: 0 6px 0 3px;
+  background: none !important; /* Remove gray background color from disabled button */
+}
+
+/**
+ * Transition styles
+ */
+
+.transition {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.transitionEntered, .transitionEntering {
+  max-height: 250px;
+  overflow: visible;
+  opacity: 1;
+  transition: max-height 1000ms linear 750ms, opacity 300ms ease-in 750ms;
+}
+
+.transitionExiting, .transitionExited {
+  transition: max-height 1000ms linear 750ms, opacity 500ms ease-out 1300ms;
+}
+
+.fasterExitTransition.transition {
+  transition: max-height 1000ms linear, opacity 600ms ease-out 500ms;
+}

--- a/lib/SearchAndSort/components/ResetButton/ResetButton.js
+++ b/lib/SearchAndSort/components/ResetButton/ResetButton.js
@@ -1,0 +1,84 @@
+/**
+ * Reset Button
+ *
+ * A delayed disapearable button
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import camelCase from 'lodash/camelCase';
+import classnames from 'classnames'; /* eslint-disable-line import/no-extraneous-dependencies */
+import { Transition } from 'react-transition-group'; /* eslint-disable-line import/no-extraneous-dependencies */
+import Icon from '@folio/stripes-components/lib/Icon';
+import Button from '@folio/stripes-components/lib/Button';
+import css from './ResetButton.css';
+
+export default class ResetButton extends Component {
+  static propTypes = {
+    id: PropTypes.string,
+    onClick: PropTypes.func.isRequired,
+    label: PropTypes.node,
+    visible: PropTypes.bool,
+    className: PropTypes.string,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      fasterExitTransition: false,
+    };
+
+    this.handleClick = this.handleClick.bind(this);
+    this.onExited = this.onExited.bind(this);
+  }
+
+  /**
+   * Handle button click
+   */
+  handleClick(e) {
+    // Activate a faster transition when the button is clicked
+    this.setState({
+      fasterExitTransition: true,
+    });
+
+    // Fire onClick callback passed as a required prop
+    this.props.onClick(e);
+  }
+
+  /**
+   * Disable/reset fast transition once the reset button is faded out
+   */
+  onExited() {
+    this.setState({
+      fasterExitTransition: false,
+    });
+  }
+
+  render() {
+    const { id, label, className, visible, ...rest } = this.props;
+    return (
+      <div className={css.resetButtonRoot}>
+        <Transition in={visible} timeout={1000} onExited={this.onExited}>
+          {
+            state => (
+              <div className={classnames(css.transition, css[camelCase(`transition ${state}`)], { [css.fasterExitTransition]: this.state.fasterExitTransition })}>
+                <Button
+                  buttonStyle="none"
+                  id={id}
+                  {...rest}
+                  onClick={this.handleClick}
+                  disabled={!visible}
+                  buttonClass={classnames(css.button, className)}
+                >
+                  <Icon size="small" icon="clearX" />
+                  {label}
+                </Button>
+              </div>
+            )
+          }
+        </Transition>
+      </div>
+    );
+  }
+}

--- a/lib/SearchAndSort/components/ResetButton/index.js
+++ b/lib/SearchAndSort/components/ResetButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResetButton';


### PR DESCRIPTION
We have discussed how to make the reset button less annoying (can't come up with a better way of saying it).

A solution we came up with is to transition the button in and out but with a slight delay. This makes it possible to check/uncheck fast (or uncheck one checkbox and check another) without having the entire list shift position immediately which could cause misclicks and frustration for the user.

The component is a standalone component that could be used in other places in the application but for now, it lives within this repo.

## Before
![jun-13-2018 15-39-21](https://user-images.githubusercontent.com/640976/41356585-82d0c654-6f24-11e8-8970-e559815d2679.gif)

## After
![jun-13-2018 15-37-10](https://user-images.githubusercontent.com/640976/41356604-899682b2-6f24-11e8-8a65-a0917c8b6d20.gif)

