### PR TITLE
Use upstream injectIntl()

### DIFF
--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import take from 'lodash/take';
 import uniqueId from 'lodash/uniqueId';
 
-import injectIntl from '@folio/stripes-components/lib/InjectIntl';
 import { Button, Col, Headline, Icon, Layout, Row } from '@folio/stripes-components';
 import AddressView from '../AddressView';
 import AddressEdit from '../AddressEdit';

--- a/lib/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/AddressFieldGroup/AddressView/AddressView.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { intlShape } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import { has } from 'lodash';
 
-import injectIntl from '@folio/stripes-components/lib/InjectIntl';
 import { Col, KeyValue, LayoutHeader, Row } from '@folio/stripes-components';
 import css from './AddressView.css';
 

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -2,12 +2,11 @@ import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import React from 'react';
-import { intlShape } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
 
-import injectIntl from '@folio/stripes-components/lib/InjectIntl';
 import { Button, Col, Headline, IconButton, MultiColumnList, Row } from '@folio/stripes-components';
 import EditableItem from './EditableItem';
 import css from './EditableList.css';

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape } from 'react-intl';
-import injectIntl from '@folio/stripes-components/lib/InjectIntl';
+import { injectIntl, intlShape } from 'react-intl';
 import { Modal } from '@folio/stripes-components';
 import ProxyForm from './ProxyForm';
 


### PR DESCRIPTION
The `stripes-components` [`injectIntl()`](https://github.com/folio-org/stripes-components/tree/master/lib/InjectIntl) was only intended to fix issues with React 16.3+ ref forwarding. It does not appear to be needed for any of these components - instead we can use the upstream `react-intl` version of `injectIntl()`.