### PR TITLE
Add stripes-core to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.0",
+    "@folio/stripes-core": "^2.13.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
     "react": "^16.5.0",


### PR DESCRIPTION
I noticed `eslint` errors popping up on some PRs. `stripes-core` will need to also be a `devDependency` for `eslint` to resolve the imports.