### PR TITLE
label UserLink as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Refactor proxy fetching in `<ProxyManager>`. Fixes STSMACOM-154. Available from v1.12.3.
 * Fix no results found message. Fixes STSMACOM-155.
 * Remove `noOverflow` from `<EntrySelector>` list pane. Ref UIU-764.
+* Label `<UserLink>` as deprecated. Refs STRIPES-577.
 
 ## [1.12.0](https://github.com/folio-org/stripes-smart-components/tree/v1.12.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v1.11.0...v1.12.0)

--- a/lib/UserLink/UserLink.js
+++ b/lib/UserLink/UserLink.js
@@ -14,6 +14,9 @@ class UserLink extends React.Component {
   constructor(props) {
     super(props);
 
+    console.warn('Warning: <UserLink> is deprecated and will be removed in the\n' +
+      'next major version of @folio/stripes-smart-components.\n');
+
     this.connectedUserName = props.stripes.connect(UserName);
   }
 


### PR DESCRIPTION
UserName should be deprecated too, but putting a `console` statement in
`render` for a component that isn't actually in use felt like overkill.

Refs [STRIPES-577](https://issues.folio.org/browse/STRIPES-577)