### PR TITLE
Uppercase editRecordComponent

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -638,12 +638,12 @@ class SearchAndSort extends React.Component {
       notLoadedMessage={notLoadedMessage}
     />;
     const sortOrder = this.queryParam('sort') || '';
-
+    const EditRecordComponent = editRecordComponent;
     const createRecordLayer = !editRecordComponent
       ? null
       : (
         <Layer isOpen={urlQuery.layer ? urlQuery.layer === 'create' : false}>
-          <editRecordComponent
+          <EditRecordComponent
             stripes={stripes}
             id={`${objectName}form-add${objectName}`}
             initialValues={newRecordInitialValues}


### PR DESCRIPTION
React component names must begin with capital letters (or alternatively they can be accessed via props). 
