### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-smart-components
 
-## 1.11.0 (In Progress)
+## [1.11.0](https://github.com/folio-org/stripes-smart-components/tree/v1.11.0) (2018-11-19)
+[Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.10.0...v1.11.0)
 
 * Add clone option to `EntryManager`. Fixes STSMACOM-134.
 * Add ability to pass custom add menu component to `EntryManager`. Fixes STSMACOM-136.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
* Add clone option to `EntryManager`. Fixes STSMACOM-134.
* Add ability to pass custom add menu component to `EntryManager`. Fixes STSMACOM-136.
* Use react-intl directly instead of stripes.intl
* Enable tags by default. Part of UITAG-8.
* Add parseInitialValues to entry wrapper. Fixes STSMACOM-137.
* `ControlledVocab` accepts `sortby` to override its default ordering. Refs MODUSERS-98, fixes STSMACOM-139. Available from v1.10.1.
* Show details view of the newly created record after duplication. Fixes STSMACOM-140.
* Open details screen after new record is created. Fixes STSMACOM-141.
* Internalize logic of `<UserLink>` into `<ControlledVocab>` for efficiency. Fixes STSMACOM-142. Available from v1.10.2.
* Remove `<Paneset>` from `<Settings>`
* Clear query resource on `SearchAndSort` component unmount. Fixes STSMACOM-146.
* Replace `formatMessage()` with `<FormattedMessage>` in `<SearchAndSort>`
* Use create-new-button attributes consistently.
* Validate callouts before calling them.
* Consistent id attributes for `<EntryManager>` buttons.