### PR TITLE
accept prop to override default sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Use react-intl directly instead of stripes.intl
 * Enable tags by default. Part of UITAG-8.
 * Add parseInitialValues to entry wrapper. Fixes STSMACOM-137.
-* Don't sort `ControlledVocabulary` queries; we don't know what indexes are available. Refs MODUSERS-98.
+* `ControlledVocab` accepts `sortby` to override its default ordering. Refs MODUSERS-98, fixes STSMACOM-139.
 * Show details view of the newly created record after duplication. Fixes STSMACOM-140.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -25,7 +25,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1&limit=500'
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&limit=500'
       }
     },
     activeRecord: {},
@@ -69,6 +69,7 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     rowFilter: PropTypes.element,
     rowFilterFunction: PropTypes.func,
+    sortby: PropTypes.string,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
       hasPerm: PropTypes.func.isRequired
@@ -99,6 +100,7 @@ class ControlledVocab extends React.Component {
     },
     preCreateHook: (row) => row,
     preUpdateHook: (row) => row,
+    sortby: 'name',
     validate: () => ({}),
   };
 


### PR DESCRIPTION
Not everything has a `name` field to sort by, and recent backend changes
to tighten up query parsing caused such queries to throw errors when the
bad index used to be silently ignored. This change leaves the default
sortby field (`name`) in place, preserving the previous behavior, while
allowing callers to override the default.

Refs [MODUSERS-98](https://issues.folio.org/browse/MODUSERS-98), [STSMACOM-139](https://issues.folio.org/browse/STSMACOM-139)