### PR TITLE
LocationInput: Fix onChange signature

### DIFF
--- a/lib/LocationSelection/LocationInput.js
+++ b/lib/LocationSelection/LocationInput.js
@@ -29,7 +29,7 @@ export default class LocationInput extends React.Component {
     this.onChange = this.onChange.bind(this);
   }
 
-  onChange(e, locId) {
+  onChange(locId) {
     const { resources, onSelect } = this.props;
     const locations = (resources.locations || {}).records || [];
 


### PR DESCRIPTION
`Selection` doesn't [pass back the event, just the new value](https://github.com/folio-org/stripes-components/blob/master/lib/Selection/SingleSelect.js#L261).