### PR TITLE
Replace formatMessage() with FormattedMessage in SearchAndSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Internalize logic of `<UserLink>` into `<ControlledVocab>` for efficiency. Fixes STSMACOM-142. Available from v1.10.2.
 * Remove `<Paneset>` from `<Settings>`
 * Clear query resource on `SearchAndSort` component unmount. Fixes STSMACOM-146.
+* Replace `formatMessage()` with `<FormattedMessage>` in `<SearchAndSort>`
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { FormattedXmlMessage } from 'react-intl-formatted-xml-message';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core';
@@ -70,7 +70,6 @@ class SearchAndSort extends React.Component {
     getHelperResourcePath: PropTypes.func,
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
-    intl: intlShape,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired,
@@ -200,7 +199,7 @@ class SearchAndSort extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated
-    const { intl: { formatMessage }, stripes: { logger } } = this.props;
+    const { stripes: { logger } } = this.props;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
 
@@ -223,7 +222,7 @@ class SearchAndSort extends React.Component {
       this.log('event', 'new search-result');
       const count = newState.totalCount();
       this.SRStatus.sendMessage(
-        formatMessage({ id: 'stripes-smart-components.searchReturnedResults' }, { count })
+        <FormattedMessage id="stripes-smart-components.searchReturnedResults" values={{ count }} />
       );
     }
 
@@ -475,7 +474,6 @@ class SearchAndSort extends React.Component {
 
   render() {
     const {
-      intl: { formatMessage },
       parentResources,
       filterConfig,
       disableFilters,
@@ -503,38 +501,48 @@ class SearchAndSort extends React.Component {
     const newRecordButton = !newRecordPerms ? null : (
       <IfPermission perm={newRecordPerms}>
         <PaneMenu>
-          <Button
-            id={`clickable-new${objectName}`}
-            href={this.craftLayerUrl('create')}
-            onClick={this.addNewRecord}
-            aria-label={formatMessage({ id: 'stripes-smart-components.addNew' })}
-            buttonStyle="primary"
-            marginBottom0
-          >
-            <FormattedXmlMessage
-              id="stripes-smart-components.new"
-              tags={{ 'icon': (<Icon />) }}
-            />
-          </Button>
+          <FormattedMessage id="stripes-smart-components.addNew">
+            {ariaLabel => (
+              <Button
+                id={`clickable-new${objectName}`}
+                href={this.craftLayerUrl('create')}
+                onClick={this.addNewRecord}
+                aria-label={ariaLabel}
+                buttonStyle="primary"
+                marginBottom0
+              >
+                <FormattedXmlMessage
+                  id="stripes-smart-components.new"
+                  tags={{ 'icon': (<Icon />) }}
+                />
+              </Button>
+            )}
+          </FormattedMessage>
         </PaneMenu>
       </IfPermission>
     );
 
     const { filterPaneIsVisible } = this.state;
     const filterCount = Object.keys(filters).length;
-    const hidePaneMsg = formatMessage({ id: 'stripes-smart-components.hideSearchPane' });
-    const showPaneMsg = formatMessage({ id: 'stripes-smart-components.showSearchPane' });
-    const appliedFiltersMsg = formatMessage({ id: 'stripes-smart-components.numberOfFilters' }, { count: filterCount });
-    const toggleFilterPaneMessage = `${filterPaneIsVisible ? hidePaneMsg : showPaneMsg} \n\n${appliedFiltersMsg}`;
+    const hideOrShowMessageId =
+      filterPaneIsVisible ? 'stripes-smart-components.hideSearchPane' : 'stripes-smart-components.showSearchPane';
 
     const resultsFirstMenu = (
       <PaneMenu>
-        <IconButton
-          icon="search"
-          aria-label={toggleFilterPaneMessage}
-          onClick={this.toggleFilterPane}
-          badgeCount={!filterPaneIsVisible && filterCount ? filterCount : undefined}
-        />
+        <FormattedMessage id="stripes-smart-components.numberOfFilters" values={{ count: filterCount }}>
+          {appliedFiltersMessage => (
+            <FormattedMessage id={hideOrShowMessageId}>
+              {hideOrShowMessage => (
+                <IconButton
+                  icon="search"
+                  aria-label={`${hideOrShowMessage} \n\n${appliedFiltersMessage}`}
+                  onClick={this.toggleFilterPane}
+                  badgeCount={!filterPaneIsVisible && filterCount ? filterCount : undefined}
+                />
+              )}
+            </FormattedMessage>
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
 
@@ -603,8 +611,11 @@ class SearchAndSort extends React.Component {
       this.props.resultCountMessageKey ?
         this.props.resultCountMessageKey : 'stripes-smart-components.searchResultsCountHeader';
     const paneSub =
-      !source.loaded() ?
-        formatMessage({ id: 'stripes-smart-components.searchCriteria' }) : formatMessage({ id: messageKey }, { count });
+      !source.loaded() ? (
+        <FormattedMessage id="stripes-smart-components.searchCriteria" />
+      ) : (
+        <FormattedMessage id={messageKey} values={{ count }} />
+      );
 
     return (
       <Paneset>
@@ -614,7 +625,7 @@ class SearchAndSort extends React.Component {
           <Pane
             id="pane-filter"
             defaultWidth="320px"
-            paneTitle={formatMessage({ id: 'stripes-smart-components.searchAndFilter' })}
+            paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
             onClose={this.toggleFilterPane}
           >
             <form onSubmit={this.onSubmitSearch}>
@@ -665,28 +676,32 @@ class SearchAndSort extends React.Component {
           firstMenu={resultsFirstMenu}
           noOverflow
         >
-          <MultiColumnList
-            id={`list-${moduleName}`}
-            totalCount={count}
-            contentData={records}
-            selectedRow={this.state.selectedItem}
-            formatter={this.props.resultsFormatter}
-            onRowClick={this.onSelectRow}
-            onHeaderClick={this.onSort}
-            onNeedMoreData={this.onNeedMore}
-            visibleColumns={this.props.visibleColumns}
-            sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
-            sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
-            isEmptyMessage={message}
-            columnWidths={this.props.columnWidths}
-            columnMapping={this.props.columnMapping}
-            loading={source.pending()}
-            autosize
-            virtualize
-            ariaLabel={formatMessage({ id: 'stripes-smart-components.searchResults' }, { objectName: objectNameUC })}
-            rowFormatter={this.anchoredRowFormatter}
-            containerRef={(ref) => { this.resultsList = ref; }}
-          />
+          <FormattedMessage id="stripes-smart-components.searchResults" values={{ objectName: objectNameUC }}>
+            { ariaLabel => (
+              <MultiColumnList
+                id={`list-${moduleName}`}
+                totalCount={count}
+                contentData={records}
+                selectedRow={this.state.selectedItem}
+                formatter={this.props.resultsFormatter}
+                onRowClick={this.onSelectRow}
+                onHeaderClick={this.onSort}
+                onNeedMoreData={this.onNeedMore}
+                visibleColumns={this.props.visibleColumns}
+                sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
+                sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
+                isEmptyMessage={message}
+                columnWidths={this.props.columnWidths}
+                columnMapping={this.props.columnMapping}
+                loading={source.pending()}
+                autosize
+                virtualize
+                ariaLabel={ariaLabel}
+                rowFormatter={this.anchoredRowFormatter}
+                containerRef={(ref) => { this.resultsList = ref; }}
+              />
+            )}
+          </FormattedMessage>
         </Pane>
         { !this.props.browseOnly && detailsPane }
         { !this.props.browseOnly && createRecordLayer }
@@ -700,5 +715,5 @@ class SearchAndSort extends React.Component {
 export default withRouter(
   withModule(
     props => props.packageInfo && props.packageInfo.name
-  )(withStripes(injectIntl(SearchAndSort)))
+  )(withStripes(SearchAndSort))
 );


### PR DESCRIPTION
For `<SearchAndSort>`, uses the preferred (and future-friendly) `react-intl` API, `<FormattedMessage>`, since there was no reason to fall back to `intl.formatMessage()` with `injectIntl()`.