### PR TITLE
don't sort ControlledVocabulary queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Use react-intl directly instead of stripes.intl
 * Enable tags by default. Part of UITAG-8.
 * Add parseInitialValues to entry wrapper. Fixes STSMACOM-137.
+* Don't sort `ControlledVocabulary` queries; we don't know what indexes are available. Refs MODUSERS-98.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -25,7 +25,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby name&limit=500'
+        path: '!{baseUrl}?query=cql.allRecords=1&limit=500'
       }
     },
     activeRecord: {},


### PR DESCRIPTION
It used to be the case that if you tried to run a query with an index
that didn't exist the parser would realize this and just ignore the
index. Now, it throws a query validation exception. Probably, this is a
good thing; it's good to be strict about what we're running. But at this
late stage, when things were working forever, it feels like you're just
about to submit your problem set and along comes the TA who says, "You
know you have to compile with '-Wall', right?" <sigh>

Refs [MODUSERS-98](https://issues.folio.org/browse/MODUSERS-98)