### PR TITLE
Introduce getHelperResourcePath prop. Fixes STSMACOM-131 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.9.0 (IN PROGRESS)
+
+* Introduce `getHelperResourcePath` prop. Fixes STSMACOM-131.
+
 ## [1.8.3](https://github.com/folio-org/stripes-smart-components/tree/v1.8.3) (2018-09-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.8.0...v1.8.3)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -72,6 +72,7 @@ class SearchAndSort extends React.Component {
     resultCountMessageKey: PropTypes.string,
     viewRecordComponent: PropTypes.func.isRequired,
     editRecordComponent: PropTypes.func,
+    getHelperResourcePath: PropTypes.func,
     newRecordInitialValues: PropTypes.object,
     visibleColumns: PropTypes.arrayOf(
       PropTypes.string,
@@ -447,7 +448,7 @@ class SearchAndSort extends React.Component {
   }
 
   renderHelperApp() {
-    const { stripes, match } = this.props;
+    const { stripes, match, getHelperResourcePath } = this.props;
     const moduleName = this.getModuleName();
     const helper = this.queryParam('helper');
     const HelperAppComponent = this.helperApps[helper];
@@ -456,12 +457,19 @@ class SearchAndSort extends React.Component {
       helper &&
       <Route
         path={`${match.path}/view/:id`}
-        render={props => <HelperAppComponent
-          stripes={stripes}
-          onToggle={() => this.toggleHelperApp(helper)}
-          link={`${moduleName}/${props.match.params.id}`}
-          {...props}
-        />}
+        render={props => {
+          const link = (getHelperResourcePath) ?
+            getHelperResourcePath(helper, props.match.params.id) :
+            `${moduleName}/${props.match.params.id}`;
+          return (
+            <HelperAppComponent
+              stripes={stripes}
+              onToggle={() => this.toggleHelperApp(helper)}
+              link={link}
+              {...props}
+            />
+          );
+        }}
       />
     );
   }

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -43,6 +43,7 @@ parentResources | shape | The parent component's stripes-connect `resources` pro
 parentMutator | shape | The parent component's stripes-connect `mutator` property. Must contain at least `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
 nsParams | object or string | An object or string used to namespace search and sort parameters. More information can be found [here](https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md)
 notLoadedMessage | string | A message to show the user before a search has been submitted. Defaults to "Choose a filter or enter search query to show results".
+getHelperResourcePath | func | An optional function which can be used to return helper's resource path dynamically.
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-131

This PR introduces a new prop called `getHelperResourcePath` which can be used to resolve helper's resource path dynamically. 

example usage:

````js
<SearchAndSort 
   getHelperResourcePath={(helper, id) => `finance/ledger/${id}`} 
   ...
 />
````

