### PR TITLE
Replace all formatMessage() with <FormattedMessage />

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -190,7 +190,6 @@ Address
               <Button
                 buttonStyle="link slim"
                 style={{ margin: 0, padding: 0 }}
-                title={`remove address ${this.props.fieldKey + 1}`}
                 onClick={() => { this.props.handleDelete(fieldKey); }}
               >
                 <Icon icon="trashBin" width="24px" height="24px" />

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import take from 'lodash/take';
 import uniqueId from 'lodash/uniqueId';
 
@@ -43,8 +43,6 @@ const propTypes = {
     edit: PropTypes.func,
     view: PropTypes.func,
   }),
-
-  intl: intlShape.isRequired,
 
   /**
    *  Displays a custom <h2> tag at top of listing. Default: 'Address'
@@ -238,7 +236,6 @@ class AddressList extends React.Component {
       canDelete,
       canEdit,
       headerFormatter,
-      intl: { formatMessage },
       ...viewProps
     } = this.props;
 
@@ -305,7 +302,6 @@ class AddressList extends React.Component {
         <Headline tag="h4" size="medium">{label}</Headline>
         {addAddressButton}
         <div
-          aria-label={formatMessage({ id: 'stripes-components.addressSection' })}
           tabIndex="0"
           role="tabpanel"
           ref={(ref) => { this.container = ref; }}
@@ -345,4 +341,4 @@ class AddressList extends React.Component {
 AddressList.propTypes = propTypes;
 AddressList.defaultProps = defaultProps;
 
-export default injectIntl(AddressList);
+export default AddressList;

--- a/lib/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/AddressFieldGroup/AddressView/AddressView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { has } from 'lodash';
 
@@ -12,7 +12,6 @@ const propTypes = {
   handleEdit: PropTypes.func,
   headerField: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
   headerFormatter: PropTypes.func,
-  intl: intlShape.isRequired,
   labelMap: PropTypes.object,
   uiId: PropTypes.string,
   visibleFields: PropTypes.arrayOf(PropTypes.string),
@@ -40,17 +39,17 @@ function AddressView(props) {
     uiId,
     visibleFields,
     headerFormatter,
-    intl: { formatMessage }
   } = props;
 
   const defaultLabelMap = {
-    addressLine1: formatMessage({ id: 'stripes-components.addressLine1' }),
-    addressLine2: formatMessage({ id: 'stripes-components.addressLine2' }),
-    stateRegion: formatMessage({ id: 'stripes-components.stateProviceOrRegion' }),
-    zipCode: formatMessage({ id: 'stripes-components.zipOrPostalCode' }),
-    addressType: formatMessage({ id: 'stripes-components.addressType' }),
-    city: formatMessage({ id: 'stripes-components.city' }),
-    country: formatMessage({ id: 'stripes-components.country' }),
+
+    addressLine1: <FormattedMessage id="stripes-components.addressLine1" />,
+    addressLine2: <FormattedMessage id="stripes-components.addressLine2" />,
+    stateRegion: <FormattedMessage id="stripes-components.stateProviceOrRegion" />,
+    zipCode: <FormattedMessage id="stripes-components.zipOrPostalCode" />,
+    addressType: <FormattedMessage id="stripes-components.addressType" />,
+    city: <FormattedMessage id="stripes-components.city" />,
+    country: <FormattedMessage id="stripes-components.country" />
   };
   const labelMap = props.labelMap || defaultLabelMap;
   const groupArray = [];
@@ -73,12 +72,12 @@ function AddressView(props) {
   }, this);
 
   const actions = [{
-    title: formatMessage({ id: 'stripes-components.editThisAddress' }),
+    title: <FormattedMessage id="stripes-components.editThisAddress" />,
     icon: 'edit',
     handler: () => handleEdit(uiId)
   }];
-  const primaryAddressMsg = formatMessage({ id: 'stripes-components.primaryAddress' });
-  const alternateAddressMsg = formatMessage({ id: 'stripes-components.alternateAddress' });
+  const primaryAddressMsg = <FormattedMessage id="stripes-components.primaryAddress" />;
+  const alternateAddressMsg = <FormattedMessage id="stripes-components.alternateAddress" />;
 
   return (
     <div
@@ -99,4 +98,4 @@ function AddressView(props) {
 AddressView.propTypes = propTypes;
 AddressView.defaultProps = defaultProps;
 
-export default injectIntl(AddressView);
+export default AddressView;

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, isEqual, pickBy } from 'lodash';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import moment from 'moment';
 
 import { Button, Icon, Layout } from '@folio/stripes-components';
@@ -67,7 +67,6 @@ class ChangeDueDate extends React.Component {
 
   static propTypes = {
     alerts: PropTypes.object,
-    intl: intlShape,
     loans: PropTypes.arrayOf(
       PropTypes.shape({
         dueDate: PropTypes.string,
@@ -161,7 +160,6 @@ class ChangeDueDate extends React.Component {
   }
 
   changeDueDate() {
-    const { intl: { formatMessage } } = this.props;
     const loans = this.getUpdatedLoans();
 
     const promises = loans
@@ -178,7 +176,7 @@ class ChangeDueDate extends React.Component {
         if (error.url && error.url.indexOf(putEndpoint)) {
           const failedLoan = error.url.split(putEndpoint)[1];
           this.props.onDueDateChangeFailed({
-            [failedLoan]: formatMessage({ id: 'stripes-smart-components.cddd.changeFailed' })
+            [failedLoan]: <FormattedMessage id="stripes-smart-components.cddd.changeFailed" />
           });
         } else {
           this.props.onDueDateChangeFailed(error);
@@ -222,7 +220,7 @@ class ChangeDueDate extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, loans } = this.props;
+    const { loans } = this.props;
 
     if (!loans.length) return null;
 
@@ -249,8 +247,8 @@ class ChangeDueDate extends React.Component {
             date: '',
             time: ChangeDueDate.DEFAULT_TIME,
           }}
-          dateProps={{ label: formatMessage({ id: 'stripes-smart-components.cddd.date' }) + '*' }}
-          timeProps={{ label: formatMessage({ id: 'stripes-smart-components.cddd.time' }) + '*' }}
+          dateProps={{ label: <FormattedMessage id="stripes-smart-components.cddd.date" /> }}
+          timeProps={{ label: <FormattedMessage id="stripes-smart-components.cddd.time" /> }}
         />
         <this.connectedLoanList
           stripes={this.props.stripes}
@@ -279,4 +277,4 @@ class ChangeDueDate extends React.Component {
   }
 }
 
-export default injectIntl(ChangeDueDate);
+export default ChangeDueDate;

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, isEqual } from 'lodash';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Icon, Modal } from '@folio/stripes-components';
 
@@ -28,7 +28,6 @@ class ChangeDueDateDialog extends React.Component {
   }
 
   static propTypes = {
-    intl: intlShape,
     loanIds: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string,
@@ -141,13 +140,12 @@ class ChangeDueDateDialog extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage } } = this.props;
     const { succeeded } = this.state;
 
     const BodyComponent = succeeded ? ChangeDueDateSuccess : this.connectedChangeDueDate;
     const modalLabel = succeeded ?
-      formatMessage({ id: 'stripes-smart-components.cddd.changeDueDateConfirmation' }) :
-      formatMessage({ id: 'stripes-smart-components.cddd.changeDueDate' });
+      <FormattedMessage id="stripes-smart-components.cddd.changeDueDateConfirmation" /> :
+      <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />;
 
     return (
       <Modal
@@ -173,4 +171,4 @@ class ChangeDueDateDialog extends React.Component {
   }
 }
 
-export default injectIntl(ChangeDueDateDialog);
+export default ChangeDueDateDialog;

--- a/lib/ChangeDueDateDialog/DueDatePicker.js
+++ b/lib/ChangeDueDateDialog/DueDatePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
-import { injectIntl } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 
 import DueDatePickerForm from './DueDatePickerForm';
 
@@ -12,6 +12,7 @@ class DueDatePicker extends React.Component {
       date: PropTypes.string,
       time: PropTypes.string,
     }),
+    intl: intlShape,
     onChange: PropTypes.func,
     timeProps: PropTypes.object
   }

--- a/lib/ChangeDueDateDialog/DueDatePicker.js
+++ b/lib/ChangeDueDateDialog/DueDatePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import DueDatePickerForm from './DueDatePickerForm';
 
@@ -12,7 +12,6 @@ class DueDatePicker extends React.Component {
       date: PropTypes.string,
       time: PropTypes.string,
     }),
-    intl: intlShape,
     onChange: PropTypes.func,
     timeProps: PropTypes.object
   }

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row } from '@folio/stripes-components';
@@ -38,7 +38,6 @@ class ControlledVocab extends React.Component {
     columnMapping: PropTypes.object,
     formatter: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
-    intl: intlShape,
     itemTemplate: PropTypes.object,
     label: PropTypes.string.isRequired,
     labelSingular: PropTypes.string.isRequired,
@@ -214,7 +213,6 @@ class ControlledVocab extends React.Component {
   }
 
   validate({ items }) {
-    const { intl: { formatMessage } } = this.props;
     const { primaryField } = this.state;
 
     if (Array.isArray(items)) {
@@ -227,7 +225,7 @@ class ControlledVocab extends React.Component {
         // Check if the primary field has had data entered into it.
         if (!item[primaryField]) {
           itemErrors[primaryField] =
-            formatMessage({ id: 'stripes-core.label.missingRequiredField' });
+            <FormattedMessage id="stripes-core.label.missingRequiredField" />;
         }
 
         // Add the errors if we found any for this record.
@@ -245,13 +243,12 @@ class ControlledVocab extends React.Component {
   }
 
   renderItemInUseDialog() {
-    const { intl: { formatMessage } } = this.props;
     const type = this.props.labelSingular.toLowerCase();
 
     return (
       <Modal
         open={this.state.showItemInUseDialog}
-        label={formatMessage({ id: 'stripes-smart-components.cv.cannotDeleteTermHeader' }, { type })}
+        label={<FormattedMessage id="stripes-smart-components.cv.cannotDeleteTermHeader" values={{ type }} />}
         size="small"
       >
         <Row>
@@ -275,7 +272,7 @@ class ControlledVocab extends React.Component {
    * See STCOM-308.
    */
   renderLastUpdated = (metadata) => {
-    const { intl, stripes } = this.props;
+    const { stripes } = this.props;
 
     if (!this.metadataCache[metadata.updatedByUserId]) {
       if (stripes.hasPerm('ui-users.view')) {
@@ -296,7 +293,7 @@ class ControlledVocab extends React.Component {
         <FormattedMessage
           id="stripes-smart-components.cv.updatedAtAndBy"
           values={{
-            date: intl.formatDate(metadata.updatedDate),
+            date: <FormattedDate value={metadata.updatedDate} />,
             user: this.metadataCache[metadata.updatedByUserId],
           }}
         />
@@ -307,7 +304,6 @@ class ControlledVocab extends React.Component {
   render() {
     if (!this.props.resources.values) return <div />;
 
-    const { intl: { formatMessage } } = this.props;
     const type = this.props.labelSingular.toLowerCase();
     const term = this.state.selectedItem[this.state.primaryField];
 
@@ -334,7 +330,7 @@ class ControlledVocab extends React.Component {
               // Seems to load this once before the groups data from the manifest
               // is pulled in. This still causes a JS warning, but not an error
               contentData={rows}
-              createButtonLabel={formatMessage({ id: 'stripes-core.button.new' })}
+              createButtonLabel={<FormattedMessage id="stripes-core.button.new" />}
               itemTemplate={this.props.itemTemplate}
               visibleFields={[
                 ...this.props.visibleFields,
@@ -343,10 +339,12 @@ class ControlledVocab extends React.Component {
               ].filter(field => !this.props.hiddenFields.includes(field))}
               columnMapping={{
                 name: this.props.labelSingular,
-                lastUpdated: formatMessage({ id: 'stripes-smart-components.cv.lastUpdated' }),
-                numberOfObjects: formatMessage(
-                  { id: 'stripes-smart-components.cv.numberOfObjects' },
-                  { objects: this.props.objectLabel }
+                lastUpdated: <FormattedMessage id="stripes-smart-components.cv.lastUpdated" />,
+                numberOfObjects: (
+                  <FormattedMessage
+                    id="stripes-smart-components.cv.numberOfObjects"
+                    values={{ objects: this.props.objectLabel }}
+                  />
                 ),
                 ...this.props.columnMapping,
               }}
@@ -371,8 +369,10 @@ class ControlledVocab extends React.Component {
               onCreate={this.onCreateItem}
               onDelete={this.showConfirmDialog}
               isEmptyMessage={
-                formatMessage({ id: 'stripes-smart-components.cv.noExistingTerms' },
-                  { terms: this.props.label.toLowerCase() })
+                <FormattedMessage
+                  id="stripes-smart-components.cv.noExistingTerms"
+                  values={{ terms: this.props.label.toLowerCase() }}
+                />
               }
               validate={this.validate}
             />
@@ -380,11 +380,11 @@ class ControlledVocab extends React.Component {
           <ConfirmationModal
             id={`delete${type.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}-confirmation`}
             open={this.state.showConfirmDialog}
-            heading={formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: type })}
+            heading={<FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: type }} />}
             message={modalMessage}
             onConfirm={this.onDeleteItem}
             onCancel={this.hideConfirmDialog}
-            confirmLabel={formatMessage({ id: 'stripes-core.button.delete' })}
+            confirmLabel={<FormattedMessage id="stripes-core.button.delete" />}
           />
           { this.renderItemInUseDialog() }
           <Callout ref={(ref) => { this.callout = ref; }} />
@@ -394,4 +394,4 @@ class ControlledVocab extends React.Component {
   }
 }
 
-export default injectIntl(ControlledVocab);
+export default ControlledVocab;

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -2,6 +2,7 @@ import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
@@ -368,22 +369,32 @@ class EditableListForm extends React.Component {
     return (
       <div style={{ display: 'flex' }}>
         {!actionSuppression.edit(item) &&
-          <IconButton
-            icon="edit"
-            size="small"
-            id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
-            onClick={() => this.onEdit(item.rowIndex)}
-            {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
-          />
+          <FormattedMessage id="stripes-components.editThisItem">
+            {ariaLabel => (
+              <IconButton
+                icon="edit"
+                size="small"
+                id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
+                aria-label={ariaLabel}
+                onClick={() => this.onEdit(item.rowIndex)}
+                {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
+              />
+            )}
+          </FormattedMessage>
         }
         {!actionSuppression.delete(item) &&
-          <IconButton
-            icon="trashBin"
-            size="small"
-            id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
-            onClick={() => this.onDelete(fields, item.rowIndex)}
-            {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
-          />
+          <FormattedMessage id="stripes-components.deleteThisItem">
+            {ariaLabel => (
+              <IconButton
+                icon="trashBin"
+                size="small"
+                id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
+                aria-label={ariaLabel}
+                onClick={() => this.onDelete(fields, item.rowIndex)}
+                {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
+              />
+            )}
+          </FormattedMessage>
         }
       </div>
     );

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -2,7 +2,6 @@ import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { FieldArray } from 'redux-form';
 import PropTypes from 'prop-types';
@@ -61,7 +60,6 @@ const propTypes = {
   * Initial form values
   */
   initialValues: PropTypes.object,
-  intl: intlShape.isRequired,
   /**
    * boolean that indicates if there are validation errors.
    */
@@ -342,7 +340,7 @@ class EditableListForm extends React.Component {
   }
 
   getActions = (fields, item) => {
-    const { actionProps, actionSuppression, pristine, submitting, invalid, intl: { formatMessage } } = this.props;
+    const { actionProps, actionSuppression, pristine, submitting, invalid } = this.props;
 
     if (this.state.status[item.rowIndex].editing) {
       return (
@@ -351,7 +349,6 @@ class EditableListForm extends React.Component {
             disabled={pristine || submitting || invalid}
             marginBottom0
             id={`clickable-save-${this.testingId}-${item.rowIndex}`}
-            title={formatMessage({ id: 'stripes-components.saveChangesToThisItem' })}
             onClick={() => this.onSave(fields, item.rowIndex)}
             {...(typeof actionProps.save === 'function' ? actionProps.save(item) : {})}
           >
@@ -360,7 +357,6 @@ class EditableListForm extends React.Component {
           <Button
             marginBottom0
             id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
-            title={formatMessage({ id: 'stripes-components.cancelEditingThisItem' })}
             onClick={() => this.onCancel(fields, item.rowIndex)}
             {...(typeof actionProps.cancel === 'function' ? actionProps.cancel(item) : {})}
           >
@@ -377,7 +373,6 @@ class EditableListForm extends React.Component {
             size="small"
             id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onEdit(item.rowIndex)}
-            title={formatMessage({ id: 'stripes-components.editThisItem' })}
             {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
           />
         }
@@ -387,7 +382,6 @@ class EditableListForm extends React.Component {
             size="small"
             id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onDelete(fields, item.rowIndex)}
-            title={formatMessage({ id: 'stripes-components.deleteThisItem' })}
             {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
           />
         }
@@ -451,4 +445,4 @@ export default stripesForm({
   navigationCheck: true,
   enableReinitialize: true,
   destroyOnUnmount: false,
-})(injectIntl(EditableListForm));
+})(EditableListForm);

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { Button, ConfirmationModal, Pane, PaneMenu, Paneset } from '@folio/stripes-components';
 import stripesForm from '@folio/stripes-form';
@@ -13,7 +13,6 @@ class EntryForm extends React.Component {
     formComponent: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
-    intl: intlShape,
     nameKey: PropTypes.string.isRequired,
     onCancel: PropTypes.func,
     onRemove: PropTypes.func,
@@ -41,18 +40,20 @@ class EntryForm extends React.Component {
   }
 
   addFirstMenu() {
-    const { intl: { formatMessage } } = this.props;
-
     return (
       <PaneMenu>
-        <button
-          id="clickable-close-entry"
-          onClick={this.props.onCancel}
-          aria-label={formatMessage({ id: 'stripes-smart-components.closeEntryDialog' })}
-          type="button"
-        >
-          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
-        </button>
+        <FormattedMessage id="stripes-smart-components.closeEntryDialog">
+          {ariaLabel => (
+            <button
+              id="clickable-close-entry"
+              onClick={this.props.onCancel}
+              aria-label={ariaLabel}
+              type="button"
+            >
+              <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }}>&times;</span>
+            </button>
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
@@ -77,33 +78,32 @@ class EntryForm extends React.Component {
   }
 
   saveLastMenu() {
-    const { intl: { formatMessage }, pristine, submitting } = this.props;
+    const { pristine, submitting } = this.props;
 
     return (
       <PaneMenu>
         <Button
           id="clickable-save-entry"
           type="submit"
-          title={formatMessage({ id: 'stripes-core.button.saveAndClose' })}
           disabled={(pristine || submitting)}
           marginBottom0
         >
-          {formatMessage({ id: 'stripes-core.button.saveAndClose' })}
+          <FormattedMessage id="stripes-core.button.saveAndClose" />
         </Button>
       </PaneMenu>
     );
   }
 
   render() {
-    const { handleSubmit, initialValues, intl: { formatMessage }, permissions, stripes } = this.props;
+    const { handleSubmit, initialValues, permissions, stripes } = this.props;
     const selectedEntry = initialValues || {};
     const { confirmDelete } = this.state;
     const disabled = !stripes.hasPerm(permissions.put);
     const paneTitle = selectedEntry && selectedEntry.id ?
-      formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: this.props.entryLabel }) :
-      formatMessage({ id: 'stripes-core.label.createEntry' }, { entry: this.props.entryLabel });
+      <FormattedMessage id="stripes-core.label.editEntry" values={{ entry: this.props.entryLabel }} /> :
+      <FormattedMessage id="stripes-core.label.createEntry" values={{ entry: this.props.entryLabel }} />;
     const deleteButtonText =
-      formatMessage({ id: 'stripes-core.button.deleteEntry' }, { entry: this.props.entryLabel });
+      <FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: this.props.entryLabel }} />;
 
     let deleteButton;
     if (selectedEntry && selectedEntry.id && this.props.stripes.hasPerm(permissions.delete)) {
@@ -125,7 +125,7 @@ class EntryForm extends React.Component {
       <SafeHTMLMessage
         id="stripes-core.label.confirmDeleteEntry"
         values={{
-          name: selectedEntry[this.props.nameKey] || formatMessage({ id: 'stripes-core.untitled' }),
+          name: selectedEntry[this.props.nameKey] || <FormattedMessage id="stripes-core.untitled" />,
         }}
       />
     );
@@ -154,8 +154,8 @@ class EntryForm extends React.Component {
                 message={message}
                 onConfirm={() => { this.confirmDeleteSet(true); }}
                 onCancel={() => { this.confirmDeleteSet(false); }}
-                confirmLabel={formatMessage({ id: 'stripes-core.button.delete' })}
-                cancelLabel={formatMessage({ id: 'stripes-core.button.cancel' })}
+                confirmLabel={<FormattedMessage id="stripes-core.button.delete" />}
+                cancelLabel={<FormattedMessage id="stripes-core.button.cancel" />}
               />
             }
           </Pane>
@@ -169,4 +169,4 @@ export default stripesForm({
   form: 'entryForm',
   navigationCheck: true,
   enableReinitialize: false,
-})(injectIntl(EntryForm));
+})(EntryForm);

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -109,13 +109,13 @@ class EntryForm extends React.Component {
     if (selectedEntry && selectedEntry.id && this.props.stripes.hasPerm(permissions.delete)) {
       if (this.props.deleteDisabled(selectedEntry)) {
         deleteButton = (
-          <Button title={this.props.deleteDisabledMessage} disabled>
+          <Button disabled>
             {deleteButtonText}
           </Button>
         );
       } else {
         deleteButton = (
-          <Button title={deleteButtonText} onClick={this.beginDelete} disabled={confirmDelete}>
+          <Button onClick={this.beginDelete} disabled={confirmDelete}>
             {deleteButtonText}
           </Button>
         );

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { omit } from 'lodash';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Button, Callout, EntrySelector, IfPermission, Layer, PaneMenu } from '@folio/stripes-components';
 import queryString from 'query-string';
@@ -11,7 +11,7 @@ import find from 'lodash/find';
 
 import EntryForm from './EntryForm';
 
-class EntryWrapper extends React.Component {
+export default class EntryWrapper extends React.Component {
   static manifest = Object.freeze({
     query: { initialValue: {} },
   });
@@ -36,7 +36,6 @@ class EntryWrapper extends React.Component {
       push: PropTypes.func.isRequired,
     }).isRequired,
     idFromPathnameRe: PropTypes.string,
-    intl: intlShape,
     location: PropTypes.object.isRequired,
     mutator: PropTypes.object,
     nameKey: PropTypes.string.isRequired,
@@ -147,9 +146,14 @@ class EntryWrapper extends React.Component {
   }
 
   render() {
-    const { entryList, location, permissions,
-      entryLabel, parseInitialValues,
-      nameKey, intl: { formatMessage } } = this.props;
+    const {
+      entryList,
+      location,
+      permissions,
+      entryLabel,
+      parseInitialValues,
+      nameKey
+    } = this.props;
     const { selectedId } = this.state;
 
     const query = location.search ? queryString.parse(location.search) : {};
@@ -178,12 +182,11 @@ class EntryWrapper extends React.Component {
           <PaneMenu>
             <Button
               id={`${baseId}-add-new`}
-              title={formatMessage({ id: 'stripes-core.button.new_tooltip' }, { entry: entryLabel })}
               onClick={this.onAdd}
               buttonStyle="primary"
               marginBottom0
             >
-              {formatMessage({ id: 'stripes-core.button.new' })}
+              <FormattedMessage id="stripes-core.button.new" />
             </Button>
           </PaneMenu>
         </IfPermission>
@@ -209,7 +212,7 @@ class EntryWrapper extends React.Component {
       >
         <Layer
           isOpen={!!(query.layer)}
-          label={formatMessage({ id: 'stripes-core.label.editEntry' }, { entry: entryLabel })}
+          label={<FormattedMessage id="stripes-core.label.editEntry" values={{ entry: entryLabel }} />}
           container={container}
         >
           <EntryFormComponent
@@ -231,5 +234,3 @@ class EntryWrapper extends React.Component {
     );
   }
 }
-
-export default injectIntl(EntryWrapper);

--- a/lib/LoanList/LoanList.js
+++ b/lib/LoanList/LoanList.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, FormattedTime } from 'react-intl';
 import { Checkbox, MultiColumnList } from '@folio/stripes-components';
 
 const propTypes = {
   alerts: PropTypes.object,
   allowSelection: PropTypes.bool,
   height: PropTypes.number,
-  intl: intlShape,
   loans: PropTypes.arrayOf(
     PropTypes.shape({
       dueDate: PropTypes.string,
@@ -40,7 +39,7 @@ const manifest = {
 };
 
 const LoanList = (props) => {
-  const { intl: { formatMessage, formatTime }, loanSelection, onToggleLoanSelection } = props;
+  const { loanSelection, onToggleLoanSelection } = props;
 
   const visibleColumns = [
     'alertDetails',
@@ -67,14 +66,14 @@ const LoanList = (props) => {
           checked={Object.values(loanSelection).includes(false) !== true}
           onChange={props.onToggleBulkLoanSelection}
         />,
-        alertDetails: formatMessage({ id: 'stripes-smart-components.cddd.header.alertDetails' }),
-        title: formatMessage({ id: 'stripes-smart-components.cddd.header.title' }),
-        itemStatus: formatMessage({ id: 'stripes-smart-components.cddd.header.itemStatus' }),
-        currentDueDate: formatMessage({ id: 'stripes-smart-components.cddd.header.currentDueDate' }),
-        requestQueue: formatMessage({ id: 'stripes-smart-components.cddd.header.requestQueue' }),
-        barcode: formatMessage({ id: 'stripes-smart-components.cddd.header.barcode' }),
-        callNumber: formatMessage({ id: 'stripes-smart-components.cddd.header.callNumber' }),
-        loanPolicy: formatMessage({ id: 'stripes-smart-components.cddd.header.loanPolicy' }),
+        alertDetails: <FormattedMessage id="stripes-smart-components.cddd.header.alertDetails" />,
+        title: <FormattedMessage id="stripes-smart-components.cddd.header.title" />,
+        itemStatus: <FormattedMessage id="stripes-smart-components.cddd.header.itemStatus" />,
+        currentDueDate: <FormattedMessage id="stripes-smart-components.cddd.header.currentDueDate" />,
+        requestQueue: <FormattedMessage id="stripes-smart-components.cddd.header.requestQueue" />,
+        barcode: <FormattedMessage id="stripes-smart-components.cddd.header.barcode" />,
+        callNumber: <FormattedMessage id="stripes-smart-components.cddd.header.callNumber" />,
+        loanPolicy: <FormattedMessage id="stripes-smart-components.cddd.header.loanPolicy" />
       }}
       formatter={{
         selected: loan => <Checkbox
@@ -86,7 +85,7 @@ const LoanList = (props) => {
         title: loan => get(loan, ['item', 'title']),
         itemStatus: loan => get(loan, ['item', 'status', 'name']),
         currentDueDate:
-          loan => formatTime(get(loan, ['dueDate'], { day: 'numeric', month: 'numeric', year: 'numeric' })),
+          loan => <FormattedTime value={get(loan, ['dueDate'])} day="numeric" month="numeric" year="numeric" />,
         requestQueue: () => 'N/A',
         barcode: loan => get(loan, ['item', 'barcode']),
         callNumber: loan => get(loan, ['item', 'callNumber']),
@@ -108,4 +107,4 @@ LoanList.defaultProps = defaultProps;
 LoanList.propTypes = propTypes;
 LoanList.manifest = manifest;
 
-export default injectIntl(LoanList);
+export default LoanList;

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -99,19 +99,20 @@ class LocationForm extends React.Component {
             />
           </Col>
           <Col xs={6}>
-            <FormattedMessage id="stripes-smart-components.ll.selectLocation" />
-            {placeholder => (
-              <Field
-                disabled={locations.length <= 1}
-                component={Selection}
-                label={<FormattedMessage id="stripes-smart-components.ll.location" />}
-                placeholder={placeholder}
-                name="locationId"
-                id="locationId"
-                onFilter={this.filter}
-                dataOptions={[{ label: '\u00A0', value: '' }, ...locationOpts]}
-              />
-            )}
+            <FormattedMessage id="stripes-smart-components.ll.selectLocation">
+              {placeholder => (
+                <Field
+                  disabled={locations.length <= 1}
+                  component={Selection}
+                  label={<FormattedMessage id="stripes-smart-components.ll.location" />}
+                  placeholder={placeholder}
+                  name="locationId"
+                  id="locationId"
+                  onFilter={this.filter}
+                  dataOptions={[{ label: '\u00A0', value: '' }, ...locationOpts]}
+                />
+              )}
+            </FormattedMessage>
           </Col>
         </Row>
         <br />

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -1,7 +1,7 @@
 import { sortBy, escapeRegExp } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Button, Col, Row, Select, Selection } from '@folio/stripes-components';
 import stripesForm from '@folio/stripes-form';
 import { withStripes } from '@folio/stripes-core';
@@ -12,7 +12,6 @@ class LocationForm extends React.Component {
     campuses: PropTypes.arrayOf(PropTypes.object),
     handleSubmit: PropTypes.func.isRequired,
     institutions: PropTypes.arrayOf(PropTypes.object),
-    intl: intlShape,
     libraries: PropTypes.arrayOf(PropTypes.object),
     locations: PropTypes.arrayOf(PropTypes.object),
     onCampusSelected: PropTypes.func.isRequired,
@@ -38,11 +37,6 @@ class LocationForm extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   filter(value, data) {
     return data.filter(o => new RegExp(escapeRegExp(value), 'i').test(o.label));
-  }
-
-  translate(id) {
-    const { intl: { formatMessage } } = this.props;
-    return formatMessage({ id: `stripes-smart-components.ll.${id}` });
   }
 
   render() {
@@ -72,40 +66,52 @@ class LocationForm extends React.Component {
           <Col xs={6}>
             <Field
               disabled={institutions.length <= 1}
-              label={this.translate('institution')}
+              label={<FormattedMessage id="stripes-smart-components.ll.institution" />}
               name="institutionId"
               onChange={e => onInstitutionSelected(e.target.value)}
-              dataOptions={[{ label: this.translate('selectInstitution'), value: '' }, ...institutionOpts]}
+              dataOptions={[
+                { label: <FormattedMessage id="stripes-smart-components.ll.selectInstitution" />, value: '' },
+                ...institutionOpts
+              ]}
               component={Select}
             />
             <Field
               disabled={campuses.length <= 1}
-              label={this.translate('campus')}
+              label={<FormattedMessage id="stripes-smart-components.ll.campus" />}
               name="campusId"
               onChange={e => onCampusSelected(e.target.value)}
-              dataOptions={[{ label: this.translate('selectCampus'), value: '' }, ...campusOpts]}
+              dataOptions={[
+                { label: <FormattedMessage id="stripes-smart-components.ll.selectCampus" />, value: '' },
+                ...campusOpts
+              ]}
               component={Select}
             />
             <Field
               disabled={libraries.length <= 1}
-              label={this.translate('library')}
+              label={<FormattedMessage id="stripes-smart-components.ll.library" />}
               name="libraryId"
               onChange={e => onLibrarySelected(e.target.value)}
-              dataOptions={[{ label: this.translate('selectLibrary'), value: '' }, ...libraryOpts]}
+              dataOptions={[
+                { label: <FormattedMessage id="stripes-smart-components.ll.selectLibrary" />, value: '' },
+                ...libraryOpts
+              ]}
               component={Select}
             />
           </Col>
           <Col xs={6}>
-            <Field
-              disabled={locations.length <= 1}
-              component={Selection}
-              label={this.translate('location')}
-              placeholder={this.translate('selectLocation')}
-              name="locationId"
-              id="locationId"
-              onFilter={this.filter}
-              dataOptions={[{ label: '\u00A0', value: '' }, ...locationOpts]}
-            />
+            <FormattedMessage id="stripes-smart-components.ll.selectLocation" />
+            {placeholder => (
+              <Field
+                disabled={locations.length <= 1}
+                component={Selection}
+                label={<FormattedMessage id="stripes-smart-components.ll.location" />}
+                placeholder={placeholder}
+                name="locationId"
+                id="locationId"
+                onFilter={this.filter}
+                dataOptions={[{ label: '\u00A0', value: '' }, ...locationOpts]}
+              />
+            )}
           </Col>
         </Row>
         <br />
@@ -113,7 +119,9 @@ class LocationForm extends React.Component {
           <Col xs={12}>
             <Row end="xs">
               <Col xs={2}>
-                <Button onClick={onCancel} fullWidth>{this.translate('cancel')}</Button>
+                <Button onClick={onCancel} fullWidth>
+                  <FormattedMessage id="stripes-smart-components.ll.cancel" />
+                </Button>
               </Col>
               <Col xs={2}>
                 <Button
@@ -122,7 +130,7 @@ class LocationForm extends React.Component {
                   buttonStyle="primary"
                   fullWidth
                 >
-                  {this.translate('saveAndClose')}
+                  <FormattedMessage id="stripes-smart-components.ll.saveAndClose" />
                 </Button>
               </Col>
             </Row>
@@ -137,4 +145,4 @@ export default stripesForm({
   form: 'locationForm',
   navigationCheck: false,
   enableReinitialize: true,
-})(withStripes(injectIntl(LocationForm)));
+})(withStripes(LocationForm));

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { withStripes } from '@folio/stripes-core';
 import { Button } from '@folio/stripes-components';
 import LocationModal from './LocationModal';
 
 class LocationLookup extends React.Component {
   static propTypes = {
-    intl: intlShape,
     isTemporaryLocation: PropTypes.bool,
     label: PropTypes.string,
     onLocationSelected: PropTypes.func.isRequired,
@@ -38,8 +37,8 @@ class LocationLookup extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, label, onLocationSelected, isTemporaryLocation, stripes } = this.props;
-    const buttonLabel = label || formatMessage({ id: 'stripes-smart-components.ll.locationLookup' });
+    const { label, onLocationSelected, isTemporaryLocation, stripes } = this.props;
+    const buttonLabel = label || <FormattedMessage id="stripes-smart-components.ll.locationLookup" />;
 
     return (
       <div>
@@ -65,4 +64,4 @@ class LocationLookup extends React.Component {
   }
 }
 
-export default withStripes(injectIntl(LocationLookup));
+export default withStripes(LocationLookup);

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -46,7 +46,6 @@ class LocationLookup extends React.Component {
           key="searchButton"
           buttonStyle="link"
           onClick={this.openModal}
-          title={buttonLabel}
         >
           {buttonLabel}
         </Button>

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Modal } from '@folio/stripes-components';
 
 import LocationForm from './LocationForm';
 
-class LocationModal extends React.Component {
+export default class LocationModal extends React.Component {
   static manifest = Object.freeze({
     institutions: {
       type: 'okapi',
@@ -38,7 +38,6 @@ class LocationModal extends React.Component {
   });
 
   static propTypes = {
-    intl: intlShape,
     isTemporaryLocation: PropTypes.bool,
     mutator: PropTypes.shape({
       campuses: PropTypes.shape({
@@ -175,11 +174,6 @@ class LocationModal extends React.Component {
     });
   }
 
-  translate(id, options) {
-    const { intl: { formatMessage } } = this.props;
-    return formatMessage({ id: `stripes-smart-components.ll.${id}` }, options);
-  }
-
   render() {
     const { resources, isTemporaryLocation } = this.props;
     const { campusId, libraryId, locationId, institutionId } = this.state;
@@ -188,8 +182,12 @@ class LocationModal extends React.Component {
     const libraries = (resources.libraries || {}).records || [];
     const locations = (resources.locations || {}).records || [];
 
-    const type = this.translate((isTemporaryLocation) ? 'temporary' : 'permanent');
-    const label = this.translate('selectLocationHeader', { type });
+    const type = isTemporaryLocation ? (
+      <FormattedMessage id="stripes-smart-components.ll.temporary" />
+    ) : (
+      <FormattedMessage id="stripes-smart-components.ll.permanent" />
+    );
+    const label = <FormattedMessage id="selectLocationHeader" values={{ type }} />;
 
     return (
       <Modal
@@ -216,5 +214,3 @@ class LocationModal extends React.Component {
     );
   }
 }
-
-export default injectIntl(LocationModal);

--- a/lib/LocationSelection/LocationSelection.js
+++ b/lib/LocationSelection/LocationSelection.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { withStripes } from '@folio/stripes-core';
 
 import LocationInput from './LocationInput';
 
 class LocationSelection extends React.Component {
   static propTypes = {
-    intl: intlShape,
     name: PropTypes.string,
     placeholder: PropTypes.string,
     stripes: PropTypes.shape({
@@ -25,18 +24,20 @@ class LocationSelection extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, name, placeholder } = this.props;
-    const locationPlaceholder =
-      placeholder || formatMessage({ id: 'stripes-smart-components.ls.locationPlaceholder' });
+    const { name, placeholder } = this.props;
 
     return (
-      <this.locationInputConnected
-        name={name}
-        placeholder={locationPlaceholder}
-        {...this.props}
-      />
+      <FormattedMessage id="stripes-smart-components.ls.locationPlaceholder">
+        {defaultPlaceholder => (
+          <this.locationInputConnected
+            name={name}
+            placeholder={placeholder || defaultPlaceholder}
+            {...this.props}
+          />
+        )}
+      </FormattedMessage>
     );
   }
 }
 
-export default withStripes(injectIntl(LocationSelection));
+export default withStripes(LocationSelection);

--- a/lib/Notes/NoteRenderer.js
+++ b/lib/Notes/NoteRenderer.js
@@ -136,7 +136,7 @@ class NoteRenderer extends React.Component {
                     </Button>
                   )}
                 </FormattedMessage>
-                <FormattedMessage id="">
+                <FormattedMessage id="stripes-smart-components.editOrDeleteNote">
                   {ariaLabel => (
                     <DropdownMenu
                       bsRole="menu"
@@ -174,5 +174,4 @@ class NoteRenderer extends React.Component {
     );
   }
 }
-
 export default injectIntl(NoteRenderer);

--- a/lib/Notes/NoteRenderer.js
+++ b/lib/Notes/NoteRenderer.js
@@ -79,7 +79,7 @@ class NoteRenderer extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage, locale }, note, noteKey, stripes } = this.props;
+    const { intl: { locale }, note, noteKey, stripes } = this.props;
 
     const stamp = new Date(Date.parse(note.metadata.createdDate)).toLocaleString(locale);
 
@@ -125,34 +125,42 @@ class NoteRenderer extends React.Component {
                 open={this.state.dropDownOpen}
                 onToggle={this.onToggleDropDown}
               >
-                <Button
-                  buttonStyle="link slim"
-                  aria-label={formatMessage({ id: 'stripes-smart-components.editOrDeleteNote' })}
-                  bsRole="toggle"
-                >
-                  <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
-                </Button>
-                <DropdownMenu
-                  bsRole="menu"
-                  width="5em"
-                  minWidth="5em"
-                  aria-label={formatMessage({ id: 'stripes-smart-components.editOrDeleteNote' })}
-                  onToggle={this.onToggleDropDown}
-                >
-                  <IfPermission perm="notes.item.put">
-                    <Button buttonStyle="marginBottom0 hover fullWidth" onClick={this.handleClickEdit}>
-                      <FormattedMessage id="stripes-components.button.edit" />
-                    </Button>
-                  </IfPermission>
-                  <IfPermission perm="notes.item.delete">
+                <FormattedMessage id="stripes-smart-components.editOrDeleteNote">
+                  {ariaLabel => (
                     <Button
-                      buttonStyle="marginBottom0 hover fullWidth"
-                      onClick={() => { this.handleClickDelete(noteKey); }}
+                      buttonStyle="link slim"
+                      aria-label={ariaLabel}
+                      bsRole="toggle"
                     >
-                      <FormattedMessage id="stripes-components.button.delete" />
+                      <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
                     </Button>
-                  </IfPermission>
-                </DropdownMenu>
+                  )}
+                </FormattedMessage>
+                <FormattedMessage id="">
+                  {ariaLabel => (
+                    <DropdownMenu
+                      bsRole="menu"
+                      width="5em"
+                      minWidth="5em"
+                      aria-label={ariaLabel}
+                      onToggle={this.onToggleDropDown}
+                    >
+                      <IfPermission perm="notes.item.put">
+                        <Button buttonStyle="marginBottom0 hover fullWidth" onClick={this.handleClickEdit}>
+                          <FormattedMessage id="stripes-components.button.edit" />
+                        </Button>
+                      </IfPermission>
+                      <IfPermission perm="notes.item.delete">
+                        <Button
+                          buttonStyle="marginBottom0 hover fullWidth"
+                          onClick={() => { this.handleClickDelete(noteKey); }}
+                        >
+                          <FormattedMessage id="stripes-components.button.delete" />
+                        </Button>
+                      </IfPermission>
+                    </DropdownMenu>
+                  )}
+                </FormattedMessage>
               </Dropdown>
             }
           </Col>
@@ -166,4 +174,5 @@ class NoteRenderer extends React.Component {
     );
   }
 }
+
 export default injectIntl(NoteRenderer);

--- a/lib/Notes/Notes.js
+++ b/lib/Notes/Notes.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { IfPermission, Pane } from '@folio/stripes-components';
 import NotesForm from './NotesForm';
 import NoteRenderer from './NoteRenderer';
 import css from './Notes.css';
 
-class Notes extends React.Component {
+export default class Notes extends React.Component {
   static manifest = Object.freeze({
     notes: {
       type: 'okapi',
@@ -23,7 +23,6 @@ class Notes extends React.Component {
   });
 
   static propTypes = {
-    intl: intlShape,
     link: PropTypes.string,
     location: PropTypes.shape({
       search: PropTypes.string,
@@ -71,7 +70,7 @@ class Notes extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, link, stripes } = this.props;
+    const { link, stripes } = this.props;
     const notes = (this.props.resources.notes || {}).records || [];
 
     const notesQueryString = queryString.parse(this.props.location.search || '').notes;
@@ -90,8 +89,8 @@ class Notes extends React.Component {
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={formatMessage({ id: 'stripes-smart-components.notes' })}
-        paneSub={formatMessage({ id: 'stripes-smart-components.numberOfNotes' }, { count: notes.length })}
+        paneTitle={<FormattedMessage id="stripes-smart-components.notes" />}
+        paneSub={<FormattedMessage id="stripes-smart-components.numberOfNotes" values={{ count: notes.length }} />}
         dismissible
         onClose={this.props.onToggle}
       >
@@ -113,5 +112,3 @@ class Notes extends React.Component {
     );
   }
 }
-
-export default injectIntl(Notes);

--- a/lib/Notes/NotesForm.js
+++ b/lib/Notes/NotesForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import stripesForm from '@folio/stripes-form';
 import { Button, TextArea } from '@folio/stripes-components';
 
@@ -10,7 +10,6 @@ class NotesForm extends React.Component {
     editMode: PropTypes.bool,
     form: PropTypes.string,
     handleSubmit: PropTypes.func,
-    intl: intlShape,
     onCancel: PropTypes.func,
     pristine: PropTypes.bool,
     reset: PropTypes.func,
@@ -26,7 +25,6 @@ class NotesForm extends React.Component {
     const {
       form,
       handleSubmit,
-      intl: { formatMessage },
       pristine,
       submitting,
       textRows,
@@ -48,33 +46,44 @@ class NotesForm extends React.Component {
 
     return (
       <form>
-        <Field
-          name="text"
-          placeholder={formatMessage({ id: 'stripes-smart-components.enterANote' })}
-          aria-label={formatMessage({ id: 'stripes-smart-components.notesTextArea' })}
-          fullWidth
-          id="note_textarea"
-          component={TextArea}
-          onKeyDown={(e) => { handleKeyDown(e, handleClickSubmit); }}
-          rows={textRows}
-        />
+        <FormattedMessage id="stripes-smart-components.enterANote">
+          {placeholder => (
+            <FormattedMessage id="">
+              {ariaLabel => (
+                <Field
+                  name="text"
+                  placeholder={placeholder}
+                  aria-label={ariaLabel}
+                  fullWidth
+                  id="note_textarea"
+                  component={TextArea}
+                  onKeyDown={(e) => { handleKeyDown(e, handleClickSubmit); }}
+                  rows={textRows}
+                />
+              )}
+            </FormattedMessage>
+          )}
+        </FormattedMessage>
         <div style={{ textAlign: 'right' }}>
           {editMode &&
             <Button
               buttonStyle="hover"
               onClick={onCancel}
-              aria-label={formatMessage({ id: 'stripes-smart-components.cancelEdit' })}
             >
               <FormattedMessage id="stripes-components.button.cancel" />
             </Button>
           }
-          <Button
-            disabled={pristine || submitting}
-            onClick={handleClickSubmit}
-            aria-label={formatMessage({ id: 'stripes-smart-components.postNote' })}
-          >
-            <FormattedMessage id="stripes-smart-components.post" />
-          </Button>
+          <FormattedMessage id="stripes-smart-components.postNote">
+            {ariaLabel => (
+              <Button
+                disabled={pristine || submitting}
+                onClick={handleClickSubmit}
+                aria-label={ariaLabel}
+              >
+                <FormattedMessage id="stripes-smart-components.post" />
+              </Button>
+            )}
+          </FormattedMessage>
         </div>
       </form>
     );
@@ -84,4 +93,4 @@ class NotesForm extends React.Component {
 export default stripesForm({
   form: 'NotesForm',
   enableReinitialize: true,
-})(injectIntl(NotesForm));
+})(NotesForm);

--- a/lib/Notes/NotesForm.js
+++ b/lib/Notes/NotesForm.js
@@ -48,7 +48,7 @@ class NotesForm extends React.Component {
       <form>
         <FormattedMessage id="stripes-smart-components.enterANote">
           {placeholder => (
-            <FormattedMessage id="">
+            <FormattedMessage id="stripes-smart-components.notesTextArea">
               {ariaLabel => (
                 <Field
                   name="text"

--- a/lib/ProxyManager/ProxyForm.js
+++ b/lib/ProxyManager/ProxyForm.js
@@ -1,6 +1,6 @@
 import { chunk } from 'lodash';
 import React from 'react';
-import { FormattedMessage, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { Button, Col, RadioButton, Row } from '@folio/stripes-components';
@@ -24,7 +24,6 @@ function renderEnabledRadio(proxy) {
 class ProxyForm extends React.Component {
   static propTypes = {
     handleSubmit: PropTypes.func.isRequired,
-    intl: intlShape,
     onCancel: PropTypes.func,
     patron: PropTypes.object,
     proxies: PropTypes.arrayOf(PropTypes.object),
@@ -47,20 +46,15 @@ class ProxyForm extends React.Component {
     }, {});
   }
 
-  translate(id) {
-    const { intl: { formatMessage } } = this.props;
-    return formatMessage({ id: `stripes-smart-components.pm.${id}` });
-  }
-
   renderDisabledRadio(proxy, sponsor, proxyMap) {
     let message;
 
     if (isProxyExpired(proxy, proxyMap)) {
-      message = this.translate('proxyExpired');
+      message = <FormattedMessage id="stripes-smart-components.pm.proxyExpired" />;
     } else if (isSponsorExpired(sponsor)) {
-      message = this.translate('sponsorExpired');
+      message = <FormattedMessage id="stripes-smart-components.pm.sponsorExpired" />;
     } else if (isRequestForSponsorInvalid(proxy, proxyMap)) {
-      message = this.translate('cannotRequestFoSponsor');
+      message = <FormattedMessage id="stripes-smart-components.pm.cannotRequestFoSponsor" />;
     }
 
     return message && (
@@ -73,7 +67,7 @@ class ProxyForm extends React.Component {
   }
 
   render() {
-    const { handleSubmit, onCancel, patron, proxies, intl: { formatMessage } } = this.props;
+    const { handleSubmit, onCancel, patron, proxies } = this.props;
     const proxiesList = chunk(proxies, 3).map((group, i) => (
       <Row key={`row-${i}`}>
         {group.map(proxy => (
@@ -105,7 +99,7 @@ class ProxyForm extends React.Component {
               id={`sponsor-${patron.id}`}
               key={`sponsor-${patron.id}`}
               name="sponsorId"
-              label={formatMessage({ id: 'stripes-smart-components.self' })}
+              label={<FormattedMessage id="stripes-smart-components.self" />}
               value={patron.id}
             />
           </Col>
@@ -120,10 +114,14 @@ class ProxyForm extends React.Component {
         <br />
         <Row>
           <Col xs={3}>
-            <Button onClick={onCancel} buttonStyle="secondary" fullWidth>{this.translate('cancel')}</Button>
+            <Button onClick={onCancel} buttonStyle="secondary" fullWidth>
+              <FormattedMessage id="stripes-smart-components.pm.cancel" />
+            </Button>
           </Col>
           <Col xs={3}>
-            <Button type="submit" fullWidth>{this.translate('continue')}</Button>
+            <Button type="submit" fullWidth>
+              <FormattedMessage id="stripes-smart-components.pm.continue" />
+            </Button>
           </Col>
         </Row>
       </form>

--- a/lib/ProxyManager/ProxyModal.js
+++ b/lib/ProxyManager/ProxyModal.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Modal } from '@folio/stripes-components';
 import ProxyForm from './ProxyForm';
 
 class ProxyModal extends React.Component {
   static propTypes = {
-    intl: intlShape,
     onClose: PropTypes.func,
     onContinue: PropTypes.func,
     open: PropTypes.bool,
@@ -14,21 +13,20 @@ class ProxyModal extends React.Component {
   };
 
   render() {
-    const { onClose, open, patron, onContinue, intl: { formatMessage } } = this.props;
+    const { onClose, open, patron, onContinue } = this.props;
 
     return (
       <Modal
         onClose={onClose}
         open={open}
         size="small"
-        label={formatMessage({ id: 'stripes-smart-components.whoAreYouActingAs' })}
+        label={<FormattedMessage id="stripes-smart-components.whoAreYouActingAs" />}
         dismissible
       >
         <ProxyForm
           onSubmit={onContinue}
           initialValues={{ sponsorId: patron.id }}
           onCancel={onClose}
-          intl={this.props.intl}
           {...this.props}
         />
       </Modal>
@@ -37,4 +35,4 @@ class ProxyModal extends React.Component {
 }
 
 
-export default injectIntl(ProxyModal);
+export default ProxyModal;

--- a/lib/Tags/Tag.js
+++ b/lib/Tags/Tag.js
@@ -1,36 +1,37 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Badge, Button, Icon } from '@folio/stripes-components';
 
 import css from './Tags.css';
 
-class Tag extends React.Component {
+export default class Tag extends React.Component {
   static propTypes = {
-    intl: intlShape,
     onRemove: PropTypes.func.isRequired,
     tag: PropTypes.string,
   };
 
   render() {
-    const { intl: { formatMessage }, tag, onRemove } = this.props;
+    const { tag, onRemove } = this.props;
 
     return (
       <Badge className={css.tag} color="primary">
         <span className={css.tagText}>{tag}</span>
-        <Button
-          onClick={() => onRemove(tag)}
-          size="small"
-          paddingSide0
-          marginBottom0
-          buttonStyle="primary"
-          aria-label={formatMessage({ id: 'stripes-smart-components.deleteTag' })}
-        >
-          <Icon size="small" icon="closeX" color="rgba(255, 255, 255, 1)" />
-        </Button>
+        <FormattedMessage id="stripes-smart-components.deleteTag">
+          {ariaLabel => (
+            <Button
+              onClick={() => onRemove(tag)}
+              size="small"
+              paddingSide0
+              marginBottom0
+              buttonStyle="primary"
+              aria-label={ariaLabel}
+            >
+              <Icon size="small" icon="closeX" color="rgba(255, 255, 255, 1)" />
+            </Button>
+          )}
+        </FormattedMessage>
       </Badge>
     );
   }
 }
-
-export default injectIntl(Tag);

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -1,12 +1,12 @@
 import { get, uniq, sortBy, difference } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Callout, Pane } from '@folio/stripes-components';
 
 import TagsForm from './TagsForm';
 
-class Tags extends React.Component {
+export default class Tags extends React.Component {
   static manifest = Object.freeze({
     tags: {
       type: 'okapi',
@@ -25,7 +25,6 @@ class Tags extends React.Component {
   });
 
   static propTypes = {
-    intl: intlShape,
     mutator: PropTypes.shape({
       entities: PropTypes.shape({
         PUT: PropTypes.func.isRequired,
@@ -79,7 +78,7 @@ class Tags extends React.Component {
 
   // add tags to global list of tags
   saveTags(tags) {
-    const { intl: { formatMessage }, mutator, resources } = this.props;
+    const { mutator, resources } = this.props;
     const records = (resources.tags || {}).records || [];
     const newTag = difference(tags, records.map(t => t.label.toLowerCase()));
 
@@ -90,7 +89,7 @@ class Tags extends React.Component {
       description: newTag[0],
     });
 
-    const message = formatMessage({ id: 'stripes-smart-components.newTagCreated' });
+    const message = <FormattedMessage id="stripes-smart-components.newTagCreated" />;
     this.calloutRef.current.sendCallout({ message });
   }
 
@@ -113,15 +112,15 @@ class Tags extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, resources, stripes } = this.props;
+    const { resources, stripes } = this.props;
     const entityTags = this.getEntityTags();
     const tags = (resources.tags || {}).records || [];
 
     return (
       <Pane
         defaultWidth="20%"
-        paneTitle={formatMessage({ id: 'stripes-smart-components.tags' })}
-        paneSub={formatMessage({ id: 'stripes-smart-components.numberOfTags' }, { count: entityTags.length })}
+        paneTitle={<FormattedMessage id="stripes-smart-components.tags" />}
+        paneSub={<FormattedMessage id="stripes-smart-components.numberOfTags" values={{ count: entityTags.length }} />}
         dismissible
         onClose={this.props.onToggle}
       >
@@ -138,5 +137,3 @@ class Tags extends React.Component {
     );
   }
 }
-
-export default injectIntl(Tags);

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -1,13 +1,12 @@
 import { isEqual, difference, sortBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { MultiSelection } from '@folio/stripes-components';
 
-class TagsForm extends React.Component {
+export default class TagsForm extends React.Component {
   static propTypes = {
     entityTags: PropTypes.arrayOf(PropTypes.string),
-    intl: intlShape,
     onAdd: PropTypes.func,
     onRemove: PropTypes.func,
     stripes: PropTypes.shape({
@@ -85,7 +84,7 @@ class TagsForm extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage }, tags } = this.props;
+    const { tags } = this.props;
     const { entityTags } = this.state;
     const dataOptions = tags.map(t => ({ value: t.label.toLowerCase(), label: t.label.toLowerCase() }));
     const tagsList = entityTags.map(tag => ({ value: tag.toLowerCase(), label: tag.toLowerCase() }));
@@ -93,18 +92,24 @@ class TagsForm extends React.Component {
     const actions = [addAction];
 
     return (
-      <MultiSelection
-        placeholder={formatMessage({ id: 'stripes-smart-components.enterATag' })}
-        aria-label={formatMessage({ id: 'stripes-smart-components.tagsTextArea' })}
-        actions={actions}
-        filter={this.filterItems}
-        emptyMessage=" "
-        onChange={this.onChange}
-        dataOptions={sortBy(dataOptions, ['value'])}
-        value={sortBy(tagsList, ['value'])}
-      />
+      <FormattedMessage id="stripes-smart-components.enterATag">
+        {placeholder => (
+          <FormattedMessage id="stripes-smart-components.tagsTextArea">
+            {ariaLabel => (
+              <MultiSelection
+                placeholder={placeholder}
+                aria-label={ariaLabel}
+                actions={actions}
+                filter={this.filterItems}
+                emptyMessage=" "
+                onChange={this.onChange}
+                dataOptions={sortBy(dataOptions, ['value'])}
+                value={sortBy(tagsList, ['value'])}
+              />
+            )}
+          </FormattedMessage>
+        )}
+      </FormattedMessage>
     );
   }
 }
-
-export default injectIntl(TagsForm);


### PR DESCRIPTION
## Purpose
Finishes the work from https://github.com/folio-org/stripes-smart-components/pull/329. Applied to `stripes-components` in https://github.com/folio-org/stripes-components/pull/696.

Aligns with `stripes` i18n documentation at https://github.com/folio-org/stripes/blob/master/doc/i18n.md, in preferring the `react-intl` component API instead of its functions with `injectIntl()`.

## Approach
- Exclusively use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` from `react-intl`. 
- Discontinue using `intl.formatMessage()`, `intl.formatDate()`, and `intl.formatTime()`.
- I had to leave two `injectIntl()`s - one is in the deprecated `NoteRenderer`, and the other is in `DueDatePicker`. At some point, `DueDatePicker`'s date handling should be re-evaluated to see if can just use `<FormattedDate>`. Not a priority, and not a big deal if it continues to use `injectIntl()`.

## Risk
`stripes-smart-components` doesn't have the kind of test coverage it needs, so this has a high chance of minor regressions. The most likely is `[Object object]` showing up in the UI instead of the internationalized string. Issues that arise should be quick to remedy.