### PR TITLE
STCOR-267 Use react-intl directly instead of stripes.intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add clone option to `EntryManager`. Fixes STSMACOM-134.
 * Add ability to pass custom add menu component to `EntryManager`. Fixes STSMACOM-136.
+* Use react-intl directly instead of stripes.intl
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -238,7 +238,7 @@ class AddressList extends React.Component {
       canDelete,
       canEdit,
       headerFormatter,
-      intl,
+      intl: { formatMessage },
       ...viewProps
     } = this.props;
 
@@ -305,7 +305,7 @@ class AddressList extends React.Component {
         <Headline tag="h4" size="medium">{label}</Headline>
         {addAddressButton}
         <div
-          aria-label={intl.formatMessage({ id: 'stripes-components.addressSection' })}
+          aria-label={formatMessage({ id: 'stripes-components.addressSection' })}
           tabIndex="0"
           role="tabpanel"
           ref={(ref) => { this.container = ref; }}

--- a/lib/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/AddressFieldGroup/AddressView/AddressView.js
@@ -40,17 +40,17 @@ function AddressView(props) {
     uiId,
     visibleFields,
     headerFormatter,
-    intl
+    intl: { formatMessage }
   } = props;
 
   const defaultLabelMap = {
-    addressLine1: intl.formatMessage({ id: 'stripes-components.addressLine1' }),
-    addressLine2: intl.formatMessage({ id: 'stripes-components.addressLine2' }),
-    stateRegion: intl.formatMessage({ id: 'stripes-components.stateProviceOrRegion' }),
-    zipCode: intl.formatMessage({ id: 'stripes-components.zipOrPostalCode' }),
-    addressType: intl.formatMessage({ id: 'stripes-components.addressType' }),
-    city: intl.formatMessage({ id: 'stripes-components.city' }),
-    country: intl.formatMessage({ id: 'stripes-components.country' }),
+    addressLine1: formatMessage({ id: 'stripes-components.addressLine1' }),
+    addressLine2: formatMessage({ id: 'stripes-components.addressLine2' }),
+    stateRegion: formatMessage({ id: 'stripes-components.stateProviceOrRegion' }),
+    zipCode: formatMessage({ id: 'stripes-components.zipOrPostalCode' }),
+    addressType: formatMessage({ id: 'stripes-components.addressType' }),
+    city: formatMessage({ id: 'stripes-components.city' }),
+    country: formatMessage({ id: 'stripes-components.country' }),
   };
   const labelMap = props.labelMap || defaultLabelMap;
   const groupArray = [];
@@ -73,12 +73,12 @@ function AddressView(props) {
   }, this);
 
   const actions = [{
-    title: intl.formatMessage({ id: 'stripes-components.editThisAddress' }),
+    title: formatMessage({ id: 'stripes-components.editThisAddress' }),
     icon: 'edit',
     handler: () => handleEdit(uiId)
   }];
-  const primaryAddressMsg = intl.formatMessage({ id: 'stripes-components.primaryAddress' });
-  const alternateAddressMsg = intl.formatMessage({ id: 'stripes-components.alternateAddress' });
+  const primaryAddressMsg = formatMessage({ id: 'stripes-components.primaryAddress' });
+  const alternateAddressMsg = formatMessage({ id: 'stripes-components.alternateAddress' });
 
   return (
     <div

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, isEqual, pickBy } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import moment from 'moment';
 
 import { Button, Icon, Layout } from '@folio/stripes-components';
@@ -67,6 +67,7 @@ class ChangeDueDate extends React.Component {
 
   static propTypes = {
     alerts: PropTypes.object,
+    intl: intlShape,
     loans: PropTypes.arrayOf(
       PropTypes.shape({
         dueDate: PropTypes.string,
@@ -96,10 +97,7 @@ class ChangeDueDate extends React.Component {
       }),
     }).isRequired,
     stripes: PropTypes.shape({
-      connect: PropTypes.func,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func,
-      }),
+      connect: PropTypes.func
     }),
     user: PropTypes.shape({ // eslint-disable-line
       id: PropTypes.string.isRequired,
@@ -163,6 +161,7 @@ class ChangeDueDate extends React.Component {
   }
 
   changeDueDate() {
+    const { intl: { formatMessage } } = this.props;
     const loans = this.getUpdatedLoans();
 
     const promises = loans
@@ -179,7 +178,7 @@ class ChangeDueDate extends React.Component {
         if (error.url && error.url.indexOf(putEndpoint)) {
           const failedLoan = error.url.split(putEndpoint)[1];
           this.props.onDueDateChangeFailed({
-            [failedLoan]: this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.changeFailed' })
+            [failedLoan]: formatMessage({ id: 'stripes-smart-components.cddd.changeFailed' })
           });
         } else {
           this.props.onDueDateChangeFailed(error);
@@ -223,7 +222,7 @@ class ChangeDueDate extends React.Component {
   }
 
   render() {
-    const { loans, stripes } = this.props;
+    const { intl: { formatMessage }, loans } = this.props;
 
     if (!loans.length) return null;
 
@@ -250,8 +249,8 @@ class ChangeDueDate extends React.Component {
             date: '',
             time: ChangeDueDate.DEFAULT_TIME,
           }}
-          dateProps={{ label: stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.date' }) + '*' }}
-          timeProps={{ label: stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.time' }) + '*' }}
+          dateProps={{ label: formatMessage({ id: 'stripes-smart-components.cddd.date' }) + '*' }}
+          timeProps={{ label: formatMessage({ id: 'stripes-smart-components.cddd.time' }) + '*' }}
         />
         <this.connectedLoanList
           stripes={this.props.stripes}
@@ -280,4 +279,4 @@ class ChangeDueDate extends React.Component {
   }
 }
 
-export default ChangeDueDate;
+export default injectIntl(ChangeDueDate);

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, isEqual } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
 import { Icon, Modal } from '@folio/stripes-components';
 
@@ -28,6 +28,7 @@ class ChangeDueDateDialog extends React.Component {
   }
 
   static propTypes = {
+    intl: intlShape,
     loanIds: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
@@ -54,10 +55,7 @@ class ChangeDueDateDialog extends React.Component {
       })
     }).isRequired,
     stripes: PropTypes.shape({
-      connect: PropTypes.func,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func,
-      }),
+      connect: PropTypes.func
     }),
   }
 
@@ -143,7 +141,7 @@ class ChangeDueDateDialog extends React.Component {
   }
 
   render() {
-    const { formatMessage } = this.props.stripes.intl;
+    const { intl: { formatMessage } } = this.props;
     const { succeeded } = this.state;
 
     const BodyComponent = succeeded ? ChangeDueDateSuccess : this.connectedChangeDueDate;
@@ -175,4 +173,4 @@ class ChangeDueDateDialog extends React.Component {
   }
 }
 
-export default ChangeDueDateDialog;
+export default injectIntl(ChangeDueDateDialog);

--- a/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
@@ -20,7 +20,9 @@ class ChangeDueDateSuccess extends React.Component {
       }),
     ),
     onCancel: PropTypes.func,
-    stripes: PropTypes.object,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    })
   }
 
   static defaultProps = {

--- a/lib/ChangeDueDateDialog/DueDatePicker.js
+++ b/lib/ChangeDueDateDialog/DueDatePicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
+import { injectIntl, intlShape } from 'react-intl';
 
 import DueDatePickerForm from './DueDatePickerForm';
 
@@ -11,10 +12,8 @@ class DueDatePicker extends React.Component {
       date: PropTypes.string,
       time: PropTypes.string,
     }),
+    intl: intlShape,
     onChange: PropTypes.func,
-    stripes: PropTypes.shape({
-      timezone: PropTypes.string.isRequired,
-    }).isRequired,
     timeProps: PropTypes.object
   }
 
@@ -39,11 +38,12 @@ class DueDatePicker extends React.Component {
   }
 
   handleChange = (values) => {
+    const { intl: { timeZone } } = this.props;
     // Values are received in the following form: { date: "2018-10-20T00:00:00.000Z", time: "22:59:00.000Z" }
     const date = values.date.split('T')[0];
     const time = values.time.split(/[Z+-]/)[0];
 
-    const localDatetime = moment.tz(`${date}T${time}`, this.props.stripes.timezone);
+    const localDatetime = moment.tz(`${date}T${time}`, timeZone);
     const utcDatetime = localDatetime.tz('UTC').format();
 
     this.props.onChange(utcDatetime);
@@ -61,4 +61,4 @@ class DueDatePicker extends React.Component {
   }
 }
 
-export default DueDatePicker;
+export default injectIntl(DueDatePicker);

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -40,7 +40,9 @@ class ConfigManager extends React.Component {
     onAfterSave: PropTypes.func,
     onBeforeSave: PropTypes.func,
     resources: PropTypes.object.isRequired,
-    stripes: PropTypes.object,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    }),
     validate: PropTypes.func,
   };
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
 import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -38,6 +38,7 @@ class ControlledVocab extends React.Component {
     columnMapping: PropTypes.object,
     formatter: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
+    intl: intlShape,
     itemTemplate: PropTypes.object,
     label: PropTypes.string.isRequired,
     labelSingular: PropTypes.string.isRequired,
@@ -70,11 +71,7 @@ class ControlledVocab extends React.Component {
     rowFilterFunction: PropTypes.func,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      formatDate: PropTypes.func.isRequired,
-      hasPerm: PropTypes.func.isRequired,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func.isRequired,
-      }).isRequired,
+      hasPerm: PropTypes.func.isRequired
     }).isRequired,
     /*
     * Allows for custom field validation. The function is called for each record (row) and should
@@ -213,6 +210,7 @@ class ControlledVocab extends React.Component {
   }
 
   validate({ items }) {
+    const { intl: { formatMessage } } = this.props;
     const { primaryField } = this.state;
 
     if (Array.isArray(items)) {
@@ -225,7 +223,7 @@ class ControlledVocab extends React.Component {
         // Check if the primary field has had data entered into it.
         if (!item[primaryField]) {
           itemErrors[primaryField] =
-            this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.missingRequiredField' });
+            formatMessage({ id: 'stripes-core.label.missingRequiredField' });
         }
 
         // Add the errors if we found any for this record.
@@ -243,13 +241,13 @@ class ControlledVocab extends React.Component {
   }
 
   renderItemInUseDialog() {
-    const { stripes: { intl } } = this.props;
+    const { intl: { formatMessage } } = this.props;
     const type = this.props.labelSingular.toLowerCase();
 
     return (
       <Modal
         open={this.state.showItemInUseDialog}
-        label={intl.formatMessage({ id: 'stripes-smart-components.cv.cannotDeleteTermHeader' }, { type })}
+        label={formatMessage({ id: 'stripes-smart-components.cv.cannotDeleteTermHeader' }, { type })}
         size="small"
       >
         <Row>
@@ -273,12 +271,14 @@ class ControlledVocab extends React.Component {
    * See STCOM-308.
    */
   renderLastUpdated = (metadata) => {
+    const { intl, stripes } = this.props;
+
     if (!this.metadataCache) {
       this.metadataCache = {};
     }
 
     if (!this.metadataCache[metadata.updatedByUserId]) {
-      const UserComponent = this.props.stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
+      const UserComponent = stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
       this.metadataCache[metadata.updatedByUserId] = (
         <span className={css.lastUpdatedUser}>
           <UserComponent stripes={this.props.stripes} id={metadata.updatedByUserId} />
@@ -291,7 +291,7 @@ class ControlledVocab extends React.Component {
         <FormattedMessage
           id="stripes-smart-components.cv.updatedAtAndBy"
           values={{
-            date: this.props.stripes.formatDate(metadata.updatedDate),
+            date: intl.formatDate(metadata.updatedDate),
             user: this.metadataCache[metadata.updatedByUserId],
           }}
         />
@@ -302,7 +302,7 @@ class ControlledVocab extends React.Component {
   render() {
     if (!this.props.resources.values) return <div />;
 
-    const { formatMessage } = this.props.stripes.intl;
+    const { intl: { formatMessage } } = this.props;
     const type = this.props.labelSingular.toLowerCase();
     const term = this.state.selectedItem[this.state.primaryField];
 
@@ -389,4 +389,4 @@ class ControlledVocab extends React.Component {
   }
 }
 
-export default ControlledVocab;
+export default injectIntl(ControlledVocab);

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -342,7 +342,7 @@ class EditableListForm extends React.Component {
   }
 
   getActions = (fields, item) => {
-    const { actionProps, actionSuppression, pristine, submitting, invalid } = this.props;
+    const { actionProps, actionSuppression, pristine, submitting, invalid, intl: { formatMessage } } = this.props;
 
     if (this.state.status[item.rowIndex].editing) {
       return (
@@ -351,7 +351,7 @@ class EditableListForm extends React.Component {
             disabled={pristine || submitting || invalid}
             marginBottom0
             id={`clickable-save-${this.testingId}-${item.rowIndex}`}
-            title={this.props.intl.formatMessage({ id: 'stripes-components.saveChangesToThisItem' })}
+            title={formatMessage({ id: 'stripes-components.saveChangesToThisItem' })}
             onClick={() => this.onSave(fields, item.rowIndex)}
             {...(typeof actionProps.save === 'function' ? actionProps.save(item) : {})}
           >
@@ -360,7 +360,7 @@ class EditableListForm extends React.Component {
           <Button
             marginBottom0
             id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
-            title={this.props.intl.formatMessage({ id: 'stripes-components.cancelEditingThisItem' })}
+            title={formatMessage({ id: 'stripes-components.cancelEditingThisItem' })}
             onClick={() => this.onCancel(fields, item.rowIndex)}
             {...(typeof actionProps.cancel === 'function' ? actionProps.cancel(item) : {})}
           >
@@ -377,7 +377,7 @@ class EditableListForm extends React.Component {
             size="small"
             id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onEdit(item.rowIndex)}
-            title={this.props.intl.formatMessage({ id: 'stripes-components.editThisItem' })}
+            title={formatMessage({ id: 'stripes-components.editThisItem' })}
             {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
           />
         }
@@ -387,7 +387,7 @@ class EditableListForm extends React.Component {
             size="small"
             id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onDelete(fields, item.rowIndex)}
-            title={this.props.intl.formatMessage({ id: 'stripes-components.deleteThisItem' })}
+            title={formatMessage({ id: 'stripes-components.deleteThisItem' })}
             {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
           />
         }

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { Button, ConfirmationModal, Pane, PaneMenu, Paneset } from '@folio/stripes-components';
 import stripesForm from '@folio/stripes-form';
@@ -12,6 +13,7 @@ class EntryForm extends React.Component {
     formComponent: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
+    intl: intlShape,
     nameKey: PropTypes.string.isRequired,
     onCancel: PropTypes.func,
     onRemove: PropTypes.func,
@@ -23,10 +25,7 @@ class EntryForm extends React.Component {
     }),
     pristine: PropTypes.bool,
     stripes: PropTypes.shape({
-      hasPerm: PropTypes.func.isRequired,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func,
-      }),
+      hasPerm: PropTypes.func.isRequired
     }),
     submitting: PropTypes.bool,
     validate: PropTypes.func.isRequired,
@@ -42,12 +41,14 @@ class EntryForm extends React.Component {
   }
 
   addFirstMenu() {
+    const { intl: { formatMessage } } = this.props;
+
     return (
       <PaneMenu>
         <button
           id="clickable-close-entry"
           onClick={this.props.onCancel}
-          aria-label={this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.closeEntryDialog' })}
+          aria-label={formatMessage({ id: 'stripes-smart-components.closeEntryDialog' })}
           type="button"
         >
           <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
@@ -76,32 +77,33 @@ class EntryForm extends React.Component {
   }
 
   saveLastMenu() {
-    const { pristine, submitting } = this.props;
+    const { intl: { formatMessage }, pristine, submitting } = this.props;
+
     return (
       <PaneMenu>
         <Button
           id="clickable-save-entry"
           type="submit"
-          title={this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.saveAndClose' })}
+          title={formatMessage({ id: 'stripes-core.button.saveAndClose' })}
           disabled={(pristine || submitting)}
           marginBottom0
         >
-          {this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.saveAndClose' })}
+          {formatMessage({ id: 'stripes-core.button.saveAndClose' })}
         </Button>
       </PaneMenu>
     );
   }
 
   render() {
-    const { handleSubmit, permissions, initialValues, stripes: { intl } } = this.props;
+    const { handleSubmit, initialValues, intl: { formatMessage }, permissions, stripes } = this.props;
     const selectedEntry = initialValues || {};
     const { confirmDelete } = this.state;
-    const disabled = !this.props.stripes.hasPerm(permissions.put);
+    const disabled = !stripes.hasPerm(permissions.put);
     const paneTitle = selectedEntry && selectedEntry.id ?
-      this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel }) :
-      this.props.stripes.intl.formatMessage({ id: 'stripes-core.label.createEntry' }, { entry: this.props.entryLabel });
+      formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel }) :
+      formatMessage({ id: 'stripes-core.label.createEntry' }, { entry: this.props.entryLabel });
     const deleteButtonText =
-      intl.formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: this.props.entryLabel });
+      formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: this.props.entryLabel });
 
     let deleteButton;
     if (selectedEntry && selectedEntry.id && this.props.stripes.hasPerm(permissions.delete)) {
@@ -123,7 +125,7 @@ class EntryForm extends React.Component {
       <SafeHTMLMessage
         id="stripes-core.label.confirmDeleteEntry"
         values={{
-          name: selectedEntry[this.props.nameKey] || intl.formatMessage({ id: 'stripes-core.untitled' }),
+          name: selectedEntry[this.props.nameKey] || formatMessage({ id: 'stripes-core.untitled' }),
         }}
       />
     );
@@ -152,8 +154,8 @@ class EntryForm extends React.Component {
                 message={message}
                 onConfirm={() => { this.confirmDeleteSet(true); }}
                 onCancel={() => { this.confirmDeleteSet(false); }}
-                confirmLabel={this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.delete' })}
-                cancelLabel={this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.cancel' })}
+                confirmLabel={formatMessage({ id: 'stripes-core.button.delete' })}
+                cancelLabel={formatMessage({ id: 'stripes-core.button.cancel' })}
               />
             }
           </Pane>
@@ -167,4 +169,4 @@ export default stripesForm({
   form: 'entryForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(EntryForm);
+})(injectIntl(EntryForm));

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { omit } from 'lodash';
+import { injectIntl, intlShape } from 'react-intl';
 
 import { Button, Callout, EntrySelector, IfPermission, Layer, PaneMenu } from '@folio/stripes-components';
 import queryString from 'query-string';
@@ -35,6 +36,7 @@ class EntryWrapper extends React.Component {
       push: PropTypes.func.isRequired,
     }).isRequired,
     idFromPathnameRe: PropTypes.string,
+    intl: intlShape,
     location: PropTypes.object.isRequired,
     mutator: PropTypes.object,
     nameKey: PropTypes.string.isRequired,
@@ -46,11 +48,6 @@ class EntryWrapper extends React.Component {
       put: PropTypes.string.isRequired,
     }),
     resourceKey: PropTypes.string,
-    stripes: PropTypes.shape({
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func,
-      }),
-    }),
     validate: PropTypes.func,
   };
 
@@ -142,7 +139,7 @@ class EntryWrapper extends React.Component {
   }
 
   render() {
-    const { entryList, location, permissions, entryLabel, nameKey, stripes: { intl } } = this.props;
+    const { entryList, location, permissions, entryLabel, nameKey, intl: { formatMessage } } = this.props;
     const { selectedId } = this.state;
 
     const query = location.search ? queryString.parse(location.search) : {};
@@ -166,12 +163,12 @@ class EntryWrapper extends React.Component {
           <PaneMenu>
             <Button
               id={`${baseId}-add-new`}
-              title={intl.formatMessage({ id: 'stripes-core.button.new_tooltip' }, { entry: entryLabel })}
+              title={formatMessage({ id: 'stripes-core.button.new_tooltip' }, { entry: entryLabel })}
               onClick={this.onAdd}
               buttonStyle="primary paneHeaderNewButton"
               marginBottom0
             >
-              {intl.formatMessage({ id: 'stripes-core.button.new' })}
+              {formatMessage({ id: 'stripes-core.button.new' })}
             </Button>
           </PaneMenu>
         </IfPermission>
@@ -197,7 +194,7 @@ class EntryWrapper extends React.Component {
       >
         <Layer
           isOpen={!!(query.layer)}
-          label={intl.formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: entryLabel })}
+          label={formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: entryLabel })}
           container={container}
         >
           <EntryFormComponent
@@ -220,4 +217,4 @@ class EntryWrapper extends React.Component {
   }
 }
 
-export default EntryWrapper;
+export default injectIntl(EntryWrapper);

--- a/lib/LoanList/LoanList.js
+++ b/lib/LoanList/LoanList.js
@@ -85,7 +85,8 @@ const LoanList = (props) => {
         alertDetails: loan => props.alerts[loan.id] || '',
         title: loan => get(loan, ['item', 'title']),
         itemStatus: loan => get(loan, ['item', 'status', 'name']),
-        currentDueDate: loan => formatTime(get(loan, ['dueDate'], { day: 'numeric', month: 'numeric', year: 'numeric' })),
+        currentDueDate:
+          loan => formatTime(get(loan, ['dueDate'], { day: 'numeric', month: 'numeric', year: 'numeric' })),
         requestQueue: () => 'N/A',
         barcode: loan => get(loan, ['item', 'barcode']),
         callNumber: loan => get(loan, ['item', 'callNumber']),

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -1,6 +1,7 @@
 import { sortBy, escapeRegExp } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Button, Col, Row, Select, Selection } from '@folio/stripes-components';
 import stripesForm from '@folio/stripes-form';
 import { withStripes } from '@folio/stripes-core';
@@ -11,6 +12,7 @@ class LocationForm extends React.Component {
     campuses: PropTypes.arrayOf(PropTypes.object),
     handleSubmit: PropTypes.func.isRequired,
     institutions: PropTypes.arrayOf(PropTypes.object),
+    intl: intlShape,
     libraries: PropTypes.arrayOf(PropTypes.object),
     locations: PropTypes.arrayOf(PropTypes.object),
     onCampusSelected: PropTypes.func.isRequired,
@@ -18,7 +20,6 @@ class LocationForm extends React.Component {
     onInstitutionSelected: PropTypes.func.isRequired,
     onLibrarySelected: PropTypes.func.isRequired,
     stripes: PropTypes.shape({
-      intl: PropTypes.object.isRequired,
       store: PropTypes.object.isRequired,
     }).isRequired,
   };
@@ -40,8 +41,8 @@ class LocationForm extends React.Component {
   }
 
   translate(id) {
-    const { stripes: { intl } } = this.props;
-    return intl.formatMessage({ id: `stripes-smart-components.ll.${id}` });
+    const { intl: { formatMessage } } = this.props;
+    return formatMessage({ id: `stripes-smart-components.ll.${id}` });
   }
 
   render() {
@@ -136,4 +137,4 @@ export default stripesForm({
   form: 'locationForm',
   navigationCheck: false,
   enableReinitialize: true,
-})(withStripes(LocationForm));
+})(withStripes(injectIntl(LocationForm)));

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { withStripes } from '@folio/stripes-core';
 import { Button } from '@folio/stripes-components';
 import LocationModal from './LocationModal';
 
 class LocationLookup extends React.Component {
   static propTypes = {
+    intl: intlShape,
     isTemporaryLocation: PropTypes.bool,
     label: PropTypes.string,
     onLocationSelected: PropTypes.func.isRequired,
     stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
+      connect: PropTypes.func.isRequired
     }).isRequired,
   };
 
@@ -37,9 +38,8 @@ class LocationLookup extends React.Component {
   }
 
   render() {
-    const { label, onLocationSelected, isTemporaryLocation, stripes } = this.props;
-    const { intl } = stripes;
-    const buttonLabel = label || intl.formatMessage({ id: 'stripes-smart-components.ll.locationLookup' });
+    const { intl: { formatMessage }, label, onLocationSelected, isTemporaryLocation, stripes } = this.props;
+    const buttonLabel = label || formatMessage({ id: 'stripes-smart-components.ll.locationLookup' });
 
     return (
       <div>
@@ -65,4 +65,4 @@ class LocationLookup extends React.Component {
   }
 }
 
-export default withStripes(LocationLookup);
+export default withStripes(injectIntl(LocationLookup));

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Modal } from '@folio/stripes-components';
 
 import LocationForm from './LocationForm';
 
-export default class LocationModal extends React.Component {
+class LocationModal extends React.Component {
   static manifest = Object.freeze({
     institutions: {
       type: 'okapi',
@@ -37,6 +38,7 @@ export default class LocationModal extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape,
     isTemporaryLocation: PropTypes.bool,
     mutator: PropTypes.shape({
       campuses: PropTypes.shape({
@@ -72,10 +74,7 @@ export default class LocationModal extends React.Component {
       locations: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
-    }).isRequired,
-    stripes: PropTypes.shape({
-      intl: PropTypes.object.isRequired,
-    }).isRequired,
+    }).isRequired
   };
 
   constructor(props) {
@@ -177,8 +176,8 @@ export default class LocationModal extends React.Component {
   }
 
   translate(id, options) {
-    const { stripes: { intl } } = this.props;
-    return intl.formatMessage({ id: `stripes-smart-components.ll.${id}` }, options);
+    const { intl: { formatMessage } } = this.props;
+    return formatMessage({ id: `stripes-smart-components.ll.${id}` }, options);
   }
 
   render() {
@@ -217,3 +216,5 @@ export default class LocationModal extends React.Component {
     );
   }
 }
+
+export default injectIntl(LocationModal);

--- a/lib/LocationSelection/LocationSelection.js
+++ b/lib/LocationSelection/LocationSelection.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { withStripes } from '@folio/stripes-core';
 
 import LocationInput from './LocationInput';
 
 class LocationSelection extends React.Component {
   static propTypes = {
+    intl: intlShape,
     name: PropTypes.string,
     placeholder: PropTypes.string,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
-      intl: PropTypes.object.isRequired,
     }),
   };
 
@@ -24,9 +25,9 @@ class LocationSelection extends React.Component {
   }
 
   render() {
-    const { stripes, name, placeholder } = this.props;
+    const { intl: { formatMessage }, name, placeholder } = this.props;
     const locationPlaceholder =
-      placeholder || stripes.intl.formatMessage({ id: 'stripes-smart-components.ls.locationPlaceholder' });
+      placeholder || formatMessage({ id: 'stripes-smart-components.ls.locationPlaceholder' });
 
     return (
       <this.locationInputConnected
@@ -38,4 +39,4 @@ class LocationSelection extends React.Component {
   }
 }
 
-export default withStripes(LocationSelection);
+export default withStripes(injectIntl(LocationSelection));

--- a/lib/Notes/NoteRenderer.js
+++ b/lib/Notes/NoteRenderer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'react-bootstrap';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import {
   Button,
   Col,
@@ -17,11 +17,15 @@ import css from './Notes.css';
 class NoteRenderer extends React.Component {
   static propTypes = {
     highlighted: PropTypes.bool,
+    intl: intlShape,
     note: PropTypes.object,
     noteKey: PropTypes.string,
     onDelete: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
-    stripes: PropTypes.object,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+      hasPerm: PropTypes.func.isRequired
+    }),
   }
 
   constructor(props) {
@@ -75,10 +79,9 @@ class NoteRenderer extends React.Component {
   }
 
   render() {
-    const { note, noteKey, stripes } = this.props;
-    const formatMsg = stripes.intl.formatMessage;
+    const { intl: { formatMessage, locale }, note, noteKey, stripes } = this.props;
 
-    const stamp = new Date(Date.parse(note.metadata.createdDate)).toLocaleString(stripes.locale);
+    const stamp = new Date(Date.parse(note.metadata.createdDate)).toLocaleString(locale);
 
     if (this.state.editMode) {
       return (
@@ -124,7 +127,7 @@ class NoteRenderer extends React.Component {
               >
                 <Button
                   buttonStyle="link slim"
-                  aria-label={formatMsg({ id: 'stripes-smart-components.editOrDeleteNote' })}
+                  aria-label={formatMessage({ id: 'stripes-smart-components.editOrDeleteNote' })}
                   bsRole="toggle"
                 >
                   <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
@@ -133,7 +136,7 @@ class NoteRenderer extends React.Component {
                   bsRole="menu"
                   width="5em"
                   minWidth="5em"
-                  aria-label={formatMsg({ id: 'stripes-smart-components.editOrDeleteNote' })}
+                  aria-label={formatMessage({ id: 'stripes-smart-components.editOrDeleteNote' })}
                   onToggle={this.onToggleDropDown}
                 >
                   <IfPermission perm="notes.item.put">
@@ -163,4 +166,4 @@ class NoteRenderer extends React.Component {
     );
   }
 }
-export default NoteRenderer;
+export default injectIntl(NoteRenderer);

--- a/lib/Notes/Notes.js
+++ b/lib/Notes/Notes.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
+import { injectIntl, intlShape } from 'react-intl';
 import { IfPermission, Pane } from '@folio/stripes-components';
 import NotesForm from './NotesForm';
 import NoteRenderer from './NoteRenderer';
@@ -22,6 +23,7 @@ class Notes extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape,
     link: PropTypes.string,
     location: PropTypes.shape({
       search: PropTypes.string,
@@ -69,8 +71,7 @@ class Notes extends React.Component {
   }
 
   render() {
-    const { stripes, link } = this.props;
-    const formatMsg = stripes.intl.formatMessage;
+    const { intl: { formatMessage }, link, stripes } = this.props;
     const notes = (this.props.resources.notes || {}).records || [];
 
     const notesQueryString = queryString.parse(this.props.location.search || '').notes;
@@ -89,8 +90,8 @@ class Notes extends React.Component {
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={formatMsg({ id: 'stripes-smart-components.notes' })}
-        paneSub={formatMsg({ id: 'stripes-smart-components.numberOfNotes' }, { count: notes.length })}
+        paneTitle={formatMessage({ id: 'stripes-smart-components.notes' })}
+        paneSub={formatMessage({ id: 'stripes-smart-components.numberOfNotes' }, { count: notes.length })}
         dismissible
         onClose={this.props.onToggle}
       >
@@ -113,4 +114,4 @@ class Notes extends React.Component {
   }
 }
 
-export default Notes;
+export default injectIntl(Notes);

--- a/lib/Notes/NotesForm.js
+++ b/lib/Notes/NotesForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { Button, TextArea } from '@folio/stripes-components';
 
@@ -10,14 +10,12 @@ class NotesForm extends React.Component {
     editMode: PropTypes.bool,
     form: PropTypes.string,
     handleSubmit: PropTypes.func,
+    intl: intlShape,
     onCancel: PropTypes.func,
     pristine: PropTypes.bool,
     reset: PropTypes.func,
     stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func.isRequired,
-      }),
+      connect: PropTypes.func.isRequired
     }).isRequired,
     submitting: PropTypes.bool,
     textRows: PropTypes.string,
@@ -28,13 +26,13 @@ class NotesForm extends React.Component {
     const {
       form,
       handleSubmit,
+      intl: { formatMessage },
       pristine,
       submitting,
       textRows,
       editMode,
       onCancel,
     } = this.props;
-    const formatMsg = this.props.stripes.intl.formatMessage;
 
     const handleKeyDown = (e, handler) => {
       if (e.key === 'Enter' && e.shiftKey === false) {
@@ -52,8 +50,8 @@ class NotesForm extends React.Component {
       <form>
         <Field
           name="text"
-          placeholder={formatMsg({ id: 'stripes-smart-components.enterANote' })}
-          aria-label={formatMsg({ id: 'stripes-smart-components.notesTextArea' })}
+          placeholder={formatMessage({ id: 'stripes-smart-components.enterANote' })}
+          aria-label={formatMessage({ id: 'stripes-smart-components.notesTextArea' })}
           fullWidth
           id="note_textarea"
           component={TextArea}
@@ -65,7 +63,7 @@ class NotesForm extends React.Component {
             <Button
               buttonStyle="hover"
               onClick={onCancel}
-              aria-label={formatMsg({ id: 'stripes-smart-components.cancelEdit' })}
+              aria-label={formatMessage({ id: 'stripes-smart-components.cancelEdit' })}
             >
               <FormattedMessage id="stripes-components.button.cancel" />
             </Button>
@@ -73,7 +71,7 @@ class NotesForm extends React.Component {
           <Button
             disabled={pristine || submitting}
             onClick={handleClickSubmit}
-            aria-label={formatMsg({ id: 'stripes-smart-components.postNote' })}
+            aria-label={formatMessage({ id: 'stripes-smart-components.postNote' })}
           >
             <FormattedMessage id="stripes-smart-components.post" />
           </Button>
@@ -86,4 +84,4 @@ class NotesForm extends React.Component {
 export default stripesForm({
   form: 'NotesForm',
   enableReinitialize: true,
-})(NotesForm);
+})(injectIntl(NotesForm));

--- a/lib/ProxyManager/ProxyForm.js
+++ b/lib/ProxyManager/ProxyForm.js
@@ -48,8 +48,8 @@ class ProxyForm extends React.Component {
   }
 
   translate(id) {
-    const { intl } = this.props;
-    return intl.formatMessage({ id: `stripes-smart-components.pm.${id}` });
+    const { intl: { formatMessage } } = this.props;
+    return formatMessage({ id: `stripes-smart-components.pm.${id}` });
   }
 
   renderDisabledRadio(proxy, sponsor, proxyMap) {
@@ -73,7 +73,7 @@ class ProxyForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, onCancel, patron, proxies, intl } = this.props;
+    const { handleSubmit, onCancel, patron, proxies, intl: { formatMessage } } = this.props;
     const proxiesList = chunk(proxies, 3).map((group, i) => (
       <Row key={`row-${i}`}>
         {group.map(proxy => (
@@ -105,7 +105,7 @@ class ProxyForm extends React.Component {
               id={`sponsor-${patron.id}`}
               key={`sponsor-${patron.id}`}
               name="sponsorId"
-              label={intl.formatMessage({ id: 'stripes-smart-components.self' })}
+              label={formatMessage({ id: 'stripes-smart-components.self' })}
               value={patron.id}
             />
           </Col>

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -14,14 +14,14 @@ class ProxyModal extends React.Component {
   };
 
   render() {
-    const { onClose, open, patron, onContinue, intl } = this.props;
+    const { onClose, open, patron, onContinue, intl: { formatMessage } } = this.props;
 
     return (
       <Modal
         onClose={onClose}
         open={open}
         size="small"
-        label={intl.formatMessage({ id: 'stripes-smart-components.whoAreYouActingAs' })}
+        label={formatMessage({ id: 'stripes-smart-components.whoAreYouActingAs' })}
         dismissible
       >
         <ProxyForm

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -6,8 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
-import { FormattedMessage } from 'react-intl';
-import { stripesShape } from '@folio/stripes-core/src/Stripes';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core';
 import queryString from 'query-string';
@@ -69,6 +68,7 @@ class SearchAndSort extends React.Component {
     getHelperResourcePath: PropTypes.func,
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
+    intl: intlShape,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired,
@@ -145,7 +145,10 @@ class SearchAndSort extends React.Component {
     searchableIndexesPlaceholder: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
-    stripes: stripesShape,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func,
+      hasPerm: PropTypes.func.isRequired
+    }),
     viewRecordComponent: PropTypes.func.isRequired,
     viewRecordPerms: PropTypes.string.isRequired,
     visibleColumns: PropTypes.arrayOf(
@@ -195,7 +198,7 @@ class SearchAndSort extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated
-    const logger = this.props.stripes.logger;
+    const { intl: { formatMessage }, stripes: { logger } } = this.props;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
 
@@ -218,7 +221,7 @@ class SearchAndSort extends React.Component {
       this.log('event', 'new search-result');
       const count = newState.totalCount();
       this.SRStatus.sendMessage(
-        this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.searchReturnedResults' }, { count })
+        formatMessage({ id: 'stripes-smart-components.searchReturnedResults' }, { count })
       );
     }
 
@@ -468,6 +471,7 @@ class SearchAndSort extends React.Component {
 
   render() {
     const {
+      intl: { formatMessage },
       parentResources,
       filterConfig,
       disableFilters,
@@ -485,7 +489,6 @@ class SearchAndSort extends React.Component {
     const searchTerm =
       (locallyChangedSearchTerm !== undefined) ? locallyChangedSearchTerm : (this.queryParam('query') || '');
     const filters = filterState(this.queryParam('filters'));
-    const formatMsg = stripes.intl.formatMessage;
 
     const moduleName = this.getModuleName();
 
@@ -500,11 +503,11 @@ class SearchAndSort extends React.Component {
             id={`clickable-new${objectName}`}
             href={this.craftLayerUrl('create')}
             onClick={this.addNewRecord}
-            aria-label={formatMsg({ id: 'stripes-smart-components.addNew' })}
+            aria-label={formatMessage({ id: 'stripes-smart-components.addNew' })}
             buttonStyle="primary paneHeaderNewButton"
             marginBottom0
           >
-            {formatMsg({ id: 'stripes-smart-components.new' })}
+            {formatMessage({ id: 'stripes-smart-components.new' })}
           </Button>
         </PaneMenu>
       </IfPermission>
@@ -512,9 +515,9 @@ class SearchAndSort extends React.Component {
 
     const { filterPaneIsVisible } = this.state;
     const filterCount = Object.keys(filters).length;
-    const hidePaneMsg = formatMsg({ id: 'stripes-smart-components.hideSearchPane' });
-    const showPaneMsg = formatMsg({ id: 'stripes-smart-components.showSearchPane' });
-    const appliedFiltersMsg = formatMsg({ id: 'stripes-smart-components.numberOfFilters' }, { count: filterCount });
+    const hidePaneMsg = formatMessage({ id: 'stripes-smart-components.hideSearchPane' });
+    const showPaneMsg = formatMessage({ id: 'stripes-smart-components.showSearchPane' });
+    const appliedFiltersMsg = formatMessage({ id: 'stripes-smart-components.numberOfFilters' }, { count: filterCount });
     const toggleFilterPaneMessage = `${filterPaneIsVisible ? hidePaneMsg : showPaneMsg} \n\n${appliedFiltersMsg}`;
 
     const resultsFirstMenu = (
@@ -594,7 +597,7 @@ class SearchAndSort extends React.Component {
         this.props.resultCountMessageKey : 'stripes-smart-components.searchResultsCountHeader';
     const paneSub =
       !source.loaded() ?
-        formatMsg({ id: 'stripes-smart-components.searchCriteria' }) : formatMsg({ id: messageKey }, { count });
+        formatMessage({ id: 'stripes-smart-components.searchCriteria' }) : formatMessage({ id: messageKey }, { count });
 
     return (
       <Paneset>
@@ -604,7 +607,7 @@ class SearchAndSort extends React.Component {
           <Pane
             id="pane-filter"
             defaultWidth="320px"
-            paneTitle={formatMsg({ id: 'stripes-smart-components.searchAndFilter' })}
+            paneTitle={formatMessage({ id: 'stripes-smart-components.searchAndFilter' })}
             onClose={this.toggleFilterPane}
           >
             <form onSubmit={this.onSubmitSearch}>
@@ -672,7 +675,7 @@ class SearchAndSort extends React.Component {
             loading={source.pending()}
             autosize
             virtualize
-            ariaLabel={formatMsg({ id: 'stripes-smart-components.searchResults' }, { objectName: objectNameUC })}
+            ariaLabel={formatMessage({ id: 'stripes-smart-components.searchResults' }, { objectName: objectNameUC })}
             rowFormatter={this.anchoredRowFormatter}
             containerRef={(ref) => { this.resultsList = ref; }}
           />
@@ -693,5 +696,5 @@ class SearchAndSort extends React.Component {
 export default withRouter(
   withModule(
     props => props.packageInfo && props.packageInfo.name
-  )(withStripes(SearchAndSort))
+  )(withStripes(injectIntl(SearchAndSort)))
 );

--- a/lib/Tags/Tag.js
+++ b/lib/Tags/Tag.js
@@ -1,20 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Badge, Button, Icon } from '@folio/stripes-components';
-import { withStripes } from '@folio/stripes-core';
 
 import css from './Tags.css';
 
 class Tag extends React.Component {
   static propTypes = {
+    intl: intlShape,
     onRemove: PropTypes.func.isRequired,
-    stripes: PropTypes.object,
     tag: PropTypes.string,
   };
 
   render() {
-    const { tag, stripes, onRemove } = this.props;
-    const formatMsg = stripes.intl.formatMessage;
+    const { intl: { formatMessage }, tag, onRemove } = this.props;
 
     return (
       <Badge className={css.tag} color="primary">
@@ -25,7 +24,7 @@ class Tag extends React.Component {
           paddingSide0
           marginBottom0
           buttonStyle="primary"
-          aria-label={formatMsg({ id: 'stripes-smart-components.deleteTag' })}
+          aria-label={formatMessage({ id: 'stripes-smart-components.deleteTag' })}
         >
           <Icon size="small" icon="closeX" color="rgba(255, 255, 255, 1)" />
         </Button>
@@ -34,4 +33,4 @@ class Tag extends React.Component {
   }
 }
 
-export default withStripes(Tag);
+export default injectIntl(Tag);

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -1,6 +1,7 @@
 import { get, uniq, sortBy, difference } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { Callout, Pane } from '@folio/stripes-components';
 
 import TagsForm from './TagsForm';
@@ -24,6 +25,7 @@ class Tags extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape,
     mutator: PropTypes.shape({
       entities: PropTypes.shape({
         PUT: PropTypes.func.isRequired,
@@ -77,7 +79,7 @@ class Tags extends React.Component {
 
   // add tags to global list of tags
   saveTags(tags) {
-    const { mutator, stripes, resources } = this.props;
+    const { intl: { formatMessage }, mutator, resources } = this.props;
     const records = (resources.tags || {}).records || [];
     const newTag = difference(tags, records.map(t => t.label.toLowerCase()));
 
@@ -88,7 +90,7 @@ class Tags extends React.Component {
       description: newTag[0],
     });
 
-    const message = stripes.intl.formatMessage({ id: 'stripes-smart-components.newTagCreated' });
+    const message = formatMessage({ id: 'stripes-smart-components.newTagCreated' });
     this.calloutRef.current.sendCallout({ message });
   }
 
@@ -111,16 +113,15 @@ class Tags extends React.Component {
   }
 
   render() {
-    const { stripes, resources } = this.props;
-    const formatMsg = stripes.intl.formatMessage;
+    const { intl: { formatMessage }, resources, stripes } = this.props;
     const entityTags = this.getEntityTags();
     const tags = (resources.tags || {}).records || [];
 
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={formatMsg({ id: 'stripes-smart-components.tags' })}
-        paneSub={formatMsg({ id: 'stripes-smart-components.numberOfTags' }, { count: entityTags.length })}
+        paneTitle={formatMessage({ id: 'stripes-smart-components.tags' })}
+        paneSub={formatMessage({ id: 'stripes-smart-components.numberOfTags' }, { count: entityTags.length })}
         dismissible
         onClose={this.props.onToggle}
       >
@@ -138,4 +139,4 @@ class Tags extends React.Component {
   }
 }
 
-export default Tags;
+export default injectIntl(Tags);

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -1,18 +1,17 @@
 import { isEqual, difference, sortBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from 'react-intl';
 import { MultiSelection } from '@folio/stripes-components';
 
 class TagsForm extends React.Component {
   static propTypes = {
     entityTags: PropTypes.arrayOf(PropTypes.string),
+    intl: intlShape,
     onAdd: PropTypes.func,
     onRemove: PropTypes.func,
     stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-      intl: PropTypes.shape({
-        formatMessage: PropTypes.func.isRequired,
-      }),
+      connect: PropTypes.func.isRequired
     }).isRequired,
     tags: PropTypes.arrayOf(PropTypes.object),
   };
@@ -86,9 +85,8 @@ class TagsForm extends React.Component {
   }
 
   render() {
-    const { tags } = this.props;
+    const { intl: { formatMessage }, tags } = this.props;
     const { entityTags } = this.state;
-    const formatMsg = this.props.stripes.intl.formatMessage;
     const dataOptions = tags.map(t => ({ value: t.label.toLowerCase(), label: t.label.toLowerCase() }));
     const tagsList = entityTags.map(tag => ({ value: tag.toLowerCase(), label: tag.toLowerCase() }));
     const addAction = { onSelect: this.addTag, render: this.renderTag };
@@ -96,8 +94,8 @@ class TagsForm extends React.Component {
 
     return (
       <MultiSelection
-        placeholder={formatMsg({ id: 'stripes-smart-components.enterATag' })}
-        aria-label={formatMsg({ id: 'stripes-smart-components.tagsTextArea' })}
+        placeholder={formatMessage({ id: 'stripes-smart-components.enterATag' })}
+        aria-label={formatMessage({ id: 'stripes-smart-components.tagsTextArea' })}
         actions={actions}
         filter={this.filterItems}
         emptyMessage=" "
@@ -109,4 +107,4 @@ class TagsForm extends React.Component {
   }
 }
 
-export default TagsForm;
+export default injectIntl(TagsForm);


### PR DESCRIPTION
## Purpose
Retrieving the intl object from the `stripes` god object (`stripes.intl`) is a deprecated pattern.

## Approach
Sets some repo-wide conventions:
- Don't use `stripes.intl`
- When using `injectIntl()` that injects an `intl` prop, destructure `intl`
- Don't try to alias `formatMessage()` and its siblings; instead use destructuring to achieve brevity
- Always specify what parts of `props.stripes` are being used in the prop type validation