### PR TITLE
 Adjust search form styles

### DIFF
--- a/lib/ConfigManager/ConfigForm.js
+++ b/lib/ConfigManager/ConfigForm.js
@@ -15,7 +15,7 @@ const ConfigForm = (props) => {
   const lastMenu = (
     <Button
       type="submit"
-      buttonStyle="primary paneHeaderNewButton"
+      buttonStyle="primary"
       disabled={(pristine || submitting)}
       marginBottom0
       id="clickable-save-config"

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -180,7 +180,7 @@ class EntryWrapper extends React.Component {
               id={`${baseId}-add-new`}
               title={formatMessage({ id: 'stripes-core.button.new_tooltip' }, { entry: entryLabel })}
               onClick={this.onAdd}
-              buttonStyle="primary paneHeaderNewButton"
+              buttonStyle="primary"
               marginBottom0
             >
               {formatMessage({ id: 'stripes-core.button.new' })}

--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -1,3 +1,6 @@
+
+@import '@folio/stripes-components/lib/variables';
+
 /**
  * SearchAndSort
  */
@@ -5,4 +8,8 @@
 /* reset button wrap - minor alignment adjustment */
 .resetButtonWrap {
   margin-left: -3px;
+}
+
+.searchField {
+  margin-bottom: calc(var(--control-margin-bottom) / 2);
 }

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -620,6 +620,8 @@ class SearchAndSort extends React.Component {
                 onClear={this.onClearSearchQuery}
                 value={searchTerm}
                 loading={source.pending()}
+                marginBottom0
+                className={css.searchField}
               />
               <Button
                 type="submit"
@@ -630,7 +632,6 @@ class SearchAndSort extends React.Component {
               >
                 <FormattedMessage id="stripes-smart-components.search" />
               </Button>
-              <hr />
               { this.renderResetButton() }
               <FilterGroups
                 config={filterConfig}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -504,7 +504,7 @@ class SearchAndSort extends React.Component {
             href={this.craftLayerUrl('create')}
             onClick={this.addNewRecord}
             aria-label={formatMessage({ id: 'stripes-smart-components.addNew' })}
-            buttonStyle="primary paneHeaderNewButton"
+            buttonStyle="primary"
             marginBottom0
           >
             {formatMessage({ id: 'stripes-smart-components.new' })}


### PR DESCRIPTION
Request from @filipjakobsen; moves the search button `0.5rem` closer to the search field, so their relationship is clearer. Removes the `<hr />`.

### Before
![localhost_3000_users_sort name ipad 1](https://user-images.githubusercontent.com/230597/47893837-1f033a80-de2d-11e8-850f-007551afb17a.png)

### After
![localhost_3000_users_sort name ipad](https://user-images.githubusercontent.com/230597/47893839-21fe2b00-de2d-11e8-9a15-b8a63acbafc5.png)