### PR TITLE
pass id prop to ConfirmationModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * Cache user object metadata in `<ControlledVocab>`; it's faster. Fixes STCOM-308.
 * Refactor EntryManager to support anointed resource. Fixes STCOR-231.
 * Retrieve more locations via `<LocationSelection>`.
+* Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317. Available from v1.4.22.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -356,6 +356,7 @@ class ControlledVocab extends React.Component {
             />
           }
           <ConfirmationModal
+            id={`delete${type.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}-confirmation`}
             open={this.state.showConfirmDialog}
             heading={formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: type })}
             message={modalMessage}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.21",
+  "version": "1.4.22",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Generation of HTML element-IDs in `<ConfirmationModal>` changed in
https://github.com/folio-org/stripes-components/commit/ce3ba8c996463a389ae3c3aeb36069d9a785ed69
and that broke a bunch of tests that relied on the old style of element
IDs. Happily, we can restore this behavior by passing in an ID prop that
matches the old format.

Refs [STCOM-317](https://issues.folio.org/browse/STCOM-317)