### PR TITLE
STSMACOM-145: Update text and position of "+ Add address" button on User record

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -53,7 +53,6 @@
 .addressFormList {
   list-style: none;
   padding: 0;
-  margin-bottom: 0;
 }
 
 .addressFormListItem {

--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -75,7 +75,9 @@ class AddressEditList extends React.Component {
           <Col xs>
             <Layout>
               <Button type="button" onClick={() => { this.onAdd(fields); }}>
-                <FormattedMessage id="stripes-smart-components.address.addAddress" />
+                <FormattedMessage
+                  id="stripes-smart-components.address.addAddress"
+                />
               </Button>
             </Layout>
           </Col>

--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FieldArray } from 'redux-form';
 import { Button, Col, Layout, Row } from '@folio/stripes-components';
+import { FormattedMessage } from 'react-intl';
 import EmbeddedAddressForm from './EmbeddedAddressForm';
 import css from './AddressEdit.css';
 
@@ -50,11 +51,6 @@ class AddressEditList extends React.Component {
           <Col xs>
             <div className={css.legend} id="addressGroupLabel">{this.props.label}</div>
           </Col>
-          <Col xs={4}>
-            <Layout className="right">
-              <Button type="button" onClick={() => { this.onAdd(fields); }}>+ New</Button>
-            </Layout>
-          </Col>
         </Row>
         <Row>
           <Col xs>
@@ -73,6 +69,15 @@ class AddressEditList extends React.Component {
                 </li>
               ))}
             </ul>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs>
+            <Layout>
+              <Button type="button" onClick={() => { this.onAdd(fields); }}>
+                <FormattedMessage id="stripes-smart-components.address.addAddress" />
+              </Button>
+            </Layout>
           </Col>
         </Row>
       </div>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import { FormattedXmlMessage } from 'react-intl-formatted-xml-message';
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import { withStripes } from '@folio/stripes-core';
 import queryString from 'query-string';
@@ -20,7 +19,6 @@ import FilterGroups, {
 import {
   Button,
   IfPermission,
-  Icon,
   IconButton,
   Layer,
   MultiColumnList,
@@ -511,9 +509,8 @@ class SearchAndSort extends React.Component {
             buttonStyle="primary"
             marginBottom0
           >
-            <FormattedXmlMessage
+            <FormattedMessage
               id="stripes-smart-components.new"
-              tags={{ 'icon': (<Icon />) }}
             />
           </Button>
         </PaneMenu>

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -100,5 +100,6 @@
   "password.keyboardSequence.invalid": "The password must not contain a keyboard sequence.",
   "password.repeatingSymbols.invalid": "The password must not contain the same character in a row.",
   "password.whiteSpace.invalid": "The password must not contain whitespaces.",
-  "password.lastTenPasswords.invalid": "Previously used password. Please enter a new password."
+  "password.lastTenPasswords.invalid": "Previously used password. Please enter a new password.",
+  "address.addAddress": "\u002B Add address"
 }

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -63,7 +63,7 @@
   "searchAndFilter": "Search & filter",
   "search": "Search",
   "addNew": "Add new",
-  "new": "<icon icon='plus-sign'>New</icon>",
+  "new": "New",
   "hideSearchPane": "Hide search and filters pane.",
   "showSearchPane": "Show search and filters pane.",
   "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",
@@ -101,5 +101,5 @@
   "password.repeatingSymbols.invalid": "The password must not contain the same character in a row.",
   "password.whiteSpace.invalid": "The password must not contain whitespaces.",
   "password.lastTenPasswords.invalid": "Previously used password. Please enter a new password.",
-  "address.addAddress": "\u002B Add address"
+  "address.addAddress": "Add address"
 }


### PR DESCRIPTION
According to [this](https://issues.folio.org/browse/STSMACOM-145) story, "Add address" button should be aligned to the left so that the label text and position for this type of button follow the latest general FOLIO style guidelines:

![user-details-4](https://user-images.githubusercontent.com/43514877/48004115-ff179380-e118-11e8-8913-935c327889ec.png)
