### PR TITLE
Remove react-intl-formatted-xml-message

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "query-string": "^5.0.0",
     "react-bootstrap": "0.32.1",
     "react-intl": "^2.4.0",
-    "react-intl-formatted-xml-message": "^1.0.1",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",
     "react-transition-group": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9420,11 +9420,6 @@ react-hot-loader@^4.3.10:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
 
-react-intl-formatted-xml-message@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-intl-formatted-xml-message/-/react-intl-formatted-xml-message-1.0.1.tgz#83f8b3d9077a46d35bb2fddf4cdfb2a23c6bcec5"
-  integrity sha512-GLZpVgO01qe+zSzeu3aYgL+J/foI0DBGv+oJSQ9D7+r35XDsVonVSsbILI/AIkzFGXzmQl50mVImUW8L1xQUeQ==
-
 react-intl@^2.4.0, react-intl@^2.5.0:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.7.2.tgz#efe97e3fc0e99b4e88a6e6150854d3d1852a4381"


### PR DESCRIPTION
Dependency no longer in use by `stripes-smart-components`.