### PR TITLE
Reset query resource to initial values on unmount. Refs UIU-733

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.12.0 (IN PROGRESS)
 
 * Add stopPropagation to search from. Refs UIU-731. 
+* Reset query resource to initial values on unmount. Refs UIU-733.
 
 ## [1.11.0](https://github.com/folio-org/stripes-smart-components/tree/v1.11.0) (2018-11-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.10.0...v1.11.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -188,8 +188,8 @@ class SearchAndSort extends React.Component {
     const initialPath = (get(props.packageInfo, ['stripes', 'home']) || get(props.packageInfo, ['stripes', 'route']));
     const initialSearch = initialPath.indexOf('?') === -1 ? initialPath :
       initialPath.substr(initialPath.indexOf('?') + 1);
-    const initialQuery = queryString.parse(initialSearch);
-    this.initialFilters = initialQuery.filters;
+    this.initialQuery = queryString.parse(initialSearch);
+    this.initialFilters = this.initialQuery.filters;
 
     const logger = props.stripes.logger;
     this.log = logger.log.bind(logger);
@@ -237,7 +237,7 @@ class SearchAndSort extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.parentMutator.query.replace({});
+    this.props.parentMutator.query.replace(this.initialQuery);
 
     if (this.props.onComponentWillUnmount) {
       this.props.onComponentWillUnmount(this.props);
@@ -403,6 +403,7 @@ class SearchAndSort extends React.Component {
   queryParam(name) {
     const { parentResources, nsParams } = this.props;
     const nsKey = getNsKey(name, nsParams);
+
     return get(parentResources.query, nsKey);
   }
 


### PR DESCRIPTION
When user lookup (ui-plugin-find-user) was closed / unmounted the `SearchAndSort` was reseting the query resource completely including initial / default values (for example `sort` by name). This PR is trying to address that by reseting it to initial values. 

https://issues.folio.org/browse/UIU-733