### PR TITLE
pass actionMenuItems prop to Results Pane

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -36,6 +36,7 @@ import ResetButton from './components/ResetButton';
 class SearchAndSort extends React.Component {
   static propTypes = {
     // parameter properties provided by caller
+    actionMenuItems: PropTypes.arrayOf(PropTypes.object),
     objectName: PropTypes.string.isRequired, // machine-readable
     searchableIndexes: PropTypes.arrayOf(
       PropTypes.object,
@@ -212,7 +213,7 @@ class SearchAndSort extends React.Component {
     this.setState({ locallyChangedSearchTerm: query });
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
     const logger = this.props.stripes.logger;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
@@ -635,6 +636,7 @@ class SearchAndSort extends React.Component {
           padContent={false}
           id="pane-results"
           defaultWidth="fill"
+          actionMenuItems={this.props.actionMenuItems}
           appIcon={appIcon}
           paneTitle={this.props.module.displayName}
           paneSub={paneSub}


### PR DESCRIPTION
This PR is to allow UI apps to pass the `actionMenuItems` prop to the SearchAndSort results pane. The prop enables a dropdown in the Pane header. This dropdown is where the Export To CSV action goes.