### PR TITLE
Fixed SearchAndSort row URL creation for subapps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0 (IN PROGRESS)
 
 * Use `MultiSelection` for tags. Part of STSMACOM-113.
+* Fixed `SearchAndSort` row URL creation for subapps (e.g., `/finance/funds`).
 
 ## [1.5.0](https://github.com/folio-org/stripes-smart-components/tree/v1.5.0) (2018-09-05)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.4.0...v1.5.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -344,8 +344,7 @@ class SearchAndSort extends React.Component {
   }
 
   getRowURL(id) {
-    const first = this.props.location.pathname.split('/')[1];
-    return `/${first}/view/${id}${this.props.location.search}`;
+    return `${this.props.match.path}/view/${id}${this.props.location.search}`;
   }
 
   addNewRecord = (e) => {


### PR DESCRIPTION
Previously, the row URL created while on a page like `/finance/funds` or `/finance/ledgers` would be `/finance/view/123` for both of them and thus fail to render the correct thing when right-click-open-in-new-tabbing.

This uses the matched part of the path of the SAS's parent which should always be the full route to the app/subapp but it won't include the `/view/1234` part of the path because that's a nested child route.