### PR TITLE
use consistent create-new-button id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Remove `<Paneset>` from `<Settings>`
 * Clear query resource on `SearchAndSort` component unmount. Fixes STSMACOM-146.
 * Replace `formatMessage()` with `<FormattedMessage>` in `<SearchAndSort>`
+* Use create-new-button attributes consistently.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -181,7 +181,7 @@ export default class EntryWrapper extends React.Component {
         <IfPermission perm={permissions.put}>
           <PaneMenu>
             <Button
-              id={`${baseId}-add-new`}
+              id={`clickable-create-${baseId}`}
               onClick={this.onAdd}
               buttonStyle="primary"
               marginBottom0


### PR DESCRIPTION
`clickable-create-${foo}` was already used elsewhere. Now it's used
here, too.