### PR TITLE
STCOR-208: Context API

### DIFF
--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -108,13 +108,6 @@ class ChangeDueDate extends React.Component {
     }).isRequired,
   }
 
-  static contextTypes = {
-    stripes: PropTypes.shape({
-      formatDateTime: PropTypes.func.isRequired,
-    }).isRequired,
-  };
-
-
   static defaultProps = {
     loans: [],
   }
@@ -232,7 +225,7 @@ class ChangeDueDate extends React.Component {
   }
 
   render() {
-    const { loans } = this.props;
+    const { loans, stripes } = this.props;
 
     if (!loans.length) return null;
 
@@ -259,8 +252,8 @@ class ChangeDueDate extends React.Component {
             date: '',
             time: ChangeDueDate.DEFAULT_TIME,
           }}
-          dateProps={{ label: 'Date*' }}
-          timeProps={{ label: 'Time *' }}
+          dateProps={{ label: stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.date' }) + '*' }}
+          timeProps={{ label: stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.time' }) + '*' }}
         />
         <this.connectedLoanList
           stripes={this.props.stripes}

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -29,14 +29,15 @@ class EntryForm extends React.Component {
     deleteDisabled: PropTypes.func.isRequired,
     deleteDisabledMessage: PropTypes.string.isRequired,
     stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
       intl: PropTypes.shape({
         formatMessage: PropTypes.func,
       }),
     }),
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.saveEntry = this.saveEntry.bind(this);
     this.beginDelete = this.beginDelete.bind(this);
@@ -93,14 +94,14 @@ class EntryForm extends React.Component {
     const { handleSubmit, permissions, initialValues } = this.props;
     const selectedEntry = initialValues || {};
     const { confirmDelete } = this.state;
-    const disabled = !this.context.stripes.hasPerm(permissions.put);
+    const disabled = !this.props.stripes.hasPerm(permissions.put);
     const paneTitle = selectedEntry && selectedEntry.id ?
       this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel }) :
       this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.createEntry' }, { entry: this.props.entryLabel });
     const deleteButtonText = this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: this.props.entryLabel });
 
     let deleteButton;
-    if (selectedEntry && selectedEntry.id && this.context.stripes.hasPerm(permissions.delete)) {
+    if (selectedEntry && selectedEntry.id && this.props.stripes.hasPerm(permissions.delete)) {
       if (this.props.deleteDisabled(selectedEntry)) {
         deleteButton = <Button title={this.props.deleteDisabledMessage} disabled> {deleteButtonText} </Button>;
       } else {
@@ -144,12 +145,6 @@ class EntryForm extends React.Component {
     );
   }
 }
-
-EntryForm.contextTypes = {
-  stripes: PropTypes.shape({
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
-};
 
 export default stripesForm({
   form: 'entryForm',

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -6,6 +6,7 @@ import Selection from '@folio/stripes-components/lib/Selection';
 import Button from '@folio/stripes-components/lib/Button';
 import stripesForm from '@folio/stripes-form';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import { Field, getFormValues } from 'redux-form';
 
 class LocationForm extends React.Component {
@@ -20,9 +21,6 @@ class LocationForm extends React.Component {
     onLibrarySelected: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
-  };
-
-  static contextTypes = {
     stripes: PropTypes.shape({
       intl: PropTypes.object.isRequired,
       store: PropTypes.object.isRequired,
@@ -42,7 +40,7 @@ class LocationForm extends React.Component {
   }
 
   getCurrentValues() {
-    const { stripes: { store } } = this.context;
+    const { stripes: { store } } = this.props;
     const state = store.getState();
     return getFormValues('locationForm')(state) || {};
   }
@@ -53,7 +51,7 @@ class LocationForm extends React.Component {
   }
 
   translate(id) {
-    const { stripes: { intl } } = this.context;
+    const { stripes: { intl } } = this.props;
     return intl.formatMessage({ id: `stripes-smart-components.ll.${id}` });
   }
 
@@ -142,4 +140,4 @@ export default stripesForm({
   form: 'locationForm',
   navigationCheck: false,
   enableReinitialize: true,
-})(LocationForm);
+})(withStripes(LocationForm));

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -1,29 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import Button from '@folio/stripes-components/lib/Button';
 import LocationModal from './LocationModal';
 
-export default class LocationLookup extends React.Component {
+class LocationLookup extends React.Component {
   static propTypes = {
     label: PropTypes.string,
     onLocationSelected: PropTypes.func.isRequired,
-    temporary: PropTypes.bool,
-  };
-
-  static contextTypes = {
+    isTemporaryLocation: PropTypes.bool,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
       intl: PropTypes.object.isRequired,
     }).isRequired,
   };
 
-  constructor(props, context) {
+  constructor(props) {
     super(props);
 
     this.state = { openModal: false };
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
-    this.connectedLocationModal = context.stripes.connect(LocationModal, { dataKey: 'locationLookup' });
+    this.connectedLocationModal = props.stripes.connect(LocationModal, { dataKey: 'locationLookup' });
   }
 
   onSave() {
@@ -39,8 +37,8 @@ export default class LocationLookup extends React.Component {
   }
 
   render() {
-    const { label, onLocationSelected, temporary } = this.props;
-    const { stripes: { intl } } = this.context;
+    const { label, onLocationSelected, isTemporaryLocation, stripes } = this.props;
+    const { intl } = stripes;
     const buttonLabel = label || intl.formatMessage({ id: 'stripes-smart-components.ll.locationLookup' });
 
     return (
@@ -58,10 +56,13 @@ export default class LocationLookup extends React.Component {
             open={this.state.openModal}
             onClose={this.closeModal}
             onLocationSelected={onLocationSelected}
-            temporary={temporary}
+            isTemporaryLocation={isTemporaryLocation}
+            stripes={stripes}
           />
         }
       </div>
     );
   }
 }
+
+export default withStripes(LocationLookup);

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -38,7 +38,7 @@ export default class LocationModal extends React.Component {
 
   static propTypes = {
     open: PropTypes.bool,
-    temporary: PropTypes.bool,
+    isTemporaryLocation: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onLocationSelected: PropTypes.func.isRequired,
     resources: PropTypes.shape({
@@ -73,13 +73,9 @@ export default class LocationModal extends React.Component {
         reset: PropTypes.func,
       }),
     }).isRequired,
-  };
-
-  static contextTypes = {
     stripes: PropTypes.shape({
       intl: PropTypes.object.isRequired,
     }).isRequired,
-    temporary: PropTypes.bool,
   };
 
   constructor(props) {
@@ -174,19 +170,19 @@ export default class LocationModal extends React.Component {
   }
 
   translate(id, options) {
-    const { stripes: { intl } } = this.context;
+    const { stripes: { intl } } = this.props;
     return intl.formatMessage({ id: `stripes-smart-components.ll.${id}` }, options);
   }
 
   render() {
-    const { resources, temporary } = this.props;
+    const { resources, isTemporaryLocation } = this.props;
     const { campusId, libraryId, locationId, institutionId } = this.state;
     const institutions = (resources.institutions || {}).records || [];
     const campuses = (resources.campuses || {}).records || [];
     const libraries = (resources.libraries || {}).records || [];
     const locations = (resources.locations || {}).records || [];
 
-    const type = this.translate((temporary) ? 'temporary' : 'permanent');
+    const type = this.translate((isTemporaryLocation) ? 'temporary' : 'permanent');
     const label = this.translate('selectLocationHeader', { type });
 
     return (

--- a/lib/LocationSelection/LocationSelection.js
+++ b/lib/LocationSelection/LocationSelection.js
@@ -1,33 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
 import LocationInput from './LocationInput';
 
-export default class LocationSelection extends React.Component {
+class LocationSelection extends React.Component {
   static propTypes = {
     name: PropTypes.string,
     placeholder: PropTypes.string,
-  };
-
-  static contextTypes = {
     stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
       intl: PropTypes.object.isRequired,
-    }).isRequired,
+    }),
   };
 
   static defaultProps = {
     name: 'locationId',
   };
 
-  constructor(props, context) {
+  constructor(props) {
     super(props);
-    this.locationInputConnected = context.stripes.connect(LocationInput, { dataKey: 'locationSelection' });
+    this.locationInputConnected = props.stripes.connect(LocationInput, { dataKey: 'locationSelection' });
   }
 
   render() {
-    const { stripes: { intl } } = this.context;
-    const { name, placeholder } = this.props;
-    const locationPlaceholder = placeholder || intl.formatMessage({ id: 'stripes-smart-components.ls.locationPlaceholder' });
+    const { stripes, name, placeholder } = this.props;
+    const locationPlaceholder = placeholder || stripes.intl.formatMessage({ id: 'stripes-smart-components.ls.locationPlaceholder' });
 
     return (
       <this.locationInputConnected
@@ -38,3 +36,5 @@ export default class LocationSelection extends React.Component {
     );
   }
 }
+
+export default withStripes(LocationSelection);

--- a/lib/ProxyManager/ProxyForm.js
+++ b/lib/ProxyManager/ProxyForm.js
@@ -1,6 +1,6 @@
 import { chunk } from 'lodash';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import Button from '@folio/stripes-components/lib/Button';
@@ -26,18 +26,12 @@ function renderEnabledRadio(proxy) {
 class ProxyForm extends React.Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
+    intl: intlShape,
     onCancel: PropTypes.func,
     patron: PropTypes.object,
     proxies: PropTypes.arrayOf(PropTypes.object),
     proxiesFor: PropTypes.arrayOf(PropTypes.object),
     sponsorOf: PropTypes.arrayOf(PropTypes.object),
-  };
-
-  static contextTypes = {
-    stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
-    }).isRequired,
   };
 
   constructor(props) {
@@ -56,7 +50,7 @@ class ProxyForm extends React.Component {
   }
 
   translate(id) {
-    const { stripes: { intl } } = this.context;
+    const { intl } = this.props;
     return intl.formatMessage({ id: `stripes-smart-components.pm.${id}` });
   }
 
@@ -81,8 +75,7 @@ class ProxyForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, onCancel, patron, proxies } = this.props;
-    const formatMsg = this.context.stripes.intl.formatMessage;
+    const { handleSubmit, onCancel, patron, proxies, intl } = this.props;
     const proxiesList = chunk(proxies, 3).map((group, i) => (
       <Row key={`row-${i}`}>
         {group.map(proxy => (
@@ -111,7 +104,7 @@ class ProxyForm extends React.Component {
               id={`sponsor-${patron.id}`}
               key={`sponsor-${patron.id}`}
               name="sponsorId"
-              label={formatMsg({ id: 'stripes-smart-components.self' })}
+              label={intl.formatMessage({ id: 'stripes-smart-components.self' })}
               value={patron.id}
             />
           </Col>

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { intlShape } from 'react-intl';
 import Modal from '@folio/stripes-components/lib/Modal';
-import injectIntl from '@folio/stripes-componentslib/InjectIntl';
+import injectIntl from '@folio/stripes-components/lib/InjectIntl';
 import ProxyForm from './ProxyForm';
 
 class ProxyModal extends React.Component {

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { intlShape } from 'react-intl';
 import Modal from '@folio/stripes-components/lib/Modal';
+import injectIntl from '@folio/stripes-componentslib/InjectIntl';
 import ProxyForm from './ProxyForm';
-import injectIntl from '../../../stripes-components/lib/InjectIntl';
 
 class ProxyModal extends React.Component {
   static propTypes = {

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -3,29 +3,27 @@ import PropTypes from 'prop-types';
 import { intlShape } from 'react-intl';
 import Modal from '@folio/stripes-components/lib/Modal';
 import ProxyForm from './ProxyForm';
+import injectIntl from '../../../stripes-components/lib/InjectIntl';
 
 class ProxyModal extends React.Component {
   static propTypes = {
+    intl: intlShape,
     patron: PropTypes.object,
     open: PropTypes.bool,
     onClose: PropTypes.func,
     onContinue: PropTypes.func,
   };
 
-  static contextTypes = {
-    intl: intlShape,
-  }
-
   render() {
-    const { onClose, open, patron, onContinue } = this.props;
-    const formatMsg = this.context.intl.formatMessage;
+    const { onClose, open, patron, onContinue, intl } = this.props;
 
     return (
-      <Modal onClose={onClose} open={open} size="small" label={formatMsg({ id: 'stripes-smart-components.whoAreYouActingAs' })} dismissible>
+      <Modal onClose={onClose} open={open} size="small" label={intl.formatMessage({ id: 'stripes-smart-components.whoAreYouActingAs' })} dismissible>
         <ProxyForm
           onSubmit={onContinue}
           initialValues={{ sponsorId: patron.id }}
           onCancel={onClose}
+          intl={this.props.intl}
           {...this.props}
         />
       </Modal>
@@ -34,4 +32,4 @@ class ProxyModal extends React.Component {
 }
 
 
-export default ProxyModal;
+export default injectIntl(ProxyModal);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -10,6 +10,7 @@ import { withRouter } from 'react-router';
 import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes-core/src/Stripes';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import queryString from 'query-string';
 import FilterGroups, { filterState, handleFilterChange, handleFilterClear } from '@folio/stripes-components/lib/FilterGroups';
 import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
@@ -128,6 +129,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
     }).isRequired,
     parentData: PropTypes.object,
     queryFunction: PropTypes.func, // only needed when GraphQL is used
+    stripes: stripesShape,
     apolloQuery: PropTypes.object,
     apolloResource: PropTypes.string,
 
@@ -171,16 +173,12 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
     ]),
   };
 
-  static contextTypes = {
-    stripes: stripesShape.isRequired,
-  };
-
   static defaultProps = {
     showSingleResult: false,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     let initiallySelected = {};
     const match = this.props.location.pathname.match('/[^/]*/view/');
@@ -196,8 +194,8 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
 
     this.handleFilterChange = handleFilterChange.bind(this);
     this.handleFilterClear = handleFilterClear.bind(this);
-    this.connectedViewRecord = context.stripes.connect(props.viewRecordComponent);
-    this.connectedNotes = context.stripes.connect(Notes);
+    this.connectedViewRecord = props.stripes.connect(props.viewRecordComponent);
+    this.connectedNotes = props.stripes.connect(Notes);
     this.SRStatus = null;
     this.lastNonNullReaultCount = undefined;
 
@@ -209,10 +207,9 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
     const initialQuery = queryString.parse(initialSearch);
     this.initialFilters = initialQuery.filters;
 
-    const logger = context.stripes.logger;
+    const logger = props.stripes.logger;
     this.log = logger.log.bind(logger);
     this.transitionToParams = this.transitionToParams.bind(this);
-
   }
 
   componentDidMount() {
@@ -222,7 +219,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
   }
 
   componentWillReceiveProps(nextProps) {
-    const logger = this.context.stripes.logger;
+    const logger = this.props.stripes.logger;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
 
@@ -244,7 +241,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
     if (oldState.pending() && !newState.pending()) {
       this.log('event', 'new search-result');
       const count = newState.totalCount();
-      this.SRStatus.sendMessage(this.context.stripes.intl.formatMessage({ id: 'stripes-smart-components.searchReturnedResults' }, { count }));
+      this.SRStatus.sendMessage(this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.searchReturnedResults' }, { count }));
     }
 
     // if the results list is winnowed down to a single record, display the record.
@@ -327,7 +324,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
   }
 
   onNeedMore = () => {
-    const source = makeConnectedSource(this.props, this.context.stripes.logger);
+    const source = makeConnectedSource(this.props, this.props.stripes.logger);
     source.fetchMore(this.props.resultCountIncrement);
   }
 
@@ -449,10 +446,9 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
   }
 
   render() {
-    const { parentResources, filterConfig, disableFilters, newRecordPerms, viewRecordPerms, objectName, detailProps, packageInfo } = this.props;
-    const source = makeConnectedSource(this.props, this.context.stripes.logger);
+    const { parentResources, filterConfig, disableFilters, newRecordPerms, viewRecordPerms, objectName, detailProps, packageInfo, stripes } = this.props;
+    const source = makeConnectedSource(this.props, stripes.logger);
     const urlQuery = queryString.parse(this.props.location.search || '');
-    const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
     const records = source.records();
     const searchTerm = this.state.locallyChangedSearchTerm || '';
@@ -660,5 +656,5 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
 export default withRouter(
   withModule(
     props => props.packageInfo && props.packageInfo.name
-  )(SearchAndSort)
+  )(withStripes(SearchAndSort))
 );

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -1,4 +1,6 @@
 {
+  "cddd.date": "Date",
+  "cddd.time": "Time",
   "cddd.changeDueDate": "Change due date",
   "cddd.changeDueDateConfirmation": "Change due date",
   "cddd.itemsSelected": "<b>{count}</b> items <b>selected.</b>",


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-208

- Use `stripes` prop if already available, otherwise get it with `withStripes`
- Two new translation strings (`"Date"`, `"Time"`)
- `<LocationLookup>` prop rename: `temporary` -> `isTemporaryLocation` to make it more obvious

https://github.com/folio-org/ui-inventory/pull/219 uses `isTemporaryLocation` to fix the label. 