### PR TITLE
validate error object before checking its keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * Initial support for tags on individual records. Toward STSMACOM-113, FOLIO-1303. Available from v1.4.24.
 * Update version of @folio/react-intl-safe-html. Fixes STRIPES-545
 * Add custom field validation for `<ControlledVocab>`. Fixes STSMACOM-114.
+* Check for `<ControlledVocab>` errors more carefully. Refs STSMACOM-114. Available from v1.4.26. 
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -234,7 +234,7 @@ class ControlledVocab extends React.Component {
         }
 
         // Add the errors if we found any for this record.
-        if (Object.keys(itemErrors).length) {
+        if (itemErrors && Object.keys(itemErrors).length) {
           errors[index] = itemErrors;
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.25",
+  "version": "1.4.26",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Don't call `Object.keys(null)`; that's an error.

Refs [STSMACOM-114](https://issues.folio.org/browse/STSMACOM-114)