### PR TITLE
Adjust lodash imports

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import has from 'lodash/has';
 
 import { Field } from 'redux-form';
 import stripesForm from '@folio/stripes-form';
@@ -112,7 +112,7 @@ const AddressEdit = (props) => {
   let rowArray = [];
 
   visibleFields.forEach((field, i) => {
-    const fieldLabel = _.has(labelMap, field) ? labelMap[field] : field;
+    const fieldLabel = has(labelMap, field) ? labelMap[field] : field;
     const componentData = mergedFieldComponents[field];
     let component = componentData;
     let compProps = {};

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
-import _ from 'lodash';
+import take from 'lodash/take';
+import uniqueId from 'lodash/uniqueId';
 
 import injectIntl from '@folio/stripes-components/lib/InjectIntl';
 import Button from '@folio/stripes-components/lib/Button';
@@ -188,7 +189,7 @@ class AddressList extends React.Component {
   handleAddNew() {
     this.setState(prevState => {
       const newAdds = prevState.newAddresses;
-      const newUiId = _.uniqueId();
+      const newUiId = uniqueId();
       newAdds.push(newUiId);
       return {
         newAddresses: newAdds,
@@ -247,7 +248,7 @@ class AddressList extends React.Component {
     } = this.props;
 
     const canToggleExpansion = (addresses.length > 1);
-    const filteredAddresses = (this.state.expanded) ? addresses : _.take(addresses, 1);
+    const filteredAddresses = (this.state.expanded) ? addresses : take(addresses, 1);
     const addressBlocks = filteredAddresses.map((ad) => {
       if (this.state.editting.indexOf(ad[uniqueField]) === -1) {
         return (

--- a/lib/EditableList/EditableList.js
+++ b/lib/EditableList/EditableList.js
@@ -1,6 +1,6 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import sortBy from 'lodash/sortBy';
 import EditableListForm from './EditableListForm';
 
 const propTypes = {
@@ -44,7 +44,7 @@ const defaultProps = {
 
 const EditableList = (props) => {
   const { contentData, nameKey } = props;
-  const items = _.sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
+  const items = sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
   return (<EditableListForm initialValues={{ items }} {...props} />);
 };
 

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -9,6 +8,8 @@ import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Layer from '@folio/stripes-components/lib/Layer';
 import queryString from 'query-string';
+import isFunction from 'lodash/isFunction';
+import find from 'lodash/find';
 
 import EntryForm from './EntryForm';
 
@@ -26,7 +27,7 @@ class EntryWrapper extends React.Component {
     }).isRequired,
     entryFormComponent: PropTypes.func,
     formComponent: (props, propName) => {
-      if (!_.isFunction(props.entryFormComponent) && !_.isFunction(props[propName])) {
+      if (!isFunction(props.entryFormComponent) && !isFunction(props[propName])) {
         return new Error('`entryFormComponent` or `formComponent` prop is isRequired');
       }
       return null;
@@ -143,7 +144,7 @@ class EntryWrapper extends React.Component {
     const baseId = entryLabel.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
 
     const selectedItem = (this.state.selectedId)
-      ? _.find(entryList, entry => entry.id === this.state.selectedId) : defaultEntry;
+      ? find(entryList, entry => entry.id === this.state.selectedId) : defaultEntry;
 
     const container = document.getElementById('ModuleContainer');
     if (!container) return (<div />);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -2,7 +2,6 @@
 
 // NOTE: modules using this with react-apollo MUST set errorPolicy: 'all' for Apollo.
 
-import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
@@ -12,6 +11,7 @@ import { stripesShape } from '@folio/stripes-core/src/Stripes';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import queryString from 'query-string';
+import { debounce, get, upperFirst } from 'lodash';
 import FilterGroups, { filterState, handleFilterChange, handleFilterClear } from '@folio/stripes-components/lib/FilterGroups';
 import { Accordion, FilterAccordionHeader } from '@folio/stripes-components/lib/Accordion';
 import Pane from '@folio/stripes-components/lib/Pane';
@@ -196,7 +196,7 @@ class SearchAndSort extends React.Component {
 
     this.craftLayerUrl = craftLayerUrl.bind(this);
 
-    const initialPath = (_.get(props.packageInfo, ['stripes', 'home']) || _.get(props.packageInfo, ['stripes', 'route']));
+    const initialPath = (get(props.packageInfo, ['stripes', 'home']) || get(props.packageInfo, ['stripes', 'route']));
     const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
       initialPath.substr(initialPath.indexOf('?') + 1);
     const initialQuery = queryString.parse(initialSearch);
@@ -391,7 +391,7 @@ class SearchAndSort extends React.Component {
   }
 
   // eslint-disable-next-line react/sort-comp
-  performSearch = _.debounce((query) => {
+  performSearch = debounce((query) => {
     this.props.parentMutator.resultCount.replace(this.props.initialResultCount);
     this.log('action', `searched for '${query}'`);
     this.transitionToParams({ query });
@@ -400,7 +400,7 @@ class SearchAndSort extends React.Component {
   queryParam(name) {
     const { parentResources, nsParams } = this.props;
     const nsKey = getNsKey(name, nsParams);
-    return _.get(parentResources.query, nsKey);
+    return get(parentResources.query, nsKey);
   }
 
   toggleFilterPane = () => {
@@ -468,7 +468,7 @@ class SearchAndSort extends React.Component {
     const { locallyChangedSearchTerm } = this.state;
     const source = makeConnectedSource(this.props, stripes.logger);
     const urlQuery = queryString.parse(this.props.location.search || '');
-    const objectNameUC = _.upperFirst(objectName);
+    const objectNameUC = upperFirst(objectName);
     const records = source.records();
     const searchTerm = (locallyChangedSearchTerm !== undefined) ? locallyChangedSearchTerm : (this.queryParam('query') || '');
     const searchIndex = this.queryParam('qindex') || '';


### PR DESCRIPTION
## Purpose
Lodash is notorious for delivering way more code to the bundle than might actually be needed.

## Approach
We should avoid importing all of lodash. Both of these are better options:
```
import get from 'lodash/get';
```
or 
```
import { get } from 'lodash';
```

I haven't confirmed that the second option above appropriately tree-shakes. The first is optimal with our stack.

## Learning
- https://www.blazemeter.com/blog/the-correct-way-to-import-lodash-libraries-a-benchmark
- https://stackoverflow.com/questions/35250500/correct-way-to-import-lodash