### PR TITLE
Add stopPropagation to search form. Refs UIU-731

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.12.0 (IN PROGRESS)
+
+* Remove onSubmit from search form. Refs UIU-731. 
+
 ## [1.11.0](https://github.com/folio-org/stripes-smart-components/tree/v1.11.0) (2018-11-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.10.0...v1.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.12.0 (IN PROGRESS)
 
-* Remove onSubmit from search form. Refs UIU-731. 
+* Add stopPropagation to search from. Refs UIU-731. 
 
 ## [1.11.0](https://github.com/folio-org/stripes-smart-components/tree/v1.11.0) (2018-11-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.10.0...v1.11.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -262,6 +262,7 @@ class SearchAndSort extends React.Component {
 
   onSubmitSearch = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     this.performSearch(this.state.locallyChangedSearchTerm);
   }
 
@@ -625,7 +626,7 @@ class SearchAndSort extends React.Component {
             paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
             onClose={this.toggleFilterPane}
           >
-            <form>
+            <form onSubmit={this.onSubmitSearch}>
               <SearchField
                 id={`input-${objectName}-search`}
                 searchableIndexes={this.props.searchableIndexes}
@@ -643,7 +644,6 @@ class SearchAndSort extends React.Component {
                 buttonStyle="primary"
                 fullWidth
                 disabled={!searchTerm}
-                onClick={this.onSubmitSearch}
                 data-test-search-and-sort-submit
               >
                 <FormattedMessage id="stripes-smart-components.search" />

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -625,7 +625,7 @@ class SearchAndSort extends React.Component {
             paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
             onClose={this.toggleFilterPane}
           >
-            <form onSubmit={this.onSubmitSearch}>
+            <form>
               <SearchField
                 id={`input-${objectName}-search`}
                 searchableIndexes={this.props.searchableIndexes}
@@ -643,6 +643,7 @@ class SearchAndSort extends React.Component {
                 buttonStyle="primary"
                 fullWidth
                 disabled={!searchTerm}
+                onClick={this.onSubmitSearch}
                 data-test-search-and-sort-submit
               >
                 <FormattedMessage id="stripes-smart-components.search" />


### PR DESCRIPTION
It looks like this was yet another weird issue with redux-form. The `onSubmit` handler in SearchAndSort form was also executing the UserForm `onSubmit` handler here:

https://github.com/folio-org/ui-users/blob/master/src/UserForm.js#L197

This PR just replaces the `onSubmit` with `onClick` since we don't really need to submit the SearchAndSort form. This seems to fix the issue in UserForm but it's still not clear why the UserForm `onSubmit` would execute. 