### PR TITLE
STCOM-339: Update 'searchResultsCountHeader' to use sentence casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ## 1.9.0 (IN PROGRESS) 
 * Fix tags autosuggest subsort. Fixes STSMACOM-123.
+* Updated localized string "searchResultsCountHeader" to use sentence casing. (STCOM-339)
 
 ## [1.8.0](https://github.com/folio-org/stripes-smart-components/tree/v1.8.0) (2018-09-17)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.7.1...v1.8.0)

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -71,7 +71,7 @@
   "permissionsDoNotAllowAccess": "Sorry - your permissions do not allow access to this page.",
   "searchResults": "{objectName} search results",
   "searchReturnedResults": "Search returned {count, number} {count, plural, one {result} other {results}}",
-  "searchResultsCountHeader": "{count, number} {count, plural, one {Record found} other {Records found}}",
+  "searchResultsCountHeader": "{count, number} {count, plural, one {record found} other {records found}}",
   "resetAll": "Reset all",
   "whoAreYouActingAs": "Who are you acting as?",
   "self": "Self",


### PR DESCRIPTION
Updated localized string 'searchResultsCountHeader' to use sentence casing.

Issue: https://issues.folio.org/browse/STCOM-339