### PR TITLE
UICIRC-97 Update renderable props to nodes

### DIFF
--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -8,7 +8,7 @@ import stripesForm from '@folio/stripes-form';
 class EntryForm extends React.Component {
   static propTypes = {
     deleteDisabled: PropTypes.func.isRequired,
-    deleteDisabledMessage: PropTypes.string.isRequired,
+    deleteDisabledMessage: PropTypes.node.isRequired,
     entryLabel: PropTypes.node.isRequired,
     formComponent: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -21,10 +21,10 @@ export default class EntryWrapper extends React.Component {
     asyncValidate: PropTypes.func,
     defaultEntry: PropTypes.object,
     deleteDisabled: PropTypes.func,
-    deleteDisabledMessage: PropTypes.string,
+    deleteDisabledMessage: PropTypes.node,
     detailComponent: PropTypes.func.isRequired,
     entryFormComponent: PropTypes.func,
-    entryLabel: PropTypes.string.isRequired,
+    entryLabel: PropTypes.node.isRequired,
     entryList: PropTypes.arrayOf(PropTypes.object).isRequired,
     formComponent: (props, propName) => {
       if (!isFunction(props.entryFormComponent) && !isFunction(props[propName])) {


### PR DESCRIPTION
## Purpose
Follow-up to https://github.com/folio-org/stripes-smart-components/pull/338

Renderable props were set to `PropTypes.string`, so passing a `<FormattedMessage>` to those throws a warning.

## Approach
Accept `node` prop type for `deleteDisabledMessage` and `entryLabel`.