### PR TITLE
use current stripes-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.8.0 (IN PROGRESS)
+
+* Update to stripes-form 0.9.0. Refs STRIPES-555.
+
 ## [1.7.1](https://github.com/folio-org/stripes-smart-components/tree/v1.7.1) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.7.0...v1.7.1)
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-core": "^2.10.2",
-    "@folio/stripes-form": "^0.8.2",
+    "@folio/stripes-form": "^0.9.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.4",
     "moment": "^2.22.1",


### PR DESCRIPTION
Because stripes-form has not been released as a v1.0.x package,
this means ^0.8.0 is effectively ~0.8.0, meaning those packages
are locked at 0.8.x, not 0.x.x as intended. stripes-form 0.8.0
pulled in an old version of stripes-components which pulled in
an old version of React which brought darkness upon the land.

Refs [STRIPES-555](https://issues.folio.org/browse/STRIPES-555)