### PR TITLE
Clear query resource on component unmount. Fixes STSMACOM-146

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -238,6 +238,8 @@ class SearchAndSort extends React.Component {
   }
 
   componentWillUnmount() {
+    this.props.parentMutator.query.replace({});
+
     if (this.props.onComponentWillUnmount) {
       this.props.onComponentWillUnmount(this.props);
     }


### PR DESCRIPTION
It looks like the query resource (which sits in the redux store) was not cleaned up properly when `SearchAndSort` was unmounted. This PR cleans the query resource during `componentWillUnmount ` lifecycle. 