### PR TITLE
be less strict with label prop-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 1.13.0 (IN PROGRESS)
+
+* Lenient label proptypes accept a node in order to receive a `<FormattedMessage>`.
+
 ## [1.12.0](https://github.com/folio-org/stripes-smart-components/tree/v1.12.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.11.0...v1.12.0)
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -42,7 +42,7 @@ class ControlledVocab extends React.Component {
     label: PropTypes.node.isRequired,
     labelSingular: PropTypes.node.isRequired,
     listSuppressor: PropTypes.func,
-    listSuppressorText: PropTypes.string,
+    listSuppressorText: PropTypes.node,
     mutator: PropTypes.shape({
       activeRecord: PropTypes.shape({
         update: PropTypes.func,

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -40,7 +40,7 @@ const propTypes = {
   /**
    * Label for the 'Add' button
    */
-  createButtonLabel: PropTypes.string,
+  createButtonLabel: PropTypes.node,
   /**
    *  set custom component for editing
    */
@@ -77,7 +77,7 @@ const propTypes = {
   /**
    * The text for the H3 tag in the header of the component
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
   /**
    * Callback for creating new list items.
    */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "publishConfig": {


### PR DESCRIPTION
Labels may be strings or `<FormattedMessage>` components containing
translated strings. Accept either.