### PR TITLE
lock react-bootstrap version to avoid buggy deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * Add custom field validation for `<ControlledVocab>`. Fixes STSMACOM-114.
 * Check for `<ControlledVocab>` errors more carefully. Refs STSMACOM-114. Available from v1.4.26. 
 * Cleaner handling of result-count header. Refs STSMACOM-108. Available from v1.4.27.
+* Lock react-bootstrap to v0.32.1 to avoid buggy babel-runtime 7.0.0-beta.42 dep. Refs FOLIO-1425. Available from v1.4.28.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {
@@ -95,7 +95,7 @@
     "moment-timezone": "^0.5.17",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
-    "react-bootstrap": "^0.32.0",
+    "react-bootstrap": "0.32.1",
     "react-intl": "^2.4.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",


### PR DESCRIPTION
react-bootstrap >0.32.1 introduces a dependency on babel-runtime
^7.0.0-beta.42 that is incompatible with other modules in our system and
breaks the build. Locking onto v0.32.1 resolves the issue. Mad props to
@marcjohnson-kint for diagnosing this.

Refs [FOLIO-1425](https://issues.folio.org/browse/FOLIO-1425)