### PR TITLE
UIU-679 Update label propTypes

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -378,7 +378,7 @@ class ControlledVocab extends React.Component {
             />
           }
           <ConfirmationModal
-            id={`delete${this.props.nameKey}-confirmation`}
+            id="delete-controlled-vocab-entry-confirmation"
             open={this.state.showConfirmDialog}
             heading={<FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: type }} />}
             message={modalMessage}

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -36,11 +36,11 @@ class ControlledVocab extends React.Component {
     actionSuppressor: PropTypes.object,
     baseUrl: PropTypes.string.isRequired,
     columnMapping: PropTypes.object,
-    formatter: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
+    formatter: PropTypes.object,
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
     itemTemplate: PropTypes.object,
     label: PropTypes.node.isRequired,
-    labelSingular: PropTypes.string.isRequired,
+    labelSingular: PropTypes.node.isRequired,
     listSuppressor: PropTypes.func,
     listSuppressorText: PropTypes.string,
     mutator: PropTypes.shape({
@@ -56,7 +56,7 @@ class ControlledVocab extends React.Component {
       }),
     }).isRequired,
     nameKey: PropTypes.string,
-    objectLabel: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
+    objectLabel: PropTypes.node.isRequired,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
     readOnlyFields: PropTypes.arrayOf(PropTypes.string),
@@ -203,7 +203,7 @@ class ControlledVocab extends React.Component {
       <SafeHTMLMessage
         id="stripes-smart-components.cv.termDeleted"
         values={{
-          type: this.props.labelSingular.toLowerCase(),
+          type: this.props.labelSingular,
           term: item[this.state.primaryField],
         }}
       />
@@ -243,7 +243,7 @@ class ControlledVocab extends React.Component {
   }
 
   renderItemInUseDialog() {
-    const type = this.props.labelSingular.toLowerCase();
+    const type = this.props.labelSingular;
 
     return (
       <Modal
@@ -304,7 +304,7 @@ class ControlledVocab extends React.Component {
   render() {
     if (!this.props.resources.values) return <div />;
 
-    const type = this.props.labelSingular.toLowerCase();
+    const type = this.props.labelSingular;
     const term = this.state.selectedItem[this.state.primaryField];
 
     const modalMessage = (
@@ -371,14 +371,14 @@ class ControlledVocab extends React.Component {
               isEmptyMessage={
                 <FormattedMessage
                   id="stripes-smart-components.cv.noExistingTerms"
-                  values={{ terms: this.props.label.toLowerCase() }}
+                  values={{ terms: this.props.label }}
                 />
               }
               validate={this.validate}
             />
           }
           <ConfirmationModal
-            id={`delete${type.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()}-confirmation`}
+            id={`delete${this.props.nameKey}-confirmation`}
             open={this.state.showConfirmDialog}
             heading={<FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: type }} />}
             message={modalMessage}


### PR DESCRIPTION
## Purpose
While working on https://issues.folio.org/browse/UIU-679, @Godlevskyi noticed that passing in `<FormattedMessage>` nodes to some `<ControlledVocab>` props would cause incidents of `[Object object]` making their way to the outputted UI.

For `labelSingular` in particular, `<ControlledVocab>` would attempt to transform the given already-localized string to lower case. This probably will not scale to languages with different capitalization rules than English (like German). We shouldn't be doing any transformations of the strings provided by translators.

## Approach
- Accept `node` prop type for `label`, `labelSingular`, and `objectLabel`
- Stop attempting to change capitalization of already-localized strings
- Change confirmation modal id to use `nameKey` prop instead of a transformed `labelSingular`

## Open questions
- Was there a need for the `toLowerCase()` that I'm missing?
