### PR TITLE
wait for settings query before rendering form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 * Lock react-bootstrap to v0.32.1 to avoid buggy babel-runtime 7.0.0-beta.42 dep. Refs FOLIO-1425. Available from v1.4.28.
 * New optional `notLoadedMessage` prop for `<SearchAndSort>`. Fixes STSMACOM-116. Available from v1.4.29.
 * Fix initial query string to keep searchField updated. Fixes STSMACOM-119.
+* Wait until settings load before rendering the form. Refs UICIRC-75. Available from v1.4.32.
 
 ## [1.4.0](https://github.com/folio-org/stripes-smart-components/tree/v1.4.0) (2017-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.3.0...v1.4.0)

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -105,12 +105,18 @@ class ConfigManager extends React.Component {
   }
 
   render() {
-    return (
-      <div style={{ width: '100%' }}>
-        {this.getConfigForm()}
-        <Callout ref={(ref) => { this.callout = ref; }} />
-      </div>
-    );
+    const settings = (this.props.resources.settings || {});
+
+    if (settings && settings.hasLoaded) {
+      return (
+        <div style={{ width: '100%' }}>
+          {this.getConfigForm()}
+          <Callout ref={(ref) => { this.callout = ref; }} />
+        </div>
+      );
+    }
+
+    return <div />;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.4.31",
+  "version": "1.4.32",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Previously, the form would render immediately upon invocation and then
rerender when the settings resource returned. If you are fast with the
mouse, and I mean real fast like faster than The Waco Kid fast, or
maybe if you are a Nightmare test, you could click the submit button
between the first (pre-resource results) and second (post-resource
results) renders. Without an existing record with an id to coalesce into
([line 59](/folio-org/stripes-smart-components/blob/43394b2eaf41b7f45fa4b223d0171e5efed58de2/lib/ConfigManager/ConfigManager.js#L59)) we'll get a POST request instead of a PUT ([line 65](/folio-org/stripes-smart-components/blob/43394b2eaf41b7f45fa4b223d0171e5efed58de2/lib/ConfigManager/ConfigManager.js#L75)) that will
blow up when Okapi rejects the duplicate record.

This solves all that.

Refs [UICIRC-75](https://issues.folio.org/browse/UICIRC-75)