### PR TITLE
STCOM-391 Remove plus sign from translation strings

### DIFF
--- a/translations/stripes-smart-components/ar.json
+++ b/translations/stripes-smart-components/ar.json
@@ -59,7 +59,7 @@
     "postNote": "نشر ملاحظة",
     "searchAndFilter": "بحث وتنقيح ",
     "search": "بحث",
-    "new": "+ جديد",
+    "new": "جديد",
     "hideSearchPane": "إخفاء جزء البحث والمنقحات.",
     "showSearchPane": "إظهار جزء البحث والمنقحات.",
     "numberOfFilters": "{count, number} {count, plural, one {منقح مطبق} other {منقحات مطبقة}}",

--- a/translations/stripes-smart-components/ca.json
+++ b/translations/stripes-smart-components/ca.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/da.json
+++ b/translations/stripes-smart-components/da.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/de.json
+++ b/translations/stripes-smart-components/de.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Suche",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/en_GB.json
+++ b/translations/stripes-smart-components/en_GB.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/en_US.json
+++ b/translations/stripes-smart-components/en_US.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/es.json
+++ b/translations/stripes-smart-components/es.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/es_ES.json
+++ b/translations/stripes-smart-components/es_ES.json
@@ -59,7 +59,7 @@
     "postNote": "Publicar Nota",
     "searchAndFilter": "Buscar y Filtrar",
     "search": "Buscar",
-    "new": "+ Nuevo",
+    "new": "Nuevo",
     "hideSearchPane": "Ocultar panel de Búsqueda y Filtros.",
     "showSearchPane": "Mostrar panel Búsqueda y Filtros.",
     "numberOfFilters": "{count, number} {count, plural, one { applied filter } other { applied filters }}",

--- a/translations/stripes-smart-components/fr.json
+++ b/translations/stripes-smart-components/fr.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/fr_FR.json
+++ b/translations/stripes-smart-components/fr_FR.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/hu.json
+++ b/translations/stripes-smart-components/hu.json
@@ -59,7 +59,7 @@
     "postNote": "Post megjegyzés",
     "searchAndFilter": "Keresés & szűrő",
     "search": "Keresés",
-    "new": "+ Új",
+    "new": "Új",
     "hideSearchPane": "Keresés és szűrők ablak elrejtése.",
     "showSearchPane": "Keresés és szűrők ablak mutatása.",
     "numberOfFilters": "{count, number} {count, plural, one {alkalmazott szűrő} other {alkalmazott szűrők}}",

--- a/translations/stripes-smart-components/it_IT.json
+++ b/translations/stripes-smart-components/it_IT.json
@@ -59,7 +59,7 @@
     "postNote": "Post Note",
     "searchAndFilter": "Search & Filter",
     "search": "Search",
-    "new": "+ New",
+    "new": "New",
     "hideSearchPane": "Hide Search and Filters pane.",
     "showSearchPane": "Show Search and Filters pane.",
     "numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",

--- a/translations/stripes-smart-components/pt_BR.json
+++ b/translations/stripes-smart-components/pt_BR.json
@@ -59,7 +59,7 @@
     "postNote": "Nota de correio",
     "searchAndFilter": "Pesquisar e filtrar",
     "search": "Pesquisa",
-    "new": "+ Novo",
+    "new": "Novo",
     "hideSearchPane": "Ocultar painel de pesquisa e filtros.",
     "showSearchPane": "Mostrar painel de pesquisa e filtros.",
     "numberOfFilters": "{count, number} {count, plural, one {filtro aplicado} other {filtros aplicados}}",

--- a/translations/stripes-smart-components/pt_PT.json
+++ b/translations/stripes-smart-components/pt_PT.json
@@ -59,7 +59,7 @@
     "postNote": "Nota de correio",
     "searchAndFilter": "Pesquisa & Filtro",
     "search": "Pesquisa",
-    "new": "+ Novo",
+    "new": "Novo",
     "hideSearchPane": "Ocultar painel de pesquisa e filtros",
     "showSearchPane": "Mostrar painel de pesquisa e filtros",
     "numberOfFilters": "{count, number} {count, plural, one {filtro aplicado} other {filtros aplicados}}",

--- a/translations/stripes-smart-components/zh_CN.json
+++ b/translations/stripes-smart-components/zh_CN.json
@@ -59,7 +59,7 @@
     "postNote": "发布附注",
     "searchAndFilter": "搜索和筛选",
     "search": "搜索",
-    "new": "+新建",
+    "new": "新建",
     "hideSearchPane": "隐藏 \"搜索和筛选\" 面板。",
     "showSearchPane": "显示\"搜索和筛选\" 面板。",
     "numberOfFilters": "{count, number} {count, plural, one {应用筛选} other {应用筛选}}",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-391

## Approach
Instead of having the "+" directly in the translation file, we'll now do:
```
<Icon icon="plus-sign">
  <FormattedMessage id="stripes-components.translationId" />
</Icon>
```
This new approach also works for RTL languages, placing the icon on the right. It does not accommodate situations where the translator might want to put the icon in the middle or wants to remove the icon entirely - we'll need to watch and see if those come up (they might not).
