### PR TITLE
Update SearchAndSort to use ModulesContext and i18n modules

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -8,8 +8,8 @@ import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
 import { FormattedMessage } from 'react-intl';
-// eslint-disable-next-line import/no-unresolved
 import { stripesShape } from '@folio/stripes-core/src/Stripes';
+import { withModule } from '@folio/stripes-core/src/components/Modules';
 import queryString from 'query-string';
 import FilterGroups, { filterState, handleFilterChange, handleFilterClear } from '@folio/stripes-components/lib/FilterGroups';
 import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
@@ -30,7 +30,7 @@ import css from './SearchAndSort.css';
 import makeConnectedSource from './ConnectedSource';
 import NoResultsMessage from './components/NoResultsMessage';
 
-class SearchAndSort extends React.Component {
+class SearchAndSort extends React.Component { // eslint-disable-line react/no-deprecated
   static manifest = Object.freeze({
     notes: {
       type: 'okapi',
@@ -153,10 +153,14 @@ class SearchAndSort extends React.Component {
     packageInfo: PropTypes.shape({
       initialFilters: PropTypes.string, // default filters
       moduleName: PropTypes.string, // machine-readable, for HTML ids and translation keys
-      moduleTitle: PropTypes.string, // human-readable
       stripes: PropTypes.shape({
         route: PropTypes.string, // base route; used to construct URLs
       }).isRequired,
+    }),
+
+    // values specified by the ModulesContext
+    module: PropTypes.shape({
+      displayName: PropTypes.string, // human-readable
     }),
 
     browseOnly: PropTypes.bool,
@@ -441,7 +445,6 @@ class SearchAndSort extends React.Component {
     const formatMsg = stripes.intl.formatMessage;
 
     const moduleName = packageInfo.name.replace(/.*\//, '');
-    const moduleTitle = packageInfo.stripes.displayName;
     const appIcon = {
       app: moduleName,
     };
@@ -586,7 +589,7 @@ class SearchAndSort extends React.Component {
           id="pane-results"
           defaultWidth="fill"
           appIcon={appIcon}
-          paneTitle={moduleTitle}
+          paneTitle={this.props.module.displayName}
           paneSub={paneSub}
           lastMenu={!this.props.disableRecordCreation ? newRecordButton : null}
           firstMenu={resultsFirstMenu}
@@ -638,4 +641,8 @@ class SearchAndSort extends React.Component {
   }
 }
 
-export default withRouter(SearchAndSort);
+export default withRouter(
+  withModule(
+    props => props.packageInfo && props.packageInfo.name
+  )(SearchAndSort)
+);

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "peerDependencies": {
     "@folio/stripes-connect": "^3.1.2",
-    "@folio/stripes-core": "^2.8.0",
+    "@folio/stripes-core": "^2.10.2",
     "@folio/stripes-logger": "^0.0.2",
     "react": "*"
   }


### PR DESCRIPTION
Fairly self-explanatory. Rather than pulling the module's name from `packageInfo` where it'll be raw and an untranslated key title, we look up the translated module information based on the module's name.