### PR TITLE
STCOM-387 Remove Paneset from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Show details view of the newly created record after duplication. Fixes STSMACOM-140.
 * Open details screen after new record is created. Fixes STSMACOM-141.
 * Internalize logic of `<UserLink>` into `<ControlledVocab>` for efficiency. Fixes STSMACOM-142. Available from v1.10.2.
+* Remove `<Paneset>` from `<Settings>`
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
@@ -10,8 +10,7 @@ import {
   IconButton,
   NavList,
   NavListSection,
-  Pane,
-  Paneset
+  Pane
 } from '@folio/stripes-components';
 
 import css from './Settings.css';
@@ -83,7 +82,7 @@ class Settings extends React.Component {
     });
 
     return (
-      <Paneset nested defaultWidth="80%">
+      <Fragment>
         <Pane
           defaultWidth={props.navPaneWidth}
           paneTitle={props.paneTitle || 'Module Settings'}
@@ -102,7 +101,7 @@ class Settings extends React.Component {
         <Switch>
           {routes}
         </Switch>
-      </Paneset>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
## Purpose
Settings layouts can be difficult to compose with multiple layers of `<Paneset>`s.

Part of https://issues.folio.org/browse/STCOM-387

## Approach
Move away from nested `<Paneset>`s.

[`UINavigationController`](https://developer.apple.com/documentation/uikit/uinavigationcontroller), which `<Paneset>` is inspired by, cannot be nested. A stack of UI screens can only be one-deep. 

This was the only instance left in the `folio-org` (besides the deprecated `ui-scan`) of a `<Paneset>` using a `nested` prop.

This change might affect percentage widths set by some panes, but it did not seem to have too much impact.

