### PR TITLE
bumping package version for dependent repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Refactor EntryManager to support anointed resource. Fixes STCOR-231.
 * Retrieve more locations via `<LocationSelection>`.
 * Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317. Available from v1.4.23.
+* Initial support for tags on individual records. Toward STSMACOM-113, FOLIO-1303. Available from v1.4.24.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Bumping the package version so repos that depend on tags can request it
by version number.

Refs [STSMACOM-113](https://issues.folio.org/browse/STSMACOM-113)