### PR TITLE
Clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,29 +72,29 @@
     ]
   },
   "scripts": {
-    "lint": "eslint ./",
-    "eslint": "eslint ./",
+    "lint": "eslint .",
+    "eslint": "eslint .",
     "stylelint": "stylelint \"lib/**/*.css\"",
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^3.0.0",
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^8.2.6",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
+    "@folio/eslint-config-stripes": "^3.2.0",
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.5.0",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0",
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0",
-    "webpack": "1.11.0"
+    "webpack": "^4.10.2"
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-core": "^2.10.2",
     "@folio/stripes-form": "^0.8.2",
+    "classnames": "^2.2.6",
     "lodash": "^4.17.4",
     "moment": "^2.22.1",
     "moment-timezone": "^0.5.17",
@@ -104,6 +104,7 @@
     "react-intl": "^2.4.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",
+    "react-transition-group": "^2.4.0",
     "redux-form": "^7.0.3",
     "tai-password-strength": "^1.1.1"
   },


### PR DESCRIPTION
`yarn install` now only throws a single warning, instead of several dozen:
```
warning @folio/stripes-components > @folio/stripes-connect > @folio/stripes-core > hard-source-webpack-plugin > jsonlint > nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.
```