### PR TITLE
STCOM-330 Move Settings

### DIFF
--- a/lib/Settings/Settings.css
+++ b/lib/Settings/Settings.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+@import '@folio/stripes-components/lib/variables.css';
 
 .settingsBackButton {
   @media (--mediumUp) {

--- a/lib/Settings/Settings.css
+++ b/lib/Settings/Settings.css
@@ -1,0 +1,11 @@
+@import '../variables.css';
+
+.settingsBackButton {
+  @media (--mediumUp) {
+    display: none;
+  }
+}
+
+.listSection {
+  margin-bottom: 20px;
+}

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -5,12 +5,12 @@ import Route from 'react-router-dom/Route';
 import Link from 'react-router-dom/Link';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
-import NavListItem from '../NavListItem';
-import Paneset from '../Paneset';
-import Pane from '../Pane';
-import NavList from '../NavList';
-import NavListSection from '../NavListSection';
-import IconButton from '../IconButton';
+import NavListItem from '@folio/stripes-components/lib/NavListItem';
+import Paneset from '@folio/stripes-components/lib/Paneset';
+import Pane from '@folio/stripes-components/lib/Pane';
+import NavList from '@folio/stripes-components/lib/NavList';
+import NavListSection from '@folio/stripes-components/lib/NavListSection';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 
 import css from './Settings.css';
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Switch from 'react-router-dom/Switch';
+import Route from 'react-router-dom/Route';
+import Link from 'react-router-dom/Link';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
+
+import NavListItem from '../NavListItem';
+import Paneset from '../Paneset';
+import Pane from '../Pane';
+import NavList from '../NavList';
+import NavListSection from '../NavListSection';
+import IconButton from '../IconButton';
+
+import css from './Settings.css';
+
+class Settings extends React.Component {
+  constructor(props) {
+    super(props);
+    const stripes = props.stripes;
+
+    this.sections = props.sections;
+
+    // if props.section was not provided, push props.pages into an array
+    // so it can act like props.sections. this allows all the logic here to
+    // act like we have an array of sections containing an array of
+    // { label: string, pages: array } objects, which is simpler than
+    // separate logic for props.sections and props.pages.
+    if (!this.sections) {
+      this.sections = [{
+        label: '',
+        pages: props.pages || [],
+      }];
+    }
+
+    // this.routes contains routes from all pages across all sections
+    this.routes = [];
+    this.sections.forEach(section => {
+      const sectionRoutes = section.pages
+        .filter(p => !p.perm || stripes.hasPerm(p.perm))
+        .map(page => ({
+          page,
+          component: stripes.connect(page.component, { dataKey: page.route }),
+        }));
+      this.routes = [...this.routes, ...sectionRoutes];
+    });
+  }
+
+  render() {
+    const props = this.props;
+    const stripes = props.stripes;
+    let { activeLink } = this.props;
+
+    // links in a given section
+    const navlinks = (section) => {
+      const navItems = section.pages.map((p) => {
+        const link = `${props.match.path}/${p.route}`;
+        if (props.location.pathname.startsWith(link)) {
+          activeLink = link;
+        }
+        if (p.perm && !stripes.hasPerm(p.perm)) return null;
+        return <NavListItem key={p.route} to={link}>{p.label}</NavListItem>;
+      }).filter(x => x !== null);
+
+      return (
+        <NavListSection activeLink={activeLink} label={section.label} className={css.listSection}>
+          {navItems}
+        </NavListSection>
+      );
+    };
+
+    let Saved;
+    const routes = this.routes.map((p) => {
+      const Current = p.component;
+      if (!Saved) Saved = Current;
+      return (<Route
+        key={p.page.route}
+        path={`${props.match.path}/${p.page.route}`}
+        render={props2 => <Current {...props2} stripes={stripes} label={p.page.label} />}
+      />);
+    });
+
+    return (
+      <Paneset nested defaultWidth="80%">
+        <Pane
+          defaultWidth={props.navPaneWidth}
+          paneTitle={props.paneTitle || 'Module Settings'}
+          firstMenu={(
+            <Link to="/settings" className={css.settingsBackButton}>
+              <IconButton icon="left-arrow" />
+            </Link>
+          )}
+        >
+          {this.sections.map(section => (
+            <NavList key={section.label}>
+              {navlinks(section)}
+            </NavList>
+          ))}
+        </Pane>
+        <Switch>
+          {routes}
+        </Switch>
+      </Paneset>
+    );
+  }
+}
+
+Settings.propTypes = {
+  activeLink: PropTypes.string,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  match: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+  }).isRequired,
+  navPaneWidth: PropTypes.string,
+  pages: PropTypes.arrayOf(
+    PropTypes.shape({
+      component: PropTypes.func.isRequired,
+      label: PropTypes.string.isRequired,
+      perm: PropTypes.string,
+      route: PropTypes.string.isRequired,
+    }),
+  ),
+  paneTitle: PropTypes.string,
+  sections: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      pages: PropTypes.arrayOf(
+        PropTypes.shape({
+          component: PropTypes.func.isRequired,
+          label: PropTypes.string.isRequired,
+          perm: PropTypes.string,
+          route: PropTypes.string.isRequired,
+        }),
+      ).isRequired,
+    }),
+  ),
+  stripes: PropTypes.shape({
+    connect: PropTypes.func.isRequired,
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+Settings.defaultProps = {
+  navPaneWidth: '30%',
+};
+
+export default withStripes(Settings);

--- a/lib/Settings/index.js
+++ b/lib/Settings/index.js
@@ -1,0 +1,1 @@
+export { default } from './Settings';

--- a/lib/Settings/readme.md
+++ b/lib/Settings/readme.md
@@ -1,0 +1,35 @@
+# Settings
+
+Displays the settings page for a Stripes module, given a list of the sub-pages to link and route to.
+
+## Usage
+
+```
+import React from 'react';
+import Settings from './Settings';
+
+import PermissionSets from './PermissionSets';
+import PatronGroupsSettings from './PatronGroupsSettings';
+
+const pages = [
+  { route: 'perms', label: 'Permission sets', component: PermissionSets, perm: 'perms.permissions.get' },
+  { route: 'groups', label: 'Patron groups', component: PatronGroupsSettings },
+];
+
+export default props => <Settings {...props} pages={pages} />;
+```
+
+## Properties
+
+The following properties are supported:
+
+* `navPaneWidth`: a string indicating the width of the pane where the nav links are, e.g., `"30%"`
+* `paneTitle`: the human-readable label of the pane where the nav links are.
+* `pages`: the list of sub-pages to be linked from the settings page. Each member of the list is an object with the following members:
+  * `route`: the route, relative to that of the settings page, on which the sub-page should be found.
+  * `label`: the human-readable label that, when clicked on, links to the specified route.
+  * `component`: the component that is rendered at the specified route.
+  * `perm`: if specified, the name of a permission which the current user must have in order to access the page; if the user lacks the permission, then the link is not provided. (If omitted, then no permission check is performed for the sub-page.)
+* `sections`: an array of section objects. Each member of the list is an object with the following members:
+  * `label`: the human-readable label that, when clicked on, links to the specified route.
+  * `pages`: which has the same form as the `pages` prop


### PR DESCRIPTION
## Purpose
`Settings` doesn't meet the definition of a purely presentational component (https://issues.folio.org/browse/STCOM-298), since it's coupled to `stripes-connect`. Its most logical new home is in `stripes-smart-components`.

https://issues.folio.org/browse/STCOM-330

## Approach
Used `git-subtree` to preserve as much git history for these files as possible from `stripes-components`.

## Next Steps
- [ ] Introduce deprecation warning in `stripes-components`
- [ ] Adjust imports in `folio-org` `ui-*` modules
- [ ] Remove `Settings` from `stripes-components` `v4.0.0` branch