### PR TITLE
Copy craftLayerUrl into SearchAndSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change history for stripes-smart-components
 
+## 1.10.0 (IN PROGRESS)
+
+* Copy `craftLayerUrl()` into `<SearchAndSort>`
+
 ## [1.9.0](https://github.com/folio-org/stripes-smart-components/tree/v1.9.0) (2018-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.8.3...v1.9.0)
 
 * Introduce `getHelperResourcePath` prop. Fixes STSMACOM-131.
 * Remove notes helper app from `<SearchAndSort>`
 * Move `stripes-form` to dependencies
-
 
 ## [1.8.3](https://github.com/folio-org/stripes-smart-components/tree/v1.8.3) (2018-09-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.8.0...v1.8.3)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -11,7 +11,7 @@ import { stripesShape } from '@folio/stripes-core/src/Stripes';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core';
 import queryString from 'query-string';
-import { debounce, get, upperFirst } from 'lodash';
+import { debounce, get, includes, upperFirst } from 'lodash';
 import FilterGroups, {
   filterState,
   handleFilterChange,
@@ -31,7 +31,6 @@ import {
   SearchField,
   SRStatus
 } from '@folio/stripes-components';
-import craftLayerUrl from '@folio/stripes-components/util/craftLayerUrl';
 import { mapNsKeys, getNsKey } from './nsQueryFunctions';
 import Tags from '../Tags';
 import css from './SearchAndSort.css';
@@ -186,8 +185,6 @@ class SearchAndSort extends React.Component {
     this.SRStatus = null;
     this.lastNonNullReaultCount = undefined;
 
-    this.craftLayerUrl = craftLayerUrl.bind(this);
-
     const initialPath = (get(props.packageInfo, ['stripes', 'home']) || get(props.packageInfo, ['stripes', 'route']));
     const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
       initialPath.substr(initialPath.indexOf('?') + 1);
@@ -243,6 +240,11 @@ class SearchAndSort extends React.Component {
     if (this.props.onComponentWillUnmount) {
       this.props.onComponentWillUnmount(this.props);
     }
+  }
+
+  craftLayerUrl = (mode) => {
+    const url = this.props.location.pathname + this.props.location.search;
+    return includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
   }
 
   onChangeFilter = (e) => {


### PR DESCRIPTION
`craftLayerUrl()` assists with `<SearchAndSort>`'s routing, and will be deprecated for any other use (modules should define their own routes, instead of relying on `<SearchAndSort>` to do it for them).