### PR TITLE
Add support for param namespacing. Part of STCOM-300

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -260,14 +260,9 @@ class SearchAndSort extends React.Component {
   }
 
   onChangeFilter = (e) => {
-    const { nsParams, parentMutator, initialResultCount, filterChangeCallback } = this.props;
-    parentMutator.resultCount.replace(initialResultCount);
-
-    const newFilters = this.handleFilterChange(e, nsParams);
-
-    if (filterChangeCallback) {
-      filterChangeCallback(newFilters);
-    }
+    this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
+    const newFilters = this.handleFilterChange(e);
+    if (this.props.filterChangeCallback) this.props.filterChangeCallback(newFilters);
   }
 
   onChangeSearch = (e) => {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -207,6 +207,8 @@ class SearchAndSort extends React.Component {
 
     const logger = context.stripes.logger;
     this.log = logger.log.bind(logger);
+    this.transitionToParams = this.transitionToParams.bind(this);
+
   }
 
   componentDidMount() {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -25,6 +25,7 @@ import SRStatus from '@folio/stripes-components/lib/SRStatus';
 import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import SearchField from '@folio/stripes-components/lib/SearchField';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
+import { mapNsKeys, getNsKey } from '@folio/stripes-components/util/nsQueryFunctions';
 import Notes from '../Notes';
 import css from './SearchAndSort.css';
 import makeConnectedSource from './ConnectedSource';
@@ -160,6 +161,10 @@ class SearchAndSort extends React.Component {
     }),
 
     browseOnly: PropTypes.bool,
+    nsParams: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
   };
 
   static contextTypes = {
@@ -185,7 +190,6 @@ class SearchAndSort extends React.Component {
       filterPaneIsVisible: true,
     };
 
-    this.transitionToParams = values => this.props.parentMutator.query.update(values);
     this.handleFilterChange = handleFilterChange.bind(this);
     this.handleFilterClear = handleFilterClear.bind(this);
     this.connectedViewRecord = context.stripes.connect(props.viewRecordComponent);
@@ -256,9 +260,14 @@ class SearchAndSort extends React.Component {
   }
 
   onChangeFilter = (e) => {
-    this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
-    const newFilters = this.handleFilterChange(e);
-    if (this.props.filterChangeCallback) this.props.filterChangeCallback(newFilters);
+    const { nsParams, parentMutator, initialResultCount, filterChangeCallback } = this.props;
+    parentMutator.resultCount.replace(initialResultCount);
+
+    const newFilters = this.handleFilterChange(e, nsParams);
+
+    if (filterChangeCallback) {
+      filterChangeCallback(newFilters);
+    }
   }
 
   onChangeSearch = (e) => {
@@ -308,6 +317,12 @@ class SearchAndSort extends React.Component {
     if (e) e.preventDefault();
     this.log('action', 'clicked "edit"');
     this.transitionToParams({ layer: 'edit' });
+  }
+
+  transitionToParams(values) {
+    const { nsParams, parentMutator } = this.props;
+    const nsValues = mapNsKeys(values, nsParams);
+    parentMutator.query.update(nsValues);
   }
 
   onNeedMore = () => {
@@ -397,7 +412,11 @@ class SearchAndSort extends React.Component {
     this.transitionToParams({ query });
   }, 350);
 
-  queryParam = name => _.get(this.props.parentResources.query, name);
+  queryParam(name) {
+    const { parentResources, nsParams } = this.props;
+    const nsKey = getNsKey(name, nsParams);
+    return _.get(parentResources.query, nsKey);
+  }
 
   toggleFilterPane = () => {
     this.setState(prevState => ({ filterPaneIsVisible: !prevState.filterPaneIsVisible }));

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -41,6 +41,7 @@ newRecordPerms | string | A comma-separated list of the permissions required in 
 disableRecordCreation | bool | If true, new record cannot be created. This is appropriate when one application is running embedded in another.
 parentResources | shape | The parent component's stripes-connect `resources` property, used to access the records of the relevant type. Must contain at least `records`, `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
 parentMutator | shape | The parent component's stripes-connect `mutator` property. Must contain at least `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
+nsParams | object or string | An object or string used to namespace search and sort parameters. More information can be found [here](https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md)
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 


### PR DESCRIPTION
The purpose of this PR is to introduce a way for namespacing params used by `<SearchAndSort>` component. 

The implementation follows the document written by @MikeTaylor here:

https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md
