### PR TITLE
Changed null components to satisfy proptypes

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -492,7 +492,7 @@ class SearchAndSort extends React.Component {
       app: moduleName,
     };
 
-    const newRecordButton = !newRecordPerms ? '' : (
+    const newRecordButton = !newRecordPerms ? null : (
       <IfPermission perm={newRecordPerms}>
         <PaneMenu>
           <Button


### PR DESCRIPTION
`Pane` and `PaneHeader` threw errors because they expect a React Component, which an empty string is not.