### PR TITLE
STCOR-267 Use react-intl formatTime instead of stripes.formatDateTime

### DIFF
--- a/lib/LoanList/LoanList.js
+++ b/lib/LoanList/LoanList.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import { injectIntl, intlShape } from 'react-intl';
 import { Checkbox, MultiColumnList } from '@folio/stripes-components';
 
 const propTypes = {
   alerts: PropTypes.object,
   allowSelection: PropTypes.bool,
   height: PropTypes.number,
+  intl: intlShape,
   loans: PropTypes.arrayOf(
     PropTypes.shape({
       dueDate: PropTypes.string,
@@ -18,15 +20,9 @@ const propTypes = {
   loanSelection: PropTypes.object,
   onToggleBulkLoanSelection: PropTypes.func,
   onToggleLoanSelection: PropTypes.func,
-  resources: PropTypes.shape({ // eslint-disable-line
+  resources: PropTypes.shape({
     loanPolicies: PropTypes.object,
-  }),
-  stripes: PropTypes.shape({
-    formatDateTime: PropTypes.func.isRequired,
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired,
-    }),
-  }),
+  })
 };
 
 const defaultProps = {
@@ -44,8 +40,7 @@ const manifest = {
 };
 
 const LoanList = (props) => {
-  const { formatMessage } = props.stripes.intl;
-  const { stripes, loanSelection, onToggleLoanSelection } = props;
+  const { intl: { formatMessage, formatTime }, loanSelection, onToggleLoanSelection } = props;
 
   const visibleColumns = [
     'alertDetails',
@@ -90,7 +85,7 @@ const LoanList = (props) => {
         alertDetails: loan => props.alerts[loan.id] || '',
         title: loan => get(loan, ['item', 'title']),
         itemStatus: loan => get(loan, ['item', 'status', 'name']),
-        currentDueDate: loan => stripes.formatDateTime(get(loan, ['dueDate'])),
+        currentDueDate: loan => formatTime(get(loan, ['dueDate'], { day: 'numeric', month: 'numeric', year: 'numeric' })),
         requestQueue: () => 'N/A',
         barcode: loan => get(loan, ['item', 'barcode']),
         callNumber: loan => get(loan, ['item', 'callNumber']),
@@ -112,4 +107,4 @@ LoanList.defaultProps = defaultProps;
 LoanList.propTypes = propTypes;
 LoanList.manifest = manifest;
 
-export default LoanList;
+export default injectIntl(LoanList);


### PR DESCRIPTION
We can use `react-intl`'s `formatTime()` with options to show a date instead of the soon-to-be-deprecated `formatDateTime()` on the `stripes` god object.