### PR TITLE
use limit=100 as max limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.7.4 (IN PROGRESS)
+
+* Use 100, not 500, as max limit value due RAML regression. Refs FOLIO-1517.
+
 ## [1.7.3](https://github.com/folio-org/stripes-smart-components/tree/v1.7.3) (2018-09-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.7.2...v1.7.3)
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -31,7 +31,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=500'
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=100'
       }
     },
     activeRecord: {},


### PR DESCRIPTION
Due to a regression in RAML from 0.8 to 1.0, the max limit was changed
to 100. So ... we'll respect that.

Refs FOLIO-1517