### PR TITLE
STSMACOM-133: Apply arrows for magnifying glass

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -8,10 +8,14 @@ import { deprecated } from 'prop-types-extra';
 import Route from 'react-router-dom/Route';
 import { withRouter } from 'react-router';
 import { FormattedMessage } from 'react-intl';
-import { withModule } from '@folio/stripes-core/src/components/Modules';
-import { withStripes } from '@folio/stripes-core';
 import queryString from 'query-string';
-import { debounce, get, includes, upperFirst } from 'lodash';
+import {
+  debounce,
+  get,
+  includes,
+  upperFirst,
+} from 'lodash';
+
 import FilterGroups, {
   filterState,
   handleFilterChange,
@@ -20,21 +24,28 @@ import FilterGroups, {
 import {
   Button,
   IfPermission,
-  IconButton,
   Layer,
   MultiColumnList,
   Pane,
   PaneMenu,
   Paneset,
   SearchField,
-  SRStatus
+  SRStatus,
 } from '@folio/stripes-components';
-import { mapNsKeys, getNsKey } from './nsQueryFunctions';
+import { withModule } from '@folio/stripes-core/src/components/Modules';
+import { withStripes } from '@folio/stripes-core';
+
 import Tags from '../Tags';
-import css from './SearchAndSort.css';
+import {
+  mapNsKeys,
+  getNsKey,
+} from './nsQueryFunctions';
 import makeConnectedSource from './ConnectedSource';
 import NoResultsMessage from './components/NoResultsMessage';
 import ResetButton from './components/ResetButton';
+import SearchButton from './components/SearchButton';
+
+import css from './SearchAndSort.css';
 
 class SearchAndSort extends React.Component {
   static propTypes = {
@@ -228,8 +239,8 @@ class SearchAndSort extends React.Component {
 
     // if the results list is winnowed down to a single record, display the record.
     if (nextProps.showSingleResult &&
-        newState.totalCount() === 1 &&
-        this.lastNonNullReaultCount > 1) {
+      newState.totalCount() === 1 &&
+      this.lastNonNullReaultCount > 1) {
       this.onSelectRow(null, newState.records()[0]);
     }
 
@@ -448,7 +459,12 @@ class SearchAndSort extends React.Component {
   }
 
   renderHelperApp() {
-    const { stripes, match, getHelperResourcePath } = this.props;
+    const {
+      stripes,
+      match,
+      getHelperResourcePath,
+    } = this.props;
+
     const moduleName = this.getModuleName();
     const helper = this.queryParam('helper');
     const HelperAppComponent = this.helperApps[helper];
@@ -483,17 +499,43 @@ class SearchAndSort extends React.Component {
       viewRecordPerms,
       objectName,
       detailProps,
-      stripes
+      stripes,
+      actionMenu,
+      actionMenuItems,
+      browseOnly,
+      columnMapping,
+      columnWidths,
+      disableRecordCreation,
+      editRecordComponent,
+      location,
+      match,
+      module,
+      newRecordInitialValues,
+      notLoadedMessage,
+      onChangeIndex,
+      parentMutator,
+      path,
+      resultCountMessageKey,
+      resultsFormatter,
+      searchableIndexes,
+      selectedIndex,
+      visibleColumns,
     } = this.props;
-    const { locallyChangedSearchTerm } = this.state;
+
+    const {
+      locallyChangedSearchTerm,
+      filterPaneIsVisible,
+    } = this.state;
+
     const source = makeConnectedSource(this.props, stripes.logger);
-    const urlQuery = queryString.parse(this.props.location.search || '');
+    const urlQuery = queryString.parse(location.search || '');
     const objectNameUC = upperFirst(objectName);
     const records = source.records();
-    const searchTerm =
-      (locallyChangedSearchTerm !== undefined) ? locallyChangedSearchTerm : (this.queryParam('query') || '');
-    const filters = filterState(this.queryParam('filters'));
+    const searchTerm = (locallyChangedSearchTerm !== undefined)
+      ? locallyChangedSearchTerm
+      : (this.queryParam('query') || '');
 
+    const filters = filterState(this.queryParam('filters'));
     const moduleName = this.getModuleName();
 
     const appIcon = {
@@ -523,22 +565,25 @@ class SearchAndSort extends React.Component {
       </IfPermission>
     );
 
-    const { filterPaneIsVisible } = this.state;
     const filterCount = Object.keys(filters).length;
-    const hideOrShowMessageId =
-      filterPaneIsVisible ? 'stripes-smart-components.hideSearchPane' : 'stripes-smart-components.showSearchPane';
+    const hideOrShowMessageId = filterPaneIsVisible
+      ? 'stripes-smart-components.hideSearchPane'
+      : 'stripes-smart-components.showSearchPane';
 
     const resultsFirstMenu = (
       <PaneMenu>
-        <FormattedMessage id="stripes-smart-components.numberOfFilters" values={{ count: filterCount }}>
+        <FormattedMessage
+          id="stripes-smart-components.numberOfFilters"
+          values={{ count: filterCount }}
+        >
           {appliedFiltersMessage => (
             <FormattedMessage id={hideOrShowMessageId}>
               {hideOrShowMessage => (
-                <IconButton
-                  icon="search"
+                <SearchButton
+                  visible={filterPaneIsVisible}
                   aria-label={`${hideOrShowMessage} \n\n${appliedFiltersMessage}`}
                   onClick={this.toggleFilterPane}
-                  badgeCount={!filterPaneIsVisible && filterCount ? filterCount : undefined}
+                  badge={!filterPaneIsVisible && filterCount ? filterCount : undefined}
                 />
               )}
             </FormattedMessage>
@@ -551,21 +596,22 @@ class SearchAndSort extends React.Component {
       stripes.hasPerm(viewRecordPerms) ?
         (
           <Route
-            path={this.props.path ? this.props.path : `${this.props.match.path}/view/:id`}
-            render={props => <this.connectedViewRecord
-              stripes={stripes}
-              paneWidth="44%"
-              parentResources={parentResources}
-              connectedSource={source}
-              parentMutator={this.props.parentMutator}
-              onClose={this.collapseDetails}
-              onEdit={this.onEdit}
-              editLink={this.craftLayerUrl('edit')}
-              onCloseEdit={this.onCloseEdit}
-              tagsToggle={this.toggleTags}
-              {...props}
-              {...detailProps}
-            />}
+            path={path || `${match.path}/view/:id`}
+            render={props => (
+              <this.connectedViewRecord
+                stripes={stripes}
+                paneWidth="44%"
+                parentResources={parentResources}
+                connectedSource={source}
+                parentMutator={parentMutator}
+                onClose={this.collapseDetails}
+                onEdit={this.onEdit}
+                editLink={this.craftLayerUrl('edit')}
+                onCloseEdit={this.onCloseEdit}
+                tagsToggle={this.toggleTags}
+                {...props}
+                {...detailProps}
+              />)}
           />
         ) : (
           <div
@@ -589,40 +635,39 @@ class SearchAndSort extends React.Component {
       searchTerm={searchTerm}
       filterPaneIsVisible={filterPaneIsVisible}
       toggleFilterPane={this.toggleFilterPane}
-      notLoadedMessage={this.props.notLoadedMessage}
+      notLoadedMessage={notLoadedMessage}
     />;
     const sortOrder = this.queryParam('sort') || '';
 
-    const createRecordLayer = (!this.props.editRecordComponent ? '' :
-    <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false}>
-      <this.props.editRecordComponent
-        stripes={stripes}
-        id={`${objectName}form-add${objectName}`}
-        initialValues={this.props.newRecordInitialValues}
-        onSubmit={record => this.createRecord(record)}
-        onCancel={this.closeNewRecord}
-        parentResources={parentResources}
-        connectedSource={source}
-        parentMutator={this.props.parentMutator}
-        {...detailProps}
-      />
-    </Layer>);
-
-    const messageKey =
-      this.props.resultCountMessageKey ?
-        this.props.resultCountMessageKey : 'stripes-smart-components.searchResultsCountHeader';
-    const paneSub =
-      !source.loaded() ? (
-        <FormattedMessage id="stripes-smart-components.searchCriteria" />
-      ) : (
-        <FormattedMessage id={messageKey} values={{ count }} />
+    const createRecordLayer = !editRecordComponent
+      ? null
+      : (
+        <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false}>
+          <editRecordComponent
+            stripes={stripes}
+            id={`${objectName}form-add${objectName}`}
+            initialValues={newRecordInitialValues}
+            onSubmit={record => this.createRecord(record)}
+            onCancel={this.closeNewRecord}
+            parentResources={parentResources}
+            connectedSource={source}
+            parentMutator={parentMutator}
+            {...detailProps}
+          />
+        </Layer>
       );
+
+    const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
+
+    const paneSub = !source.loaded()
+      ? <FormattedMessage id="stripes-smart-components.searchCriteria" />
+      : <FormattedMessage id={messageKey} values={{ count }} />;
 
     return (
       <Paneset>
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
         {/* Filter Pane */}
-        { filterPaneIsVisible ?
+        {filterPaneIsVisible ?
           <Pane
             id="pane-filter"
             defaultWidth="320px"
@@ -632,9 +677,9 @@ class SearchAndSort extends React.Component {
             <form onSubmit={this.onSubmitSearch}>
               <SearchField
                 id={`input-${objectName}-search`}
-                searchableIndexes={this.props.searchableIndexes}
-                selectedIndex={this.props.selectedIndex}
-                onChangeIndex={this.props.onChangeIndex}
+                searchableIndexes={searchableIndexes}
+                selectedIndex={selectedIndex}
+                onChangeIndex={onChangeIndex}
                 onChange={this.onChangeSearch}
                 onClear={this.onClearSearchQuery}
                 value={searchTerm}
@@ -651,7 +696,7 @@ class SearchAndSort extends React.Component {
               >
                 <FormattedMessage id="stripes-smart-components.search" />
               </Button>
-              { this.renderResetButton() }
+              {this.renderResetButton()}
               <FilterGroups
                 config={filterConfig}
                 filters={filters}
@@ -669,32 +714,35 @@ class SearchAndSort extends React.Component {
           padContent={false}
           id="pane-results"
           defaultWidth="fill"
-          actionMenu={this.props.actionMenu}
-          actionMenuItems={this.props.actionMenuItems}
+          actionMenu={actionMenu}
+          actionMenuItems={actionMenuItems}
           appIcon={appIcon}
-          paneTitle={this.props.module.displayName}
+          paneTitle={module.displayName}
           paneSub={paneSub}
-          lastMenu={!this.props.disableRecordCreation ? newRecordButton : null}
+          lastMenu={!disableRecordCreation ? newRecordButton : null}
           firstMenu={resultsFirstMenu}
           noOverflow
         >
-          <FormattedMessage id="stripes-smart-components.searchResults" values={{ objectName: objectNameUC }}>
-            { ariaLabel => (
+          <FormattedMessage
+            id="stripes-smart-components.searchResults"
+            values={{ objectName: objectNameUC }}
+          >
+            {ariaLabel => (
               <MultiColumnList
                 id={`list-${moduleName}`}
                 totalCount={count}
                 contentData={records}
                 selectedRow={this.state.selectedItem}
-                formatter={this.props.resultsFormatter}
+                formatter={resultsFormatter}
                 onRowClick={this.onSelectRow}
                 onHeaderClick={this.onSort}
                 onNeedMoreData={this.onNeedMore}
-                visibleColumns={this.props.visibleColumns}
+                visibleColumns={visibleColumns}
                 sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
                 sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
                 isEmptyMessage={message}
-                columnWidths={this.props.columnWidths}
-                columnMapping={this.props.columnMapping}
+                columnWidths={columnWidths}
+                columnMapping={columnMapping}
                 loading={source.pending()}
                 autosize
                 virtualize
@@ -705,9 +753,9 @@ class SearchAndSort extends React.Component {
             )}
           </FormattedMessage>
         </Pane>
-        { !this.props.browseOnly && detailsPane }
-        { !this.props.browseOnly && createRecordLayer }
-        { this.renderHelperApp() }
+        {!browseOnly && detailsPane}
+        {!browseOnly && createRecordLayer}
+        {this.renderHelperApp()}
 
       </Paneset>
     );

--- a/lib/SearchAndSort/components/SearchButton/SearchButton.css
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.css
@@ -1,0 +1,39 @@
+@import '@folio/stripes-components/lib/variables';
+
+.button {
+  width: 36px;
+  height: 43px;
+  border: solid 5px var(--bg);
+  margin: 0;
+  padding: 0 18px;
+
+  /* transition: width .3s ease-out; */
+  &.hasBadge {
+    width: auto;
+    padding: 5px;
+  }
+}
+
+.iconsWrapper {
+  margin-left: 10px;
+
+  /* transition: margin-left .3s ease-out; */
+  &.moved {
+    margin-left: -10px;
+  }
+}
+
+.icon {
+  font-size: 16px;
+  opacity: 1;
+  vertical-align: -0.3em;
+
+  /* transition: opacity .3s ease-out; */
+  &.hidden {
+    opacity: 0;
+  }
+
+  &.arrow {
+    width: 10px;
+  }
+}

--- a/lib/SearchAndSort/components/SearchButton/SearchButton.js
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import {
+  Badge,
+  Button,
+  Icon,
+} from '@folio/stripes-components';
+
+import css from './SearchButton.css';
+
+const visiblePanelIcons = ['chevron-left', 'search'];
+const hiddenPanelIcons = ['search', 'chevron-right'];
+const icons = ['chevron-left', 'search', 'badge', 'chevron-right'];
+
+export default class SearchButton extends Component {
+  static propTypes = {
+    ariaLabel: PropTypes.string,
+    badge: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    onClick: PropTypes.func.isRequired,
+    visible: PropTypes.bool.isRequired,
+  }
+
+  renderIcons = (badge) => {
+    const visibleIcons = this.props.visible ? visiblePanelIcons : hiddenPanelIcons;
+
+    return icons.map((iconName) => {
+      if (iconName === 'badge') {
+        return (badge &&
+          <Badge key={iconName}>
+            {badge}
+          </Badge>
+        );
+      }
+
+      return (
+        <Icon
+          iconRootClass={classnames(
+            css.icon,
+            { [css.hidden]: !visibleIcons.includes(iconName) },
+            { [css.arrow]: iconName.includes('chevron') },
+          )}
+          size="medium"
+          icon={iconName}
+          key={iconName}
+        />
+      );
+    });
+  }
+
+  render() {
+    const {
+      ariaLabel,
+      badge,
+      onClick,
+      visible,
+      ...rest
+    } = this.props;
+
+    const buttonClass = classnames(
+      css.button,
+      { [css.hasBadge]: typeof badge !== 'undefined' },
+    );
+
+    const iconWrapperClass = classnames(
+      css.iconsWrapper,
+      { [css.moved]: !visible },
+    );
+
+    return (
+      <Button
+        buttonStyle="none"
+        buttonClass={buttonClass}
+        aria-label={ariaLabel}
+        onClick={onClick}
+        {...rest}
+      >
+        <span className={iconWrapperClass}>
+          {this.renderIcons(badge)}
+        </span>
+      </Button>
+    );
+  }
+}

--- a/lib/SearchAndSort/components/SearchButton/index.js
+++ b/lib/SearchAndSort/components/SearchButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchButton';


### PR DESCRIPTION
## Purpose
Regarding [STSMACOM-133](https://issues.folio.org/browse/STSMACOM-133), arrow icons should be applied to magnifying glass to indicate the state of the searching pane. The existence of badge should be taken into the account (when filters are applied). 

_Animation for pane will be applied later._

## Approach
- Add arrow icons to stripes-components [STCOM-407](https://github.com/folio-org/stripes-components/pull/731).
- Create `<SearchButton> `component, where the icons are applied.
- Add animation for the icons.

## Screenshots
![2018-11-27 15 40 49](https://user-images.githubusercontent.com/43647240/49085532-e3586680-f25a-11e8-9e7f-b177427d562f.gif)

Without animation
![2018-11-27 16 18 46](https://user-images.githubusercontent.com/43647240/49087656-354fbb00-f260-11e8-8860-522e72a7d54a.gif)
:

