### PR TITLE
STSMACOM-157: Minor fixes for SearchButton

### DIFF
--- a/lib/SearchAndSort/components/SearchButton/SearchButton.css
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.css
@@ -19,11 +19,12 @@
 .arrow {
   width: 0.7rem;
   opacity: 1;
-  transition: opacity 0.2s ease-out;
+  transition: opacity 300ms ease-out;
 
   &.hidden {
     opacity: 0;
     width: 0;
     overflow: hidden;
+    transition: opacity 300ms ease-out;
   }
 }

--- a/lib/SearchAndSort/components/SearchButton/SearchButton.css
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.css
@@ -1,34 +1,29 @@
 @import '@folio/stripes-components/lib/variables';
 
 .button {
+  composes: boxOffsetSmall from "@folio/stripes-components/lib/sharedStyles/interactionStyles.css";
   margin: 0;
-  padding: 0.3rem 0.2rem;
-
-  &.hasBadge {
-    width: auto;
-    padding: 5px;
-  }
+  padding: 0;
+  font-size: var(--font-size-medium);
+  color: var(--color-text-p2);
 }
 
-.iconsWrapper {
-  margin-left: 10px;
-
-  &.moved {
-    margin-left: -10px;
-  }
+.badge {
+  margin: 0 0 0 0.2rem;
 }
 
-.icon {
-  font-size: 16px;
+[dir="rtl"] .badge {
+  margin: 0 0.2rem 0 0;
+}
+
+.arrow {
+  width: 0.7rem;
   opacity: 1;
-  vertical-align: -0.3em;
+  transition: opacity 0.2s ease-out;
 
-  /* transition: opacity .3s ease-out; */
   &.hidden {
     opacity: 0;
-  }
-
-  &.arrow {
-    width: 10px;
+    width: 0;
+    overflow: hidden;
   }
 }

--- a/lib/SearchAndSort/components/SearchButton/SearchButton.css
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.css
@@ -1,13 +1,9 @@
 @import '@folio/stripes-components/lib/variables';
 
 .button {
-  width: 36px;
-  height: 43px;
-  border: solid 5px var(--bg);
   margin: 0;
-  padding: 0 18px;
+  padding: 0.3rem 0.2rem;
 
-  /* transition: width .3s ease-out; */
   &.hasBadge {
     width: auto;
     padding: 5px;
@@ -17,7 +13,6 @@
 .iconsWrapper {
   margin-left: 10px;
 
-  /* transition: margin-left .3s ease-out; */
   &.moved {
     margin-left: -10px;
   }

--- a/lib/SearchAndSort/components/SearchButton/SearchButton.js
+++ b/lib/SearchAndSort/components/SearchButton/SearchButton.js
@@ -6,6 +6,7 @@ import {
   Badge,
   Button,
   Icon,
+  Layout,
 } from '@folio/stripes-components';
 
 import css from './SearchButton.css';
@@ -31,7 +32,7 @@ export default class SearchButton extends Component {
     return icons.map((iconName) => {
       if (iconName === 'badge') {
         return (badge &&
-          <Badge key={iconName}>
+          <Badge key={iconName} className={css.badge}>
             {badge}
           </Badge>
         );
@@ -67,7 +68,9 @@ export default class SearchButton extends Component {
     );
 
     const iconWrapperClass = classnames(
-      css.iconsWrapper,
+      'display-flex',
+      'flex-align-items-center',
+      css.inner,
       { [css.moved]: !visible },
     );
 
@@ -79,9 +82,9 @@ export default class SearchButton extends Component {
         onClick={onClick}
         {...rest}
       >
-        <span className={iconWrapperClass}>
+        <Layout className={iconWrapperClass}>
           {this.renderIcons(badge)}
-        </span>
+        </Layout>
       </Button>
     );
   }


### PR DESCRIPTION
**Ticket:** https://issues.folio.org/browse/STSMACOM-157

## Updates
- Fixed over the edge bleed
- Added small opacity transition
- Changed sizing to match other pane header icons
- Replaced pixel for rem values and applied CSS variables

## Before
![jan-02-2019 13-48-55](https://user-images.githubusercontent.com/640976/50592752-bc163a00-0e95-11e9-9921-4bca5257fa77.gif)

## After
![jan-02-2019 13-49-03](https://user-images.githubusercontent.com/640976/50592754-c0daee00-0e95-11e9-92f5-f3d2a4e305b1.gif)
