### PR TITLE
CDDD: Use new "status" prop for <Icon>s

### DIFF
--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -11,6 +11,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import DueDatePicker from './DueDatePicker';
 import LoanList from '../LoanList';
+import css from './ChangeDueDateDialog.css';
 
 class ChangeDueDate extends React.Component {
   static DEFAULT_TIME = '23:59:00.000Z';
@@ -245,8 +246,8 @@ class ChangeDueDate extends React.Component {
             /> : null
           }
           {this.state.warnings.map((warning, i) => (
-            <span key={i} style={{ color: 'orange' }}>
-              <Icon size="medium" icon="validation-error" color="orange" />
+            <span key={i} className={css.warn}>
+              <Icon size="medium" icon="validation-error" status="warn" />
               {warning}
             </span>
           ))}

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.css
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.css
@@ -1,0 +1,9 @@
+@import '@folio/stripes-components/lib/variables';
+
+.warn {
+  color: var(--warn);
+}
+
+.success {
+  color: var(--success);
+}

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -8,6 +8,7 @@ import Modal from '@folio/stripes-components/lib/Modal';
 
 import ChangeDueDate from './ChangeDueDate';
 import ChangeDueDateSuccess from './ChangeDueDateSuccess';
+import css from './ChangeDueDateDialog.css';
 
 class ChangeDueDateDialog extends React.Component {
   static fetchLoans(props) {
@@ -121,8 +122,8 @@ class ChangeDueDateDialog extends React.Component {
 
     loans.forEach((loan) => {
       alerts[loan.id] = (
-        <div style={{ color: 'green' }}>
-          <Icon size="small" icon="validation-check" color="green" />
+        <div className={css.success}>
+          <Icon size="small" icon="validation-check" status="success" />
           <FormattedMessage id="stripes-smart-components.cddd.changeSucceeded" />
         </div>
       );

--- a/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
@@ -40,7 +40,7 @@ class ChangeDueDateSuccess extends React.Component {
       <div>
         { this.props.dueDatesChanged > 1 ?
           <p>
-            <Icon size="medium" icon="validation-check" color="green" />
+            <Icon size="medium" icon="validation-check" status="success" />
             <SafeHTMLMessage
               id="stripes-smart-components.cddd.changeSucceededWithCount"
               values={{ count: this.props.dueDatesChanged }}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
-    "@folio/stripes-components": "^2.0.22",
+    "@folio/stripes-components": "^2.0.24",
     "@folio/stripes-form": "^0.8.2",
     "lodash": "^4.17.4",
     "moment": "^2.22.1",


### PR DESCRIPTION
Depends on folio-org/stripes-components#427

Removes hard-coded colours that were previously necessary when colouring an `<Icon>`