### PR TITLE
STCOM-328 Move EditableList

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
-import EditableList from '@folio/stripes-components/lib/EditableList/EditableList';
 import Button from '@folio/stripes-components/lib/Button';
 import Callout from '@folio/stripes-components/lib/Callout';
 import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal/ConfirmationModal';
@@ -12,6 +11,7 @@ import Modal from '@folio/stripes-components/lib/Modal';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import EditableList from '../EditableList';
 import UserLink from '../UserLink';
 import UserName from '../UserName';
 import css from './ControlledVocab.css';

--- a/lib/EditableList/EditableItem.js
+++ b/lib/EditableList/EditableItem.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ItemView from './ItemView';
+import ItemEdit from './ItemEdit';
+
+const EditableItem = props => (props.editing ? <ItemEdit {...props} autoFocus /> : <ItemView {...props} />);
+
+EditableItem.propTypes = {
+  editing: PropTypes.bool,
+};
+
+export default EditableItem;

--- a/lib/EditableList/EditableList.css
+++ b/lib/EditableList/EditableList.css
@@ -1,0 +1,31 @@
+/**
+ * EditableList
+ */
+
+.editableListFormHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+}
+
+.editListRow {
+  display: flex;
+  max-width: 100%;
+  justify-content: flex-start;
+  align-items: center;
+  border-radius: 8px;
+  background-color: #efefef;
+  margin-bottom: 4px;
+  min-height: 40px;
+}
+
+.editListHeaders {
+  display: flex;
+  justify-content: flex-start;
+  overflow: hidden;
+}
+
+.editableListError {
+  width: 100%;
+  padding: 6px;
+}

--- a/lib/EditableList/EditableList.js
+++ b/lib/EditableList/EditableList.js
@@ -1,0 +1,54 @@
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import EditableListForm from './EditableListForm';
+
+const propTypes = {
+  /**
+   * maps column fields to strings that should be rendered in the list headers.
+   */
+  columnMapping: PropTypes.object,
+  /**
+   * set custom column widths.
+   */
+  columnWidths: PropTypes.object,
+  /**
+   * Array of objects to be rendered as list items.
+   */
+  contentData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   *  set custom component for editing
+   */
+  fieldComponents: PropTypes.object,
+  /**
+   * Used to render custom components within the cells of the list.
+   */
+  formatter: PropTypes.object,
+  /**
+   * id for add button
+   */
+  id: PropTypes.string,
+  /**
+   * The key that uniquely names listed objects: defaults to 'name'.
+   */
+  nameKey: PropTypes.string,
+  /**
+   * Readonly fields that will not be editable.
+   */
+  readOnlyFields: PropTypes.arrayOf(PropTypes.string),
+};
+
+const defaultProps = {
+  nameKey: 'name',
+};
+
+const EditableList = (props) => {
+  const { contentData, nameKey } = props;
+  const items = _.sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
+  return (<EditableListForm initialValues={{ items }} {...props} />);
+};
+
+EditableList.propTypes = propTypes;
+EditableList.defaultProps = defaultProps;
+
+export default EditableList;

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -5,16 +5,16 @@ import React from 'react';
 import { intlShape } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { FieldArray } from 'redux-form';
-import { Row, Col } from 'react-flexbox-grid';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import PropTypes from 'prop-types';
 
-import injectIntl from '../InjectIntl';
-import Headline from '../Headline';
-import Button from '../Button';
+import injectIntl from '@folio/stripes-components/lib/InjectIntl';
+import Headline from '@folio/stripes-components/lib/Headline';
+import Button from '@folio/stripes-components/lib/Button';
+import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import EditableItem from './EditableItem';
-import MultiColumnList from '../MultiColumnList';
 import css from './EditableList.css';
-import IconButton from '../IconButton';
 
 const propTypes = {
   /**

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -1,0 +1,459 @@
+import isEqual from 'lodash/isEqual';
+import cloneDeep from 'lodash/cloneDeep';
+import uniqueId from 'lodash/uniqueId';
+import React from 'react';
+import { intlShape } from 'react-intl';
+import stripesForm from '@folio/stripes-form';
+import { FieldArray } from 'redux-form';
+import { Row, Col } from 'react-flexbox-grid';
+import PropTypes from 'prop-types';
+
+import injectIntl from '../InjectIntl';
+import Headline from '../Headline';
+import Button from '../Button';
+import EditableItem from './EditableItem';
+import MultiColumnList from '../MultiColumnList';
+import css from './EditableList.css';
+import IconButton from '../IconButton';
+
+const propTypes = {
+  /**
+   * Object containing properties of list action names: 'delete', 'edit' and
+   * values of sentinel functions that return objects to destructure onto the
+   * action button props:
+   * { delete: (item) => {return { disabled: item.item.inUse } } }
+   */
+  actionProps: PropTypes.object,
+  /**
+   * Object containing properties of list action names: 'delete', 'edit' and
+   * values of sentinel functions that return booleans based on object
+   * properties" { delete: (item) => {return (!item.item.inUse)} }
+   */
+  actionSuppression: PropTypes.object,
+  /**
+   * Additional fields that require building.
+   */
+  additionalFields: PropTypes.object,
+  /**
+   *  set custom rendered column names
+   */
+  columnMapping: PropTypes.object,
+  /**
+   * manually set column widths, if necessary.
+   */
+  columnWidths: PropTypes.object,
+  /**
+   * Label for the 'Add' button
+   */
+  createButtonLabel: PropTypes.string,
+  /**
+   *  set custom component for editing
+   */
+  fieldComponents: PropTypes.object,
+  /**
+   * passed to MultiColumnList, formatter allows control over how the data is rendered in the cells of the grid.
+   */
+  formatter: PropTypes.object,
+  /**
+   * id for Add action.
+   */
+  id: PropTypes.string,
+  /**
+   * Callback provided by redux-form to set the initialValues to something else.
+   */
+  initialize: PropTypes.func,
+  /**
+  * Initial form values
+  */
+  initialValues: PropTypes.object,
+  intl: intlShape.isRequired,
+  /**
+   * boolean that indicates if there are validation errors.
+   */
+  invalid: PropTypes.bool,
+  /**
+   * Message to display for an empty list.
+   */
+  isEmptyMessage: PropTypes.string,
+  /**
+   * Object where each key's value is the default value for that field.
+   * { resourceType: 'book' }
+   */
+  itemTemplate: PropTypes.object,
+  /**
+   * The text for the H3 tag in the header of the component
+   */
+  label: PropTypes.string,
+  /**
+   * Callback for creating new list items.
+   */
+  onCreate: PropTypes.func,
+  /**
+   * Callback for list item deletion.
+   */
+  onDelete: PropTypes.func,
+  /**
+   * Callback for saving editted list items.
+   */
+  onUpdate: PropTypes.func,
+  /**
+   * boolean that shows if the form has been modified.
+   */
+  pristine: PropTypes.bool,
+  /**
+   * List of read-only fields
+   */
+  readOnlyFields: PropTypes.arrayOf(PropTypes.string),
+  /**
+   * Callback provided by redux-form to set the field values to their initialValues
+   */
+  reset: PropTypes.func,
+  /**
+   * boolean that indicates that the form is being submitted.
+   */
+  submitting: PropTypes.bool,
+
+  /**
+   * Fieldname that includes the unique identifier for the list.
+   */
+  uniqueField: PropTypes.string,
+  /**
+   * Array of fields to render. These will also be editable.
+   */
+  visibleFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const defaultProps = {
+  actionProps: {},
+  actionSuppression: { delete: () => false, edit: () => false },
+  createButtonLabel: '+ Add new',
+  fieldComponents: {},
+  itemTemplate: {},
+  uniqueField: 'id',
+};
+
+class EditableListForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    let status = [];
+    if (props.initialValues) {
+      status = this.buildStatusArray(props.initialValues.items);
+    }
+
+    this.state = {
+      status,
+      lastAction: {},
+    };
+
+    this.RenderItems = this.RenderItems.bind(this);
+    this.setError = this.setError.bind(this);
+    this.buildStatusArray = this.buildStatusArray.bind(this);
+    this.getColumnWidths = this.getColumnWidths.bind(this);
+    this.getVisibleColumns = this.getVisibleColumns.bind(this);
+    this.getReadOnlyColumns = this.getReadOnlyColumns.bind(this);
+
+    if (this.props.id) {
+      this.testingId = this.props.id;
+    } else if (this.props.label) {
+      this.testingId = this.props.label.replace(/\s/, '').toLowerCase();
+    } else {
+      this.testingId = uniqueId();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+    if (!isEqual(this.props.initialValues, nextProps.initialValues)) {
+      this.setState({
+        status: this.buildStatusArray(nextProps.initialValues.items),
+      });
+    }
+  }
+
+  buildStatusArray(items) {
+    return items.map(() => ({ editing: false, error: false }));
+  }
+
+  onAdd(fields) {
+    const { itemTemplate } = this.props;
+    const item = { ...itemTemplate };
+    fields.unshift(item);
+    // add field to edit-tracking in edit mode.
+    this.setState((curState) => {
+      const newState = cloneDeep(curState);
+      if (newState.status.length === 0 && fields.length > 0) {
+        newState.status = this.buildStatusArray();
+      }
+      newState.status.unshift({ editing: true, error: false });
+      return newState;
+    });
+  }
+
+  onCancel(fields, index) {
+    const { uniqueField } = this.props;
+    const item = fields.get(index);
+
+    // if the item has a unique identifier, toggle its edit mode... if not, remove it.
+    if (item[uniqueField]) {
+      this.toggleEdit(index);
+    } else {
+      fields.remove(index);
+      this.setState((curState) => {
+        const newState = cloneDeep(curState);
+        newState.status.splice(index, 1);
+        return newState;
+      });
+    }
+
+    // Reset the field values.
+    this.props.reset();
+  }
+
+  onSave(fields, index) {
+    const item = fields.get(index);
+    // if item has no id, it's new...
+    const callback = (item.id) ?
+      this.props.onUpdate :
+      this.props.onCreate;
+    const res = callback(item);
+    Promise.resolve(res).then(
+      () => {
+        // Set props.initialValues to the currently-saved field values.
+        this.props.initialize(fields.getAll());
+
+        this.toggleEdit(index);
+      },
+      () => this.setError(index, 'Error on saving data'),
+    );
+  }
+
+  onEdit(index) {
+    this.toggleEdit(index);
+  }
+
+  onDelete(fields, index) {
+    const { uniqueField } = this.props;
+    const item = fields.get(index);
+    const res = this.props.onDelete(item[uniqueField]);
+    Promise.resolve(res).then(
+      () => {
+        fields.remove(index);
+        // remove item from editable tracking...
+        this.setState((curState) => {
+          const newState = cloneDeep(curState);
+          newState.status.splice(index, 1);
+          return newState;
+        });
+      },
+      () => this.setError(index, 'Error on removing data'),
+    );
+  }
+
+  setError(index, errorMsg) {
+    this.setState((curState) => {
+      const newState = cloneDeep(curState);
+      newState.status[index].error = errorMsg;
+      newState.lastAction = new Date().getTime();
+      return newState;
+    });
+  }
+
+  getColumnWidths() {
+    if (!this.props.columnWidths) {
+      const visibleColumns = this.getVisibleColumns();
+      const totalColumns = visibleColumns.length - 1;
+      const staticWidth = 80 / totalColumns;
+      const widthsObject = {};
+      visibleColumns.forEach((f) => {
+        if (f !== 'actions') {
+          widthsObject[f] = `${staticWidth}%`;
+        }
+      });
+      widthsObject.actions = '20%';
+      return widthsObject;
+    }
+    return this.props.columnWidths;
+  }
+
+  getVisibleColumns() {
+    return this.props.visibleFields.concat(['actions']);
+  }
+
+  getReadOnlyColumns() {
+    const actionsArray = ['actions'];
+    if (this.props.readOnlyFields) {
+      return this.props.readOnlyFields.concat(actionsArray);
+    }
+    return actionsArray;
+  }
+
+  toggleEdit(index) {
+    if (this.state.status.length === 0) {
+      this.buildStatusArray();
+    }
+    this.setState((curState) => {
+      const newState = cloneDeep(curState);
+      if (newState.status.length === 0) {
+        newState.status = this.buildStatusArray();
+      }
+      newState.status[index].editing = !newState.status[index].editing;
+      newState.lastAction = new Date().getTime();
+      return newState;
+    });
+  }
+
+  ItemFormatter = ({
+    rowIndex,
+    rowData,
+    cells,
+    fields,
+    columnWidths,
+    rowProps,
+  }) => {
+    let isEditing;
+    let hasError;
+    if (this.state.status.length > 0) {
+      isEditing = this.state.status[rowIndex].editing;
+      hasError = this.state.status[rowIndex].error;
+    } else {
+      isEditing = false;
+      hasError = false;
+    }
+
+    return (
+      <EditableItem
+        editing={isEditing}
+        error={hasError}
+        key={rowIndex}
+        field="items"
+        item={rowData}
+        rowIndex={rowIndex}
+        columnMapping={this.props.columnMapping}
+        actionSuppression={this.props.actionSuppression}
+        actionProps={this.props.actionProps}
+        visibleFields={this.getVisibleColumns()}
+        onCancel={() => this.onCancel(fields, rowIndex)}
+        onSave={() => this.onSave(fields, rowIndex)}
+        onEdit={() => this.onEdit(rowIndex)}
+        onDelete={() => this.onDelete(fields, rowIndex)}
+        additionalFields={this.props.additionalFields}
+        readOnlyFields={this.getReadOnlyColumns()}
+        fieldComponents={this.props.fieldComponents}
+        widths={columnWidths}
+        cells={cells}
+        {...rowProps}
+      />
+    );
+  }
+
+  getActions = (fields, item) => {
+    const { actionProps, actionSuppression, pristine, submitting, invalid } = this.props;
+
+    if (this.state.status[item.rowIndex].editing) {
+      return (
+        <div style={{ display: 'flex' }}>
+          <Button
+            disabled={pristine || submitting || invalid}
+            marginBottom0
+            id={`clickable-save-${this.testingId}-${item.rowIndex}`}
+            title={this.props.intl.formatMessage({ id: 'stripes-components.saveChangesToThisItem' })}
+            onClick={() => this.onSave(fields, item.rowIndex)}
+            {...(typeof actionProps.save === 'function' ? actionProps.save(item) : {})}
+          >
+            Save
+          </Button>
+          <Button
+            marginBottom0
+            id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
+            title={this.props.intl.formatMessage({ id: 'stripes-components.cancelEditingThisItem' })}
+            onClick={() => this.onCancel(fields, item.rowIndex)}
+            {...(typeof actionProps.cancel === 'function' ? actionProps.cancel(item) : {})}
+          >
+            Cancel
+          </Button>
+        </div>
+      );
+    }
+    return (
+      <div style={{ display: 'flex' }}>
+        {!actionSuppression.edit(item) &&
+          <IconButton
+            icon="edit"
+            size="small"
+            id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
+            onClick={() => this.onEdit(item.rowIndex)}
+            title={this.props.intl.formatMessage({ id: 'stripes-components.editThisItem' })}
+            {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
+          />
+        }
+        {!actionSuppression.delete(item) &&
+          <IconButton
+            icon="trashBin"
+            size="small"
+            id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
+            onClick={() => this.onDelete(fields, item.rowIndex)}
+            title={this.props.intl.formatMessage({ id: 'stripes-components.deleteThisItem' })}
+            {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
+          />
+        }
+      </div>
+    );
+  };
+
+  RenderItems({ fields }) {
+    const cellFormatters = Object.assign({}, this.props.formatter, { actions: item => this.getActions(fields, item) });
+    return (
+      <div>
+        <Row between="xs" className={css.editableListFormHeader}>
+          <Col xs>
+            <Headline size="medium" margin="none">{this.props.label}</Headline>
+          </Col>
+          <Col xs>
+            <Row end="xs">
+              <Col xs>
+                <Button onClick={() => this.onAdd(fields)} marginBottom0 id={`clickable-add-${this.testingId}`}>
+                  {this.props.createButtonLabel}
+                </Button>
+              </Col>
+            </Row>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <MultiColumnList
+              {...this.props}
+              visibleColumns={this.getVisibleColumns()}
+              contentData={fields.getAll()}
+              rowFormatter={this.ItemFormatter}
+              rowProps={{ fields }}
+              formatter={cellFormatters}
+              columnWidths={this.getColumnWidths()}
+              isEmptyMessage={this.props.isEmptyMessage}
+              headerRowClass={css.editListHeaders}
+              id={`editList-${this.testingId}`}
+            />
+
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <form>
+        <FieldArray name="items" component={this.RenderItems} toUpdate={this.state.lastAction} />
+      </form>
+    );
+  }
+}
+
+EditableListForm.propTypes = propTypes;
+EditableListForm.defaultProps = defaultProps;
+
+export default stripesForm({
+  form: 'editableListForm',
+  navigationCheck: true,
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(injectIntl(EditableListForm));

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import TextField from '../TextField';
+import TextField from '@folio/stripes-components/lib/TextField';
 import css from './EditableList.css';
 
 const ItemEdit = ({

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import TextField from '../TextField';
+import css from './EditableList.css';
+
+const ItemEdit = ({
+  rowIndex,
+  error,
+  field,
+  visibleFields,
+  columnMapping,
+  fieldComponents,
+  readOnlyFields,
+  widths,
+  cells,
+  autoFocus
+}) => {
+  const fields = visibleFields.map((name, fieldIndex) => {
+    if (readOnlyFields.indexOf(name) === -1) {
+      let mappedName = name;
+      if (Object.hasOwnProperty.call(columnMapping, name)) {
+        mappedName = columnMapping[name];
+      }
+
+      const fieldName = `${field}[${rowIndex}].${name}`;
+      const ariaLabel = `${mappedName} ${rowIndex}`;
+      const fieldKey = `${field}-${name}-${rowIndex}`;
+      const fieldStyle = { flex: `0 0 ${widths[name]}`, width: `${widths[name]}`, padding: '6px' };
+      const fieldProps = {
+        'name': fieldName,
+        'aria-label': ariaLabel,
+      };
+
+      if (Object.hasOwnProperty.call(fieldComponents, name)) {
+        return (
+          <div key={fieldKey} style={fieldStyle}>
+            { fieldComponents[name]({ fieldProps, fieldIndex, name, field, rowIndex }) }
+          </div>
+        );
+      }
+      return (
+        <div key={fieldKey} style={fieldStyle}>
+          <Field
+            {...fieldProps}
+            component={TextField}
+            marginBottom0
+            fullWidth
+            placeholder={name}
+            autoFocus={autoFocus && fieldIndex === 0}
+          />
+        </div>
+      );
+    }
+    return cells[fieldIndex];
+  });
+
+  return (
+    <div className={css.editListRow}>
+      {fields}
+      { error &&
+        <div className={css.editableListError}>
+Error:
+          {error}
+        </div>
+      }
+    </div>
+  );
+};
+
+ItemEdit.propTypes = {
+  autoFocus: PropTypes.bool,
+  cells: PropTypes.arrayOf(PropTypes.object),
+  columnMapping: PropTypes.object,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  field: PropTypes.string,
+  fieldComponents: PropTypes.object,
+  readOnlyFields: PropTypes.arrayOf(PropTypes.string),
+  rowIndex: PropTypes.number,
+  visibleFields: PropTypes.arrayOf(PropTypes.string),
+  widths: PropTypes.object,
+};
+
+export default ItemEdit;

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import css from './EditableList.css';
+
+const ItemView = ({ cells }) => (
+  <div className={css.editListRow}>
+    {cells}
+  </div>
+);
+
+ItemView.propTypes = {
+  cells: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default ItemView;

--- a/lib/EditableList/index.js
+++ b/lib/EditableList/index.js
@@ -1,0 +1,1 @@
+export { default } from './EditableList';

--- a/lib/EditableList/readme.md
+++ b/lib/EditableList/readme.md
@@ -1,0 +1,133 @@
+# Editable List
+A component used for creating editable CRUD lists.
+
+### Usage
+
+import
+```js
+import EditableList from '@folio/stripes-components/lib/EditableList';
+```
+
+set some data...
+```js
+    const contentData = [
+      {
+        id: 1,
+        name: 'Item 1',
+      },
+      {
+        id: 2,
+        name: 'Item 2',
+      }
+    ];
+```
+
+
+Use the `EditableList` component in your jsx
+```js
+<EditableList contentData={contentData} createButtonLabel="+ Add new" visibleFields={['name']} onUpdate={this.handleUpdate} onDelete={this.handleDelete} onCreate={this.handleCreate} />
+```
+
+### Configuration (props)
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+contentData | array of objects | Array of objects to be rendered as list items. | | yes
+nameKey | string | The key that uniquely names listed objects: defaults to 'name'. | | no
+onCreate | function | Callback for creating new list items. | | no
+onUpdate | function | Callback for saving record.  | | no
+onDelete | function | Callback for saving edited list items. | | no
+label | string | The text for the H3 tag in the header of the component | | no
+createButtonLabel | string | Label for the 'Add' button | `+ Add new` | no
+visibleFields | array of strings | Array of fields to render. These will also be editable. | | yes
+itemTemplate | object | Object where each key's value is the default value for that field: `{ resourceType: 'book' }` | {} | no
+uniqueField | string | Fieldname that includes the unique identifier for the list. | `id` | yes
+actionSuppression | object | Object containing properties of list action names: `delete`, `edit` and values of sentinel functions that return booleans based on object properties. | `{ delete: () => false, edit: () => false }` | no
+actionProps | object | Object containing properties of list action names: 'delete', 'edit' and values of sentinel functions that return objects to destructure onto the action button props. | `{ delete: (item) => {return { disabled: item.item.inUse } } }`
+isEmptyMessage | string | Message to display for an empty list. | | no
+readOnlyFields | array of strings | Array of non-editable columns - good for displaying meta information within the row. | | no
+formatter | object | Allows custom content/components to be displayed in the grid. see example below. | | no
+columnMapping | object | Allows custom column names to be applied in case they differ from the properties of `contentData`'s objects| | no
+fieldComponents | object | Allows custom components for edit mode to be used. Fields not supplied will use a `<TextField>` by default| | no
+columnWidths | object | Allows custom column widths to be set. If you use this, be sure to set a width for an 'actions' column as part of this object. | | no
+id | string | Used as a basic suffix for `id` attributes throughout the component. | |
+
+### Custom Field Components
+Many times a `<TextField>` won't be adequate for the value that needs to be edited, so to provide your own `<Field>`, using the `fieldComponents` prop is the way to accomplish this. It accepts an object with keys corresponding to visibleFields that contain render functions. The functions will be provided an object with a `fieldProps` key that can be spread on the `<Field>` for convenience (it applies `name` and `aria-label` props). Other provided props are listed after the example.
+
+Say we want to set up one of our fields (`color`) to use a `<Select>` instead of the default `<TextField>`:
+
+```
+// define the custom components, being sure to pass in the appropriate props for redux-form to work and for *accessibility*.
+
+this.fieldComponents = {
+      color: ({fieldProps}) => (
+        <Field
+        { ...fieldProps } // spread fieldProps to apply 'name' and 'aria-label' props.
+        component={Select}
+        marginBottom0
+        dataOptions={[
+          {label: 'orange', value: 'orange'},
+          {label: 'blue', value: 'blue'},
+          {label: 'red', value: 'red'},
+        ]}/>
+      )
+    }
+
+    // ... later in the JSX...
+
+    <EditableList
+      columnMapping={{
+        id: "Identifier",
+        name: "title",
+      }}
+      contentData={this.contentData}
+      visibleFields={[
+        "id",
+        "name",
+        "color",
+      ]}
+      fieldComponents={
+        this.fieldComponents
+      }
+    />
+```
+#### Render props provided to fieldComponent function
+Name | description
+--- | ---
+`fieldProps` | contains `name` (required by `<Field>`) and `aria-label` props.
+`fieldIndex` | the index of the field on the row.
+`rowIndex` | the index of the editable item within the list.
+`name` | the lone string key of the field (same as provided in the visibleFields prop).
+`mappedName` | the name for the column used in columnMapping, if any (otherwise, same as name.)
+
+### Using formatters for custom data
+Sometimes the data alone just won't serve what you need and it needs to be formatted in some certain way. The `formatter` prop allows for custom rendering of data. Each key of the `formatter` object should correspond with a field from `visibleFields` that you'd like to render custom content for. The function will be passed the data object for the particular item of the list, so multiple data points can be used to affect the display.
+In this example, the lastUpdated column will be made to display a custom component `<RenderLastUpdated>`, but the function could also simply return a string.
+There's no actual `lastUpdated` property within the contentData array's objects - formatters can be used to add completely custom columns.
+```
+//basic array for contentData
+const contentData = [
+  { group: "group0", desc: "desc0" }
+  { group: "group1", desc: "desc1" }
+  { group: "group2", desc: "desc2" }
+]
+
+// set up formatter
+    const formatter = {
+      lastUpdated: item => (<RenderLastUpdated                  // this component uses other data in the objects to match the user info with the date
+        lastUpdated={item.lastUpdatedDate}
+        user={item.lastEditingUser}
+      />
+      ),
+    };
+
+// later in JSX...
+    <EditableList
+      contentData={this.props.resources.groups.records || []}
+      visibleFields={['group', 'desc', 'lastUpdated',]}
+      columnMapping={{ desc: 'Description', lastUpdated: 'Last Updated', }}   // set column headers text
+      readOnlyFields={['lastUpdated']}                                        // set formatter-controlled field as read-only
+      {...otherProps}
+      formatter={formatter}
+    />
+```


### PR DESCRIPTION
## Purpose
`EditableList` doesn't meet the definition of a purely presentational component (https://issues.folio.org/browse/STCOM-298), since it's dependent on a redux store. It's used by more than one `folio-org` repo, so its most logical new home is in `stripes-smart-components`.

https://issues.folio.org/browse/STCOM-328

## Approach
Used `git-subtree` to preserve as much git history for these files as possible from `stripes-components`. `EditableList` was recently moved out of `lib/structures` - unfortunately `git-subtree` didn't preserve any history before that move.

## Next Steps
- [ ] Introduce deprecation warning in `stripes-components`
- [ ] Adjust import in `ui-users`
- [ ] Remove `EditableList` from `stripes-components` `v4.0.0` branch