### PR TITLE
STCOM-391 Use plus-sign icon instead of + character

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedXmlMessage } from 'react-intl-formatted-xml-message';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core';
 import queryString from 'query-string';
@@ -508,9 +509,10 @@ class SearchAndSort extends React.Component {
             buttonStyle="primary paneHeaderNewButton"
             marginBottom0
           >
-            <Icon icon="plus-sign">
-              {formatMessage({ id: 'stripes-smart-components.new' })}
-            </Icon>
+            <FormattedXmlMessage
+              id="stripes-smart-components.new"
+              tags={{ 'icon': (<Icon />) }}
+            />
           </Button>
         </PaneMenu>
       </IfPermission>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -19,6 +19,7 @@ import FilterGroups, {
 import {
   Button,
   IfPermission,
+  Icon,
   IconButton,
   Layer,
   MultiColumnList,
@@ -507,7 +508,9 @@ class SearchAndSort extends React.Component {
             buttonStyle="primary paneHeaderNewButton"
             marginBottom0
           >
-            {formatMessage({ id: 'stripes-smart-components.new' })}
+            <Icon icon="plus-sign">
+              {formatMessage({ id: 'stripes-smart-components.new' })}
+            </Icon>
           </Button>
         </PaneMenu>
       </IfPermission>

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "query-string": "^5.0.0",
     "react-bootstrap": "0.32.1",
     "react-intl": "^2.4.0",
+    "react-intl-formatted-xml-message": "^1.0.1",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",
     "react-transition-group": "^2.4.0",

--- a/translations/stripes-smart-components/ca.json
+++ b/translations/stripes-smart-components/ca.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/ca.json
+++ b/translations/stripes-smart-components/ca.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/da.json
+++ b/translations/stripes-smart-components/da.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/da.json
+++ b/translations/stripes-smart-components/da.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/de.json
+++ b/translations/stripes-smart-components/de.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Suche",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/de.json
+++ b/translations/stripes-smart-components/de.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Suche",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -63,7 +63,7 @@
   "searchAndFilter": "Search & filter",
   "search": "Search",
   "addNew": "Add new",
-  "new": "+ New",
+  "new": "New",
   "hideSearchPane": "Hide search and filters pane.",
   "showSearchPane": "Show search and filters pane.",
   "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -63,7 +63,7 @@
   "searchAndFilter": "Search & filter",
   "search": "Search",
   "addNew": "Add new",
-  "new": "New",
+  "new": "<icon icon='plus-sign'>New</icon>",
   "hideSearchPane": "Hide search and filters pane.",
   "showSearchPane": "Show search and filters pane.",
   "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/es.json
+++ b/translations/stripes-smart-components/es.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/es.json
+++ b/translations/stripes-smart-components/es.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/es_ES.json
+++ b/translations/stripes-smart-components/es_ES.json
@@ -59,7 +59,7 @@
     "postNote": "Publicar Nota",
     "searchAndFilter": "Buscar y Filtrar",
     "search": "Buscar",
-    "new": "+ Nuevo",
+    "new": "Nuevo",
     "hideSearchPane": "Ocultar panel de Búsqueda y Filtros.",
     "showSearchPane": "Mostrar panel Búsqueda y Filtros.",
     "numberOfFilters": "{count, number} {count, plural, one { applied filter } other { applied filters }}",

--- a/translations/stripes-smart-components/es_ES.json
+++ b/translations/stripes-smart-components/es_ES.json
@@ -59,7 +59,7 @@
     "postNote": "Publicar Nota",
     "searchAndFilter": "Buscar y Filtrar",
     "search": "Buscar",
-    "new": "Nuevo",
+    "new": "<icon icon='plus-sign'>Nuevo</icon>",
     "hideSearchPane": "Ocultar panel de Búsqueda y Filtros.",
     "showSearchPane": "Mostrar panel Búsqueda y Filtros.",
     "numberOfFilters": "{count, number} {count, plural, one { applied filter } other { applied filters }}",

--- a/translations/stripes-smart-components/fr.json
+++ b/translations/stripes-smart-components/fr.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/fr.json
+++ b/translations/stripes-smart-components/fr.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/fr_FR.json
+++ b/translations/stripes-smart-components/fr_FR.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/fr_FR.json
+++ b/translations/stripes-smart-components/fr_FR.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/hu.json
+++ b/translations/stripes-smart-components/hu.json
@@ -59,7 +59,7 @@
     "postNote": "Post megjegyzés",
     "searchAndFilter": "Keresés & szűrő",
     "search": "Keresés",
-    "new": "+ Új",
+    "new": "Új",
     "hideSearchPane": "Keresés és szűrők ablak elrejtése.",
     "showSearchPane": "Keresés és szűrők ablak mutatása.",
     "numberOfFilters": "{count, number} {count, plural, one {alkalmazott szűrő} other {alkalmazott szűrők}}",

--- a/translations/stripes-smart-components/hu.json
+++ b/translations/stripes-smart-components/hu.json
@@ -59,7 +59,7 @@
     "postNote": "Post megjegyzés",
     "searchAndFilter": "Keresés & szűrő",
     "search": "Keresés",
-    "new": "Új",
+    "new": "<icon icon='plus-sign'>Új</icon>",
     "hideSearchPane": "Keresés és szűrők ablak elrejtése.",
     "showSearchPane": "Keresés és szűrők ablak mutatása.",
     "numberOfFilters": "{count, number} {count, plural, one {alkalmazott szűrő} other {alkalmazott szűrők}}",

--- a/translations/stripes-smart-components/it_IT.json
+++ b/translations/stripes-smart-components/it_IT.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/it_IT.json
+++ b/translations/stripes-smart-components/it_IT.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "New",
+    "new": "<icon icon='plus-sign'>New</icon>",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/pt_BR.json
+++ b/translations/stripes-smart-components/pt_BR.json
@@ -59,7 +59,7 @@
     "postNote": "Nota de correio",
     "searchAndFilter": "Pesquisa & Filtro",
     "search": "Pesquisa",
-    "new": "Novo",
+    "new": "<icon icon='plus-sign'>Novo</icon>",
     "hideSearchPane": "Ocultar painel de pesquisa e filtros.",
     "showSearchPane": "Mostrar painel de pesquisa e filtros.",
     "numberOfFilters": "{count, number} {count, plural, one {filtro aplicado} other {filtros aplicados}}",

--- a/translations/stripes-smart-components/pt_BR.json
+++ b/translations/stripes-smart-components/pt_BR.json
@@ -59,7 +59,7 @@
     "postNote": "Nota de correio",
     "searchAndFilter": "Pesquisa & Filtro",
     "search": "Pesquisa",
-    "new": "+ Novo",
+    "new": "Novo",
     "hideSearchPane": "Ocultar painel de pesquisa e filtros.",
     "showSearchPane": "Mostrar painel de pesquisa e filtros.",
     "numberOfFilters": "{count, number} {count, plural, one {filtro aplicado} other {filtros aplicados}}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9626,6 +9626,11 @@ react-hot-loader@^4.3.10:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
 
+react-intl-formatted-xml-message@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-intl-formatted-xml-message/-/react-intl-formatted-xml-message-1.0.1.tgz#83f8b3d9077a46d35bb2fddf4cdfb2a23c6bcec5"
+  integrity sha512-GLZpVgO01qe+zSzeu3aYgL+J/foI0DBGv+oJSQ9D7+r35XDsVonVSsbILI/AIkzFGXzmQl50mVImUW8L1xQUeQ==
+
 react-intl@^2.4.0, react-intl@^2.5.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.7.0.tgz#be1244769ce51f71476afb9556485a46090db5fa"


### PR DESCRIPTION
Stops screen readers from announcing "plus": https://issues.folio.org/browse/STCOM-391

### Before
![screen shot 2018-10-31 at 11 39 48 am](https://user-images.githubusercontent.com/230597/47804106-f9c5dd80-dd01-11e8-9ddf-9e24cb131112.png)

### After
![screen shot 2018-10-31 at 11 39 01 am](https://user-images.githubusercontent.com/230597/47804111-fc283780-dd01-11e8-99f5-d4f3b1b023be.png)
