### PR TITLE
Only use font-size variables

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -7,7 +7,7 @@
 .legend {
   display: block;
   width: 100%;
-  font-size: 21px;
+  font-size: var(--font-size-large);
   color: #333;
   border: 0;
   margin-bottom: 6px;
@@ -16,7 +16,7 @@
 
 .subLegend {
   composes: legend;
-  font-size: 18px;
+  font-size: var(--font-size-medium);
   color: #777;
 }
 
@@ -82,7 +82,7 @@
 }
 
 .addressLabel {
-  font-weight: bold;
+  font-weight: var(--text-weight-headline-basis);
 }
 
 .addressFormBody {
@@ -94,7 +94,7 @@
 .primaryToggle {
   padding: 4px 8px;
   color: #555;
-  font-size: 12px;
+  font-size: var(--font-size-small);
   cursor: pointer;
   margin-bottom: 0;
 

--- a/lib/PasswordStrength/PasswordSrength.css
+++ b/lib/PasswordStrength/PasswordSrength.css
@@ -1,5 +1,7 @@
+@import '@folio/stripes-components/lib/variables';
+
 .password-strength__label {
-  font-size: 12px;
+  font-size: var(--font-size-small);
 }
 
 .password-strength-text__wrapper {

--- a/lib/ProxyManager/ProxyForm.css
+++ b/lib/ProxyManager/ProxyForm.css
@@ -1,3 +1,5 @@
+@import '@folio/stripes-components/lib/variables';
+
 .label {
   margin-left: 6px;
 }
@@ -10,5 +12,5 @@ input[disabled] {
   margin-top: 1px;
   margin-left: 24px;
   color: #f00;
-  font-size: 12px;
+  font-size: var(--font-size-small);
 }

--- a/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.css
+++ b/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.css
@@ -25,7 +25,7 @@
 }
 
 .noResultsMessageLabelWrap {
-  font-size: 22px;
+  font-size: var(--font-size-large);
 }
 
 .noResultsMessageIcon,


### PR DESCRIPTION
Updates every `font-size` declaration to use the `font-size-*` variables defined in `stripes-components`.