### PR TITLE
cleaner localization handling for result-count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Update version of @folio/react-intl-safe-html. Fixes STRIPES-545
 * Add custom field validation for `<ControlledVocab>`. Fixes STSMACOM-114.
 * Check for `<ControlledVocab>` errors more carefully. Refs STSMACOM-114. Available from v1.4.26. 
+* Cleaner handling of result-count header. Refs STSMACOM-108. Available from v1.4.27.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -65,6 +65,7 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
     filterChangeCallback: PropTypes.func,
     initialResultCount: PropTypes.number.isRequired,
     resultCountIncrement: PropTypes.number.isRequired,
+    resultCountMessageKey: PropTypes.string,
     viewRecordComponent: PropTypes.func.isRequired,
     editRecordComponent: PropTypes.func,
     newRecordInitialValues: PropTypes.object,
@@ -574,7 +575,8 @@ class SearchAndSort extends React.Component { // eslint-disable-line react/no-de
       />
     </Layer>);
 
-    const paneSub = !source.loaded() ? formatMsg({ id: 'stripes-smart-components.searchCriteria' }) : formatMsg({ id: `ui-${moduleName}.resultCount` }, { count });
+    const messageKey = this.props.resultCountMessageKey ? this.props.resultCountMessageKey : 'stripes-smart-components.searchResultsCountHeader';
+    const paneSub = !source.loaded() ? formatMsg({ id: 'stripes-smart-components.searchCriteria' }) : formatMsg({ id: messageKey }, { count });
     return (
       <Paneset>
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -71,6 +71,7 @@
   "permissionsDoNotAllowAccess": "Sorry - your permissions do not allow access to this page.",
   "searchResults": "{objectName} search results",
   "searchReturnedResults": "Search returned {count, number} {count, plural, one {result} other {results}}",
+  "searchResultsCountHeader": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "resetAll": "Reset all",
   "whoAreYouActingAs": "Who are you acting as?",
   "self": "Self",


### PR DESCRIPTION
Rather than concatenating a bunch of stuff together to build the key
for the translation field to use, either use a given key or use a
default value. So much simpler.

Fixes [STSMACOM-108](https://issues.folio.org/browse/STSMACOM-108)