### PR TITLE
internalize UserLink to enable caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add parseInitialValues to entry wrapper. Fixes STSMACOM-137.
 * `ControlledVocab` accepts `sortby` to override its default ordering. Refs MODUSERS-98, fixes STSMACOM-139. Available from v1.10.1.
 * Show details view of the newly created record after duplication. Fixes STSMACOM-140.
+* Internalize logic of `<UserLink>` into `<ControlledVocab>` for efficiency. Fixes STSMACOM-142. Available from v1.10.2.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { Link } from 'react-router-dom';
 
 import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
-import UserLink from '../UserLink';
 import UserName from '../UserName';
 import css from './ControlledVocab.css';
 
@@ -113,6 +113,8 @@ class ControlledVocab extends React.Component {
       selectedItem: {},
       primaryField: props.visibleFields[0],
     };
+
+    this.metadataCache = {};
 
     this.connectedUserName = props.stripes.connect(UserName);
 
@@ -275,17 +277,18 @@ class ControlledVocab extends React.Component {
   renderLastUpdated = (metadata) => {
     const { intl, stripes } = this.props;
 
-    if (!this.metadataCache) {
-      this.metadataCache = {};
-    }
-
     if (!this.metadataCache[metadata.updatedByUserId]) {
-      const UserComponent = stripes.hasPerm('ui-users.view') ? UserLink : this.connectedUserName;
-      this.metadataCache[metadata.updatedByUserId] = (
-        <span className={css.lastUpdatedUser}>
-          <UserComponent stripes={this.props.stripes} id={metadata.updatedByUserId} />
-        </span>
-      );
+      if (stripes.hasPerm('ui-users.view')) {
+        this.metadataCache[metadata.updatedByUserId] = (
+          <Link to={`/users/view/${this.props.id}`}>
+            <this.connectedUserName stripes={this.props.stripes} id={metadata.updatedByUserId} />
+          </Link>
+        );
+      } else {
+        this.metadataCache[metadata.updatedByUserId] = (
+          <this.connectedUserName stripes={this.props.stripes} id={metadata.updatedByUserId} />
+        );
+      }
     }
 
     return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
I added `this.metadataCache` a long time ago but it never worked. I had
one of those face-palm moments: it didn't work because
`renderLastUpdated` uses `<UserLink>`, which calls connect. You
shouldn't call connect in render because it'll be called every single
time. Duh. Internalizing the `<UserLink>` logic eliminates that problem
and allows the cache to work correctly.

Fixes [STSMACOM-142](https://issues.folio.org/browse/STSMACOM-142)