### PR TITLE
Turn on stylelint in CI

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,19 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "selector-pseudo-class-no-unknown": [true, {
+      "ignorePseudoClasses": [
+        "export",
+        "import",
+        "global",
+        "local"
+      ]
+    }],
+    "property-no-unknown": [ true, {
+      "ignoreProperties": [
+        "composes",
+        "compose-with"
+      ],
+    }],
+  }
 }

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -79,18 +79,6 @@
 .addressHeaderActions {
   margin: 0 0 0 auto; /* align to end of header */
   padding: 4px 0;
-
-  & button {
-    &:hover {
-      & :global .stripes__icon {
-        fill: #333;
-      }
-    }
-
-    & :global .stripes__icon {
-      transition: fill 0.3s;
-    }
-  }
 }
 
 .addressLabel {

--- a/lib/PasswordStrength/PasswordSrength.css
+++ b/lib/PasswordStrength/PasswordSrength.css
@@ -22,31 +22,31 @@
 }
 
 .indicator__container--veryStrong {
-& > .indicator__item:nth-child(-n + 5) {
+  & > .indicator__item:nth-child(-n + 5) {
     background-color: #3b872d;
   }
 }
 
 .indicator__container--strong {
-& > .indicator__item:nth-child(-n + 4) {
+  & > .indicator__item:nth-child(-n + 4) {
     background-color: #90c128;
   }
 }
 
 .indicator__container--reasonable {
-& > .indicator__item:nth-child(-n + 3) {
+  & > .indicator__item:nth-child(-n + 3) {
     background-color: #efce00;
   }
 }
 
 .indicator__container--weak {
-& > .indicator__item:nth-child(-n + 2) {
+  & > .indicator__item:nth-child(-n + 2) {
     background-color: #dd8100;
   }
 }
 
 .indicator__container--veryWeak {
-& > .indicator__item:nth-child(-n + 1) {
+  & > .indicator__item:nth-child(-n + 1) {
     background-color: #cf261c;
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     ]
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . && stylelint \"lib/**/*.css\"",
     "eslint": "eslint .",
     "stylelint": "stylelint \"lib/**/*.css\"",
     "test": "echo 'placeholder. no tests implemented'"


### PR DESCRIPTION
Removes address field group delete hover state for now - it was a tricky `no-descending-specificity` violation with some `global` business that probably shouldn't happen.