### PR TITLE
Use PaneBackLink in Settings

### DIFF
--- a/lib/Settings/Settings.css
+++ b/lib/Settings/Settings.css
@@ -1,11 +1,3 @@
-@import '@folio/stripes-components/lib/variables';
-
-.settingsBackButton {
-  @media (--medium-up) {
-    display: none;
-  }
-}
-
 .listSection {
-  margin-bottom: 20px;
+  margin-bottom: 1.5rem;
 }

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -2,15 +2,14 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
-import Link from 'react-router-dom/Link';
 import { withStripes } from '@folio/stripes-core';
 
 import NavListItem from '@folio/stripes-components/lib/NavListItem';
 import {
-  IconButton,
   NavList,
   NavListSection,
-  Pane
+  Pane,
+  PaneBackLink,
 } from '@folio/stripes-components';
 
 import css from './Settings.css';
@@ -86,11 +85,7 @@ class Settings extends React.Component {
         <Pane
           defaultWidth={props.navPaneWidth}
           paneTitle={props.paneTitle || 'Module Settings'}
-          firstMenu={(
-            <Link to="/settings" className={css.settingsBackButton}>
-              <IconButton icon="arrow-left" />
-            </Link>
-          )}
+          firstMenu={<PaneBackLink to="/settings" />}
         >
           {this.sections.map((section, index) => (
             <NavList key={index}>


### PR DESCRIPTION
Uses new `<PaneBackLink>` for responsive behavior in settings Paneset: https://github.com/folio-org/stripes-components/pull/772

Requires https://github.com/folio-org/stripes-components/pull/781 release first.