### PR TITLE
Hide details pane in browser only mode. Part of UIPFU-11

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -681,10 +681,7 @@ class SearchAndSort extends React.Component {
           />
         </Pane>
         {
-          detailsPane
-        }
-        {
-          !this.props.browseOnly && createRecordLayer
+          !this.props.browseOnly && detailsPane && createRecordLayer
         }
         { this.renderHelperApp() }
 


### PR DESCRIPTION
This PR fixes the issue described in https://issues.folio.org/browse/UIPFU-11
by hiding the details pane in `SearchAndSort` when `browserOnly` mode is on (which is set to true in plugin-find-user).