### PR TITLE
make stripes-core a peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.7.3 (IN PROGRESS)
+
+* stripes-core should be a peerDependency. Refs STRIPES-557.
+
 ## [1.7.2](https://github.com/folio-org/stripes-smart-components/tree/v1.7.2) (2018-09-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.7.1...v1.7.2)
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.0",
+    "@folio/stripes-core": "^2.10.2",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
     "react": "^16.5.0",
@@ -92,7 +93,6 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "^3.0.0",
-    "@folio/stripes-core": "^2.10.2",
     "@folio/stripes-form": "^0.9.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.4",
@@ -110,6 +110,7 @@
   },
   "peerDependencies": {
     "@folio/stripes-connect": "^3.1.2",
+    "@folio/stripes-core": "^2.10.2",
     "@folio/stripes-logger": "^0.0.2",
     "react": "*"
   }


### PR DESCRIPTION
stripes-core must be a peerDependency so it is included once per bundle.
Listing it as a regular dependency means it may be nested, rather than
hoisted, which can lead to multiple versions, but separate versions will
have separate instances of context, resulting in context-consumers that
can't see the context offered by the context-providers they are trying
to subscribe too.

Refs [STRIPES-557](https://issues.folio.org/browse/STRIPES-557)