### PR TITLE
Remove noOverflow from EntrySelector list pane. Refs UIU-764.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Provide `contentLabel` to `<Layer>` from `<EntryManager>`. Available from v1.12.2.
 * Refactor proxy fetching in `<ProxyManager>`. Fixes STSMACOM-154. Available from v1.12.3.
 * Fix no results found message. Fixes STSMACOM-155.
+* Remove `noOverflow` from `<EntrySelector>` list pane. Ref UIU-764.
 
 ## [1.12.0](https://github.com/folio-org/stripes-smart-components/tree/v1.12.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.11.0...v1.12.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -204,7 +204,7 @@ class EntrySelector extends React.Component {
 
     return (
       <Paneset defaultWidth={paneSetWidth}>
-        <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle} noOverflow>
+        <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle}>
           {this.props.rowFilter}
           <NavList>
             <NavListSection activeLink={this.activeLink(links)} className={contentData.length ? 'hasEntries' : ''}>


### PR DESCRIPTION
The `noOverflow` was causing scroll bars to disappear on the `EntryManager` setting pages.

https://issues.folio.org/browse/UIU-764