### PR TITLE
cache user metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * Add extra check to `<EntryManager>` to recognize add/edit mode. Fixes STSMACOM-110.
 * Allow for choosing empty value in `<LocationSelection>` and `<LocationLookup>`. Refs UIIN-198.
 * Increase default location-limit in `<LocationModal>`. Available from v1.4.18.
+* Cache user object metadata in `<ControlledVocab>`; it's faster. Fixes STCOM-308.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -257,13 +257,23 @@ class ControlledVocab extends React.Component {
     );
   }
 
-  renderLastUpdated(metadata) {
-    const UserComponent = this.props.stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
-    const User = (
-      <span className={css.lastUpdatedUser}>
-        <UserComponent stripes={this.props.stripes} id={metadata.updatedByUserId} />
-      </span>
-    );
+  /**
+   * Note: this method caches user metadata in this.metadataCache.
+   * See STCOM-308.
+   */
+  renderLastUpdated = (metadata) => {
+    if (!this.metadataCache) {
+      this.metadataCache = {};
+    }
+
+    if (!this.metadataCache[metadata.updatedByUserId]) {
+      const UserComponent = this.props.stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
+      this.metadataCache[metadata.updatedByUserId] = (
+        <span className={css.lastUpdatedUser}>
+          <UserComponent stripes={this.props.stripes} id={metadata.updatedByUserId} />
+        </span>
+      );
+    }
 
     return (
       <div className={css.lastUpdated}>
@@ -271,7 +281,7 @@ class ControlledVocab extends React.Component {
           id="stripes-smart-components.cv.updatedAtAndBy"
           values={{
             date: this.props.stripes.formatDate(metadata.updatedDate),
-            user: User,
+            user: this.metadataCache[metadata.updatedByUserId],
           }}
         />
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Cache user metadata so we don't look up the same values over and over.
Instead of looking up the same values over and over, cache the user
metadata. In order to avoid doing the same lookups of user metadata
multiple times, the results is stored in a cache. By storing a map of
user-id to user-object, we can avoid repeated lookups. If the twisty maze
of user metadata is all alike, only look up each user once. 

Refs [STCOM-308](https://issues.folio.org/browse/STCOM-308)