### PR TITLE
STCOM-332 Move makeQueryFunction

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -25,7 +25,7 @@ import SRStatus from '@folio/stripes-components/lib/SRStatus';
 import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import SearchField from '@folio/stripes-components/lib/SearchField';
 import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
-import { mapNsKeys, getNsKey } from '@folio/stripes-components/util/nsQueryFunctions';
+import { mapNsKeys, getNsKey } from './nsQueryFunctions';
 import Notes from '../Notes';
 import Tags from '../Tags';
 import css from './SearchAndSort.css';

--- a/lib/SearchAndSort/index.js
+++ b/lib/SearchAndSort/index.js
@@ -1,1 +1,2 @@
 export { default } from './SearchAndSort';
+export { default as makeQueryFunction } from './makeQueryFunction';

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -1,5 +1,5 @@
 import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
-import { filters2cql } from '../lib/FilterGroups';
+import { filters2cql } from '@folio/stripes-components/lib/FilterGroups';
 import { removeNsKeys } from './nsQueryFunctions';
 
 // failOnCondition can take values:
@@ -27,7 +27,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
 
     // This check should remain '$QUERY' until all uses of the $QUERY syntax have been removed from stripes modules
     if (queryTemplate.includes('$QUERY')) {
-      // eslint-disable-next-line max-len
+      // eslint-disable-next-line
       console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution');
       queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}'); // eslint-disable-line no-param-reassign
     }

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -1,0 +1,84 @@
+import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
+import { filters2cql } from '../lib/FilterGroups';
+import { removeNsKeys } from './nsQueryFunctions';
+
+// failOnCondition can take values:
+//      0: do not fail even if query and filters and empty
+//      1: fail if query is empty, whatever the filter state
+//      2: fail if both query and filters and empty.
+//
+// For compatibility, false and true may be used for 0 and 1 respectively.
+//
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams) {
+  return (queryParams, pathComponents, resourceValues, logger) => {
+    const resourceQuery = removeNsKeys(resourceValues.query, nsParams);
+    const nsQueryParams = removeNsKeys(queryParams, nsParams);
+    const { qindex, filters, query, sort } = resourceQuery || {};
+
+    if ((query === undefined || query === '') &&
+        (failOnCondition === 1 || failOnCondition === true)) {
+      return null;
+    }
+    if ((query === undefined || query === '') &&
+        (filters === undefined || filters === '') &&
+        (failOnCondition === 2)) {
+      return null;
+    }
+
+    // This check should remain '$QUERY' until all uses of the $QUERY syntax have been removed from stripes modules
+    if (queryTemplate.includes('$QUERY')) {
+      // eslint-disable-next-line max-len
+      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution');
+      queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}'); // eslint-disable-line no-param-reassign
+    }
+
+    let cql;
+    if (query && qindex) {
+      const t = qindex.split('/', 2);
+      if (t.length === 1) {
+        cql = `${qindex}="${query}*"`;
+      } else {
+        cql = `${t[0]} =/${t[1]} "${query}*"`;
+      }
+    } else if (query) {
+      cql = compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: resourceQuery });
+      if (cql === null) {
+        // Some part of the template requires something that we don't have.
+        return null;
+      }
+    }
+
+    const filterCql = filters2cql(filterConfig, filters);
+    if (filterCql) {
+      if (cql) {
+        cql = `(${cql}) and ${filterCql}`;
+      } else {
+        cql = filterCql;
+      }
+    }
+
+    if (sort) {
+      const sortIndexes = sort.split(',').map((sort1) => {
+        let reverse = false;
+        if (sort1.startsWith('-')) {
+          sort1 = sort1.substr(1); // eslint-disable-line no-param-reassign
+          reverse = true;
+        }
+        let sortIndex = sortMap[sort1] || sort1;
+        if (reverse) {
+          sortIndex = sortIndex.replace(' ', '/sort.descending ') + '/sort.descending';
+        }
+        return sortIndex;
+      });
+
+      if (cql === undefined) cql = findAll;
+      cql = `(${cql}) sortby ${sortIndexes.join(' ')}`;
+    }
+
+    logger.log('mquery', `query='${query}' filters='${filters}' sort='${sort}' -> ${cql}`);
+
+    return cql;
+  };
+}
+
+export default makeQueryFunction;

--- a/lib/SearchAndSort/nsQueryFunctions.js
+++ b/lib/SearchAndSort/nsQueryFunctions.js
@@ -1,0 +1,46 @@
+import { isString, isObject, mapKeys, mapValues, transform } from 'lodash';
+
+// the list of allowed parameters to which the namespace will be added
+const PARAM_WHITELIST = { filters: 1, query: 1, sort: 1, qindex: 1 };
+
+export function getNsKey(key, params) {
+  if (!params || !PARAM_WHITELIST[key]) return key;
+  return (isString(params)) ? `${params}.${key}` : (params[key] || key);
+}
+
+// Adds namespace / prefix to keys in whitelist for given values object
+//
+// example:
+// values = { query: "test", filters: 'active', userId: 1 }, params = 'users'
+// result:
+// { "users.query" : "test", "users.filters": "active", userId: 1 }
+export function mapNsKeys(values, params) {
+  if (!params) return values;
+  return mapKeys(values, (value, key) => getNsKey(key, params));
+}
+
+// Removes namespace / prefix from keys for given values object
+//
+// example:
+// values = { "users.query" : "test", "users.filters": "active" }, params = 'users'
+// result:
+// { query: "test", filters: 'active' }
+export function removeNsKeys(values, params) {
+  if (!params) return values;
+
+  if (isObject(params)) {
+    return mapValues(params, value => values[value]);
+  }
+
+  if (isString(params)) {
+    const prefix = new RegExp(`^${params}\\.`, 'i');
+    return transform(values, (result, value, key) => {
+      if (key.match(prefix)) {
+        result[key.replace(prefix, '')] = value;
+      }
+      return result;
+    }, {});
+  }
+
+  return values;
+}

--- a/lib/SearchAndSort/parameterizing-makeQueryFunction.md
+++ b/lib/SearchAndSort/parameterizing-makeQueryFunction.md
@@ -1,0 +1,106 @@
+# Discussion point: parameterizing `makeQueryFunction`
+
+<!-- md2toc -l 2 parameterizing-makeQueryFunction.md -->
+* [Introduction](#introduction)
+    * [Motivation](#motivation)
+    * [Principles](#principles)
+* [Proposal](#proposal)
+* [Examples](#examples)
+    * [Code](#code)
+    * [URLs](#urls)
+* [Implications](#implications)
+
+
+## Introduction
+
+### Motivation
+
+UNAM (the National Autonomous University of Mexico) are adding functionality to the Users app to allow an administrator, once a user has been selected, to search within that user's fees and fines. To achieve this, they want to use the `<SearchAndSort>` high-level utility component and the associated function `makeQueryFunction`. However, this does not work because the URL query parameters that it uses -- `query`, `filters`, `sort` -- have already been set by the User app's own use of `<SearchAndSort>`.
+
+How can the UNAM team provide searching at this nested level within an app?
+
+
+### Principles
+
+It is widely agreed that utilities like `<SearchAndSort>` and `makeQueryFunction` should be as dumb as possible, not making assumptions about what parts of the URL query namespace they can use. Instead, callers of `makeQueryFunction` should specify at the time they call it which URL parameters it should use. (The same is true of `<SearchAndSort>`, but for simplicity this document will concentrate on `makeQueryFunction`.)
+
+
+## Proposal
+
+The simplest way to parameterize `makeQueryFunction` is to pass in a set of parameter names to use. As a short-cut, it should be possible simply to pass in a prefix, used to namespace the standard parameter names. Finally, when no parameter names or prefix are provided, the present behaviour should be retained, and the standard set of parameter names used. This will provide both backwards-compatibility in the API and a convenient shorthand for the common case of using this facility at the top-level of a UI module.
+
+I propose a single additional argument, `params`, which may be either a string which is used as a prefix, or an object whose keys are the standard parameters and whose corresponding values are the parameters to use in their roles.
+
+
+## Examples
+
+### Code
+
+The Users app presently uses `makeQueryFunction` at the top level to manage searching and sorting users. The function that it returns is installed as `manifest.records.GET.params.query`, and the invocation is as follows:
+
+```
+	makeQueryFunction(
+	  'cql.allRecords=1',
+	  '(username="%{query.query}*" or personal.firstName="%{query.query}*" or personal.lastName="%{query.query}*" or personal.email="%{query.query}*" or barcode="%{query.query}*" or id="%{query.query}*" or externalSystemId="%{query.query}*")',
+	  {
+	    'Active': 'active',
+	    'Name': 'personal.lastName personal.firstName',
+	    'Patron group': 'patronGroup.group',
+	    'Username': 'username',
+	    'Barcode': 'barcode',
+	    'Email': 'personal.email',
+	  },
+	  filterConfig,
+	  2,
+	)
+```
+The parameters are as follows:
+* Query to use for finding all records when no query-string is specified in the UI.
+* Query string template for when the query has been specified in the UI.
+* Sort-map, from column-header names to CQL sort-field names.
+* Filter configuration (see [**FilterGroups: Filter configuration**](../lib/FilterGroups/readme.md#filter-configuration)).
+* A specification that query-generation should fail when both the UI query and the filters are unspecified.
+
+To this, a sixth argument may be added, which might take any of the following values:
+
+* `null`: use the standard parameter as is presently the case.
+* `'users': prefix the names of the standard parameters with `users.`, so that they become `users.query`, `users.filters` and `users.sort`.
+* `{ query: 'users.query', filters: 'users.filters', sort: 'users.sort' }`: equivalent to the prefix, but specified explicitly.
+* `{ query: 'uq', filters: 'uf', sort: 'us' }`: use the more terser parameter names `uq`, `uf` and `us` in place of the standard parameters.
+
+Assuming that no such argument was provided in the Users app's top-level invocation of `makeQueryFunction`, the nested component that provides searching and sorting of fees and fines might invoke along these lines for its own manifest:
+
+```
+	makeQueryFunction(
+	  'cql.allRecords=1',
+	  'feeFineType="%{query.query}*"',
+	  {
+	    'Amount': 'defaultAmount',
+	    'VAT%': 'taxVat',
+	  },
+	  filterConfig,
+	  0,
+	  'fees'
+	)
+```
+
+### URLs
+
+The setup outlined above would cause the parameter `fees.query`, `fees.filters` and `fees.sort` to be used for generating the relevant queries. These could co-exist in the URL along with the corresponding parameters as used by the top-level application, yielding URLs such as
+
+	http://demo.folio.org/users/view/123/feesfines?query=smith&filters=active.Active&fees.query=overdue
+
+It would be a matter for application designers to decide when to retain all of a URL's query parameters, and when to discard some: for example, in some situations it may be desirable when generating the URL for a fees-and-fines page to discard the information about the user search. In this case, the URL would simply be:
+
+	http://demo.folio.org/users/view/123/feesfines?fees.query=overdue
+
+(The information about which user the listed fees and fines are for is held in the URL path, not a parameter: it is the user-ID `123`.)
+
+
+## Implications
+
+A similar configurability facility would also need to be added to the `<SearchAndSort>` component, which sets the URL query parameters that `makeQueryFunction` reads. The principles are the same as outlined here.
+
+This issue is not limited to `<SearchAndSort>` and `makeQueryFunction`, but also bleeds over into `<FilterGroups>` and any other components and utility functions in stripes-components that have unfettered access to the URL.
+
+

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -46,3 +46,38 @@ notLoadedMessage | string | A message to show the user before a search has been 
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 
+## makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition)
+
+Makes and returns a function, suitable to be used as the `query` param of a stripes-connect resource configuration. The function is itself configured by five parameters, which will vary depending on the module that is using it, and will use these to determine how to interpret the query, filters and sort-specification in the application state. It is generally used as follows:
+```
+static manifest = Object.freeze({
+  items: {
+    type: 'okapi',
+    records: 'items',
+    path: 'item-storage/items',
+    params: {
+      query: makeQueryFunction(
+        'cql.allRecords=1',
+        'materialType="${query}" or barcode="${query}*" or title="${query}*"',
+        { 'Material Type': 'materialType' },
+        filterConfig,
+        2
+      ),
+    },
+    staticFallback: { params: {} },
+  },
+});
+```
+
+The five parameters are:
+
+* `findAll` -- a CQL string that can be used to find all records, for situations where no query or filters are specified and the application wants all records to be listed.
+* `queryTemplate` -- a CQL string into which the query and other data can be substituted, using the same syntax as [path substitution in stripes-connect](https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution): for example, `?{query}` interpolates the `query` parameter from the URL.
+* `sortMap` -- an object mapping the names of columns in the display to the CQL sort-specifiers that they should invoke when clicked on.
+* `filterConfig` -- the configuration of the application's filter as passed to [the `<FilterGroups>` component](../lib/FilterGroups/readme.md#filter-configuration).
+* `failOnCondition` -- an optional indicator of how to behave when no query and/or filters are provided. Can take the following values:
+  * `0`: do not fail even if query and filters and empty
+  * `1`: fail if query is empty, whatever the filter state
+  * `2`: fail if both query and filters and empty.
+
+  For backwards compatibility, `false` (or omitting the argument altogether) is equivalent to `0` , and `true` is equivalent to `1`.


### PR DESCRIPTION
## Purpose
`makeQueryFunction` doesn't meet the definition of a purely presentational component (https://issues.folio.org/browse/STCOM-298), since it's coupled to `stripes-connect` (and thus requires a redux store). Its most logical new home is in `stripes-smart-components`, with `SearchAndSort`. `makeQueryFunction`'s sibling `nsQueryFunctions` tagged along. Also includes readme and documentation moves.

https://issues.folio.org/browse/STCOM-332

## Approach
Used `git-subtree` to preserve as much git history for these files as possible from `stripes-components`. The commit history didn't come out quite as clean on this one, since I had to grab the whole `stripes-components/util` directory and whittle it down.

## Next Steps
- [ ] Introduce deprecation warning in `stripes-components`
- [ ] Adjust imports in `folio-org` `ui-*` modules
- [ ] Remove `makeQueryFunction` and `nsQueryFunctions` from `stripes-components` `v4.0.0` branch