### PR TITLE
optionally hide the editable list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * Added `<ChangeDueDateDialog>` component and it's child components.
 * Added `<LoanList>` component.
 * Update path to stripes-components previously nested within lib/structures.
+* `<ControlledVocab>` will optionally hide its list and display a reason why. Refs UIORG-83.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -77,6 +77,8 @@ class ControlledVocab extends React.Component {
     formatter: PropTypes.object,
     actionSuppressor: PropTypes.object,
     actionProps: PropTypes.object,
+    listSuppressor: PropTypes.func,
+    listSuppressorText: PropTypes.string,
     rowFilter: PropTypes.element,
     rowFilterFunction: PropTypes.func,
     preCreateHook: PropTypes.func,
@@ -292,52 +294,57 @@ class ControlledVocab extends React.Component {
 
     const rows = this.filteredRows(this.props.resources.values.records || []);
 
+    const hideList = this.props.listSuppressor && this.props.listSuppressor();
+
     return (
       <Paneset>
         <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
           {this.props.rowFilter}
-          <EditableList
-            {...this.props}
-            // TODO: not sure why we need this OR if there are no groups
-            // Seems to load this once before the groups data from the manifest
-            // is pulled in. This still causes a JS warning, but not an error
-            contentData={rows}
-            createButtonLabel={formatMessage({ id: 'stripes-core.button.new' })}
-            itemTemplate={this.props.itemTemplate}
-            visibleFields={[
-              ...this.props.visibleFields,
-              'lastUpdated',
-              'numberOfObjects',
-            ].filter(field => !this.props.hiddenFields.includes(field))}
-            columnMapping={{
-              name: this.props.labelSingular,
-              lastUpdated: formatMessage({ id: 'stripes-smart-components.cv.lastUpdated' }),
-              numberOfObjects: formatMessage({ id: 'stripes-smart-components.cv.numberOfObjects' }, { objects: this.props.objectLabel }),
-              ...this.props.columnMapping,
-            }}
-            formatter={{
-              lastUpdated: (item) => {
-                if (item.metadata) {
-                  return this.renderLastUpdated(item.metadata);
-                }
+          { hideList && this.props.listSuppressorText && <div>{this.props.listSuppressorText}</div> }
+          { !hideList &&
+            <EditableList
+              {...this.props}
+              // TODO: not sure why we need this OR if there are no groups
+              // Seems to load this once before the groups data from the manifest
+              // is pulled in. This still causes a JS warning, but not an error
+              contentData={rows}
+              createButtonLabel={formatMessage({ id: 'stripes-core.button.new' })}
+              itemTemplate={this.props.itemTemplate}
+              visibleFields={[
+                ...this.props.visibleFields,
+                'lastUpdated',
+                'numberOfObjects',
+              ].filter(field => !this.props.hiddenFields.includes(field))}
+              columnMapping={{
+                name: this.props.labelSingular,
+                lastUpdated: formatMessage({ id: 'stripes-smart-components.cv.lastUpdated' }),
+                numberOfObjects: formatMessage({ id: 'stripes-smart-components.cv.numberOfObjects' }, { objects: this.props.objectLabel }),
+                ...this.props.columnMapping,
+              }}
+              formatter={{
+                lastUpdated: (item) => {
+                  if (item.metadata) {
+                    return this.renderLastUpdated(item.metadata);
+                  }
 
-                return '-';
-              },
-              ...this.props.formatter,
-            }}
-            readOnlyFields={[
-              ...this.props.readOnlyFields,
-              'lastUpdated',
-              'numberOfObjects',
-            ]}
-            actionSuppression={this.props.actionSuppressor}
-            actionProps={this.props.actionProps}
-            onUpdate={this.onUpdateItem}
-            onCreate={this.onCreateItem}
-            onDelete={this.showConfirmDialog}
-            isEmptyMessage={formatMessage({ id: 'stripes-smart-components.cv.noExistingTerms' }, { terms: this.props.label.toLowerCase() })}
-            validate={this.validate}
-          />
+                  return '-';
+                },
+                ...this.props.formatter,
+              }}
+              readOnlyFields={[
+                ...this.props.readOnlyFields,
+                'lastUpdated',
+                'numberOfObjects',
+              ]}
+              actionSuppression={this.props.actionSuppressor}
+              actionProps={this.props.actionProps}
+              onUpdate={this.onUpdateItem}
+              onCreate={this.onCreateItem}
+              onDelete={this.showConfirmDialog}
+              isEmptyMessage={formatMessage({ id: 'stripes-smart-components.cv.noExistingTerms' }, { terms: this.props.label.toLowerCase() })}
+              validate={this.validate}
+            />
+          }
           <ConfirmationModal
             open={this.state.showConfirmDialog}
             heading={formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: type })}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
The `listSuppresssor` function and `listSuppressorText` props may be
used to completely suppress the display of the `EditableList` component.
This is useful when, for example, the component is used in conjunction
with `props.rowFilter` and a valid selection must be made from the
`rowFilter` before any element can be added/updated/removed from the list.

Refs [UIORG-82](https://issues.folio.org/browse/UIORG-82), [UIORG-83](https://issues.folio.org/browse/UIORG-83)