### PR TITLE
Fix SearchAndSort linting

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -207,7 +207,7 @@ class SearchAndSort extends React.Component {
     this.transitionToParams = this.transitionToParams.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated
+  componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated
     const logger = this.props.stripes.logger;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);


### PR DESCRIPTION
The `UNSAFE_` was unnecessary, since the line is already disabled for `react/no-deprecated` (and instead starting throwing a `camelcase` warning).