### PR TITLE
Update stripes-logger peer dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "peerDependencies": {
     "@folio/stripes-connect": "^3.1.2",
     "@folio/stripes-core": "^2.13.0",
-    "@folio/stripes-logger": "^0.0.2",
+    "@folio/stripes-logger": "^1.0.0",
     "react": "*"
   }
 }


### PR DESCRIPTION
Cleans up
```
warning " > @folio/stripes-smart-components@1.8.3" has incorrect peer dependency "@folio/stripes-logger@^0.0.2".
```