### PR TITLE
validate callouts before calling them

### DIFF
--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -70,7 +70,9 @@ class ConfigManager extends React.Component {
     if (setting.metadata) delete setting.metadata;
 
     return mutator.settings[action](setting).then(() => {
-      this.callout.sendCallout({ message: calloutMessage });
+      if (this.callout) {
+        this.callout.sendCallout({ message: calloutMessage });
+      }
       if (onAfterSave) onAfterSave(setting);
     });
   }

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -199,17 +199,19 @@ class ControlledVocab extends React.Component {
   }
 
   showDeletionSuccessCallout(item) {
-    const message = (
-      <SafeHTMLMessage
-        id="stripes-smart-components.cv.termDeleted"
-        values={{
-          type: this.props.labelSingular,
-          term: item[this.state.primaryField],
-        }}
-      />
-    );
+    if (this.callout) {
+      const message = (
+        <SafeHTMLMessage
+          id="stripes-smart-components.cv.termDeleted"
+          values={{
+            type: this.props.labelSingular,
+            term: item[this.state.primaryField],
+          }}
+        />
+      );
 
-    this.callout.sendCallout({ message });
+      this.callout.sendCallout({ message });
+    }
   }
 
   validate({ items }) {

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -89,8 +89,10 @@ export default class Tags extends React.Component {
       description: newTag[0],
     });
 
-    const message = <FormattedMessage id="stripes-smart-components.newTagCreated" />;
-    this.calloutRef.current.sendCallout({ message });
+    if (this.callout) {
+      const message = <FormattedMessage id="stripes-smart-components.newTagCreated" />;
+      this.calloutRef.current.sendCallout({ message });
+    }
   }
 
   handleRemove(tag) {


### PR DESCRIPTION
Sometimes, Nightmare tests would blow up with the following error:
```
EntryWrapper.js:145 Uncaught (in promise) i
TypeError: Cannot read property 'sendCallout' of null
```
which is the result of the delete method being called before the whole
DOM renders, which causes the callout to fail because it relies on a ref
which isn't available yet because the DOM hasn't rendered. Got that?
Good.

Follow up to #335. Not sure how I missed these the first time around.