### PR TITLE
Update renderable props to type node

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -9,7 +9,7 @@ import EmbeddedAddressForm from './EmbeddedAddressForm';
 import css from './AddressEdit.css';
 
 const propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.node,
   name: PropTypes.string,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -47,7 +47,7 @@ const propTypes = {
   /**
    *  Displays a custom <h2> tag at top of listing. Default: 'Address'
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * object to match field names with custom labels for UI rendering.

--- a/lib/ConfigManager/ConfigForm.js
+++ b/lib/ConfigManager/ConfigForm.js
@@ -36,7 +36,7 @@ const ConfigForm = (props) => {
 ConfigForm.propTypes = {
   children: PropTypes.node,
   handleSubmit: PropTypes.func.isRequired,
-  label: PropTypes.string,
+  label: PropTypes.node,
   pristine: PropTypes.bool,
   submitting: PropTypes.bool,
 };

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -21,12 +21,12 @@ class ConfigManager extends React.Component {
   });
 
   static propTypes = {
-    calloutMessage: PropTypes.string,
+    calloutMessage: PropTypes.node,
     children: PropTypes.node,
     configFormComponent: PropTypes.func,
     configName: PropTypes.string.isRequired,
     getInitialValues: PropTypes.func,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     moduleName: PropTypes.string.isRequired,
     mutator: PropTypes.shape({
       recordId: PropTypes.shape({

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -39,7 +39,7 @@ class ControlledVocab extends React.Component {
     formatter: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
     itemTemplate: PropTypes.object,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     labelSingular: PropTypes.string.isRequired,
     listSuppressor: PropTypes.func,
     listSuppressorText: PropTypes.string,

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -68,7 +68,7 @@ const propTypes = {
   /**
    * Message to display for an empty list.
    */
-  isEmptyMessage: PropTypes.string,
+  isEmptyMessage: PropTypes.node,
   /**
    * Object where each key's value is the default value for that field.
    * { resourceType: 'book' }

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -9,7 +9,7 @@ class EntryForm extends React.Component {
   static propTypes = {
     deleteDisabled: PropTypes.func.isRequired,
     deleteDisabledMessage: PropTypes.string.isRequired,
-    entryLabel: PropTypes.string.isRequired,
+    entryLabel: PropTypes.node.isRequired,
     formComponent: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
@@ -148,7 +148,7 @@ class EntryForm extends React.Component {
 
             {selectedEntry &&
               <ConfirmationModal
-                id={`delete${this.props.entryLabel.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}-confirmation`}
+                id={`delete${this.props.nameKey.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}-confirmation`}
                 open={confirmDelete}
                 heading={deleteButtonText}
                 message={message}

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -39,7 +39,7 @@ export default class EntryWrapper extends React.Component {
     location: PropTypes.object.isRequired,
     mutator: PropTypes.object,
     nameKey: PropTypes.string.isRequired,
-    paneTitle: PropTypes.string.isRequired,
+    paneTitle: PropTypes.node.isRequired,
     parentMutator: PropTypes.object,
     permissions: PropTypes.shape({
       delete: PropTypes.string.isRequired,

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -8,7 +8,7 @@ import LocationModal from './LocationModal';
 class LocationLookup extends React.Component {
   static propTypes = {
     isTemporaryLocation: PropTypes.bool,
-    label: PropTypes.string,
+    label: PropTypes.node,
     onLocationSelected: PropTypes.func.isRequired,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -53,7 +53,7 @@ class SearchAndSort extends React.Component {
     filterConfig: PropTypes.arrayOf(
       PropTypes.shape({
         cql: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
+        label: PropTypes.node.isRequired,
         name: PropTypes.string.isRequired,
         values: PropTypes.arrayOf(
           PropTypes.oneOfType([
@@ -80,7 +80,7 @@ class SearchAndSort extends React.Component {
     }).isRequired,
     maxSortKeys: PropTypes.number,
     module: PropTypes.shape({ // values specified by the ModulesContext
-      displayName: PropTypes.string, // human-readable
+      displayName: PropTypes.node, // human-readable
     }),
     newRecordInitialValues: PropTypes.object,
     newRecordPerms: PropTypes.string,

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -118,19 +118,19 @@ Settings.propTypes = {
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       component: PropTypes.func.isRequired,
-      label: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
       perm: PropTypes.string,
       route: PropTypes.string.isRequired,
     }),
   ),
-  paneTitle: PropTypes.string,
+  paneTitle: PropTypes.node,
   sections: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
       pages: PropTypes.arrayOf(
         PropTypes.shape({
           component: PropTypes.func.isRequired,
-          label: PropTypes.string.isRequired,
+          label: PropTypes.node.isRequired,
           perm: PropTypes.string,
           route: PropTypes.string.isRequired,
         }),

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -92,8 +92,8 @@ class Settings extends React.Component {
             </Link>
           )}
         >
-          {this.sections.map(section => (
-            <NavList key={section.label}>
+          {this.sections.map((section, index) => (
+            <NavList key={index}>
               {navlinks(section)}
             </NavList>
           ))}


### PR DESCRIPTION
Props that are simply rendered like `label` or `paneTitle` should accept any renderable node, not just a string, so we can pass in `react-intl` `<FormattedMessage>`, etc.

Prevents warnings like:
```
Warning: Failed prop type: Invalid prop `sections[0].label` of type `object` supplied to `Settings`, expected `string`.
```