### PR TITLE
STSMACOM-114 ControlledVocab: Support custom validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317. Available from v1.4.23.
 * Initial support for tags on individual records. Toward STSMACOM-113, FOLIO-1303. Available from v1.4.24.
 * Update version of @folio/react-intl-safe-html. Fixes STRIPES-545
+* Add custom field validation for `<ControlledVocab>`. Fixes STSMACOM-114.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -225,15 +225,13 @@ class ControlledVocab extends React.Component {
       const errors = [];
 
       items.forEach((item, index) => {
-        const itemErrors = {};
+        // Start with getting a validation check from the parent component.
+        const itemErrors = this.props.validate(item, index, items);
 
         // Check if the primary field has had data entered into it.
         if (!item[primaryField]) {
           itemErrors[primaryField] = this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' });
         }
-
-        // Mix in any validation done by the parent component.
-        Object.assign(itemErrors, this.props.validate(item, index, items));
 
         // Add the errors if we found any for this record.
         if (Object.keys(itemErrors).length) {

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -83,6 +83,13 @@ class ControlledVocab extends React.Component {
     rowFilterFunction: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
+    /*
+    * Allows for custom field validation. The function is called for each record (row) and should
+    * return an empty object for no errors, or an object where the keys are the field names and
+    * the values are the error message components/strings to display.
+    * e.g., (item, index, items) => ({ name: item.name === 'Admin' ? 'Name cannot be admin' : undefined })
+    */
+    validate: PropTypes.func,
   };
 
   static defaultProps = {
@@ -101,6 +108,7 @@ class ControlledVocab extends React.Component {
     },
     preCreateHook: (row) => row,
     preUpdateHook: (row) => row,
+    validate: () => {},
   };
 
   constructor(props) {
@@ -217,10 +225,19 @@ class ControlledVocab extends React.Component {
       const errors = [];
 
       items.forEach((item, index) => {
+        const itemErrors = {};
+
+        // Check if the primary field has had data entered into it.
         if (!item[primaryField]) {
-          errors[index] = {
-            [primaryField]: this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' }),
-          };
+          itemErrors[primaryField] = this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' });
+        }
+
+        // Mix in any validation done by the parent component.
+        Object.assign(itemErrors, this.props.validate(item, index, items));
+
+        // Add the errors if we found any for this record.
+        if (Object.keys(itemErrors).length) {
+          errors[index] = itemErrors;
         }
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.24",
+  "version": "1.4.25",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
This lets us do custom validation by supplying a `validate` prop.

E.g., to prevent creating multiple records with the same `group`, we could validate as below:
```
<ControlledVocab
  ...
  validate={(item, index, items) => ({
    group: items.find((i, idx) => (i.group === item.group) && (idx !== index)) ? 'Duplicate!' : undefined,
  })}
/>
```

Bumped version to 1.4.25