### PR TITLE
Add aria-label to SearchField

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -675,18 +675,26 @@ class SearchAndSort extends React.Component {
             onClose={this.toggleFilterPane}
           >
             <form onSubmit={this.onSubmitSearch}>
-              <SearchField
-                id={`input-${objectName}-search`}
-                searchableIndexes={searchableIndexes}
-                selectedIndex={selectedIndex}
-                onChangeIndex={onChangeIndex}
-                onChange={this.onChangeSearch}
-                onClear={this.onClearSearchQuery}
-                value={searchTerm}
-                loading={source.pending()}
-                marginBottom0
-                className={css.searchField}
-              />
+              <FormattedMessage
+                id="stripes-smart-components.searchFieldLabel"
+                values={{ moduleName: module.displayName }}
+              >
+                { ariaLabel => (
+                  <SearchField
+                    ariaLabel={ariaLabel}
+                    id={`input-${objectName}-search`}
+                    searchableIndexes={searchableIndexes}
+                    selectedIndex={selectedIndex}
+                    onChangeIndex={onChangeIndex}
+                    onChange={this.onChangeSearch}
+                    onClear={this.onClearSearchQuery}
+                    value={searchTerm}
+                    loading={source.pending()}
+                    marginBottom0
+                    className={css.searchField}
+                  />
+                )}
+              </FormattedMessage>
               <Button
                 type="submit"
                 buttonStyle="primary"

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -94,5 +94,6 @@
   "password.repeatingSymbols.invalid": "The password must not contain the same character in a row.",
   "password.whiteSpace.invalid": "The password must not contain whitespaces.",
   "password.lastTenPasswords.invalid": "Previously used password. Please enter a new password.",
-  "address.addAddress": "Add address"
+  "address.addAddress": "Add address",
+  "searchFieldLabel": "Search {moduleName}"
 }


### PR DESCRIPTION
## A11y issue
The search field was unlabled, so Axe was pinging us.
Previously, JAWS would only say "Edit, type-in text" when the search field was focused.

Applied aria-label "Search {moduleName}".