### PR TITLE
validate callouts before calling them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Clear query resource on `SearchAndSort` component unmount. Fixes STSMACOM-146.
 * Replace `formatMessage()` with `<FormattedMessage>` in `<SearchAndSort>`
 * Use create-new-button attributes consistently.
+* Validate callouts before calling them.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -142,7 +142,9 @@ export default class EntryWrapper extends React.Component {
       />
     );
 
-    this.callout.sendCallout({ message });
+    if (this.callout) {
+      this.callout.sendCallout({ message });
+    }
   }
 
   render() {


### PR DESCRIPTION
Sometimes, Nightmare tests would blow up with the following error:
```
EntryWrapper.js:145 Uncaught (in promise) TypeError: Cannot read property 'sendCallout' of null
```
which is the result of the delete method being called before the whole
DOM renders, which causes the callout to fail because it relies on a ref
which isn't available yet because the DOM hasn't rendered. Got that?
Good.