### PR TITLE
use consistent id attributes for EntryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Replace `formatMessage()` with `<FormattedMessage>` in `<SearchAndSort>`
 * Use create-new-button attributes consistently.
 * Validate callouts before calling them.
+* Consistent id attributes for `<EntryManager>` buttons.
 
 ## [1.10.0](https://github.com/folio-org/stripes-smart-components/tree/v1.10.0)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.9.0...v1.10.0)

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -83,7 +83,7 @@ class EntryForm extends React.Component {
     return (
       <PaneMenu>
         <Button
-          id="clickable-save-item"
+          id="clickable-save-entry"
           type="submit"
           disabled={(pristine || submitting)}
           marginBottom0
@@ -115,7 +115,7 @@ class EntryForm extends React.Component {
         );
       } else {
         deleteButton = (
-          <Button onClick={this.beginDelete} disabled={confirmDelete} id="clickable-delete-item">
+          <Button onClick={this.beginDelete} disabled={confirmDelete} id="clickable-delete-entry">
             {deleteButtonText}
           </Button>
         );

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -160,7 +160,6 @@ export default class EntryWrapper extends React.Component {
 
     const query = location.search ? queryString.parse(location.search) : {};
     const defaultEntry = this.props.defaultEntry || {};
-    const baseId = entryLabel.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
     const cloning = location.search.match('layer=clone');
     const adding = location.search.match('layer=add');
 
@@ -183,7 +182,7 @@ export default class EntryWrapper extends React.Component {
         <IfPermission perm={permissions.put}>
           <PaneMenu>
             <Button
-              id={`clickable-create-${baseId}`}
+              id="clickable-create-entry"
               onClick={this.onAdd}
               buttonStyle="primary"
               marginBottom0


### PR DESCRIPTION
`<EntryManager>` now uses `clickable-create-entry`,
`clickable-delete-entry`, and `clickable-edit-entry` for its buttons'
`id` attributes. That's consistent and not based on a prop which could
be based on a translated string.

Refs [UIU-679](https://issues.folio.org/browse/UIU-679)