### PR TITLE
STCOM-305 ViewMetaData: Use new MetaSection functionality

### DIFF
--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import MetaSection from '@folio/stripes-components/lib/MetaSection';
@@ -18,7 +17,7 @@ class ViewMetaData extends React.Component {
   });
 
   static propTypes = {
-    metadata: PropTypes.object.isRequired,
+    metadata: PropTypes.object,
     resources: PropTypes.shape({
       createdBy: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -29,12 +28,8 @@ class ViewMetaData extends React.Component {
     }),
   };
 
-  getFullName = (user) => {
-    const lastName = get(user, ['personal', 'lastName'], '');
-    const firstName = get(user, ['personal', 'firstName'], '');
-    const middleName = get(user, ['personal', 'middleName'], '');
-
-    return `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
+  static defaultProps = {
+    metadata: {},
   }
 
   render() {
@@ -46,8 +41,8 @@ class ViewMetaData extends React.Component {
         contentId="instanceRecordMetaContent"
         lastUpdatedDate={metadata.updatedDate}
         createdDate={metadata.createdDate}
-        lastUpdatedBy={this.getFullName(updatedBy.records[0])}
-        createdBy={this.getFullName(createdBy.records[0])}
+        lastUpdatedBy={updatedBy.records[0]}
+        createdBy={createdBy.records[0]}
       />
       :
       <div />;

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.1",
-    "@folio/stripes-components": "^2.0.24",
+    "@folio/stripes-components": "^2.1.5",
     "@folio/stripes-core": "^2.10.2",
     "@folio/stripes-form": "^0.8.2",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
`MetaSection` can now construct names itself so giving it the full user object and moving that functionality out of this component. Bumping required version as a result.

The API of `ViewMetaData` does _not_ change as a result.