### PR TITLE
Update to new stripes-components and stripes-form releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,9 +91,9 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "^3.0.0",
+    "@folio/stripes-components": "^3.1.0",
     "@folio/stripes-core": "^2.10.2",
-    "@folio/stripes-form": "^0.8.2",
+    "@folio/stripes-form": "^0.9.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.4",
     "moment": "^2.22.1",


### PR DESCRIPTION
Should help cut down on these warnings:
```
warning "@folio/stripes-smart-components > @folio/stripes-form@0.8.2" has unmet peer dependency "stripes-core@^2.7.0".
warning "@folio/stripes-smart-components > @folio/stripes-form > @folio/stripes-components@2.0.0" has unmet peer dependency "stripes-core@^2.7.0".
warning "@folio/stripes-smart-components > @folio/stripes-form > @folio/stripes-components > @storybook/addon-knobs@3.4.10" has unmet peer dependency "@storybook/addons@^3.3.0".
warning "@folio/stripes-smart-components > @folio/stripes-form > @folio/stripes-components > @storybook/addon-actions@3.4.10" has unmet peer dependency "@storybook/addons@^3.3.0".
```

`stripes-form@0.8.2` was still requesting `stripes-components@2`.