### PR TITLE
STSMACOM-160: Add renderFilters support

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -78,7 +78,7 @@ class SearchAndSort extends React.Component {
           ]),
         ).isRequired,
       }),
-    ).isRequired,
+    ),
     finishedResourceName: PropTypes.string,
     getHelperResourcePath: PropTypes.func,
     initialFilters: PropTypes.string,
@@ -106,6 +106,7 @@ class SearchAndSort extends React.Component {
     onChangeIndex: PropTypes.func,
     onComponentWillUnmount: PropTypes.func,
     onCreate: PropTypes.func,
+    onFilterChange: PropTypes.func,
     onSelectRow: PropTypes.func,
     packageInfo: PropTypes.shape({ // values pulled from the provider's package.json config object
       initialFilters: PropTypes.string, // default filters
@@ -150,6 +151,7 @@ class SearchAndSort extends React.Component {
     }).isRequired,
     path: PropTypes.string,
     queryFunction: PropTypes.func,
+    renderFilters: PropTypes.func,
     resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
     resultsFormatter: PropTypes.shape({}),
@@ -269,6 +271,17 @@ class SearchAndSort extends React.Component {
     const newFilters = this.handleFilterChange(e);
     if (this.props.filterChangeCallback) this.props.filterChangeCallback(newFilters);
   }
+
+  onFilterChangeHandler = (filter) => {
+    const {
+      parentMutator,
+      initialResultCount,
+      onFilterChange,
+    } = this.props;
+
+    parentMutator.resultCount.replace(initialResultCount);
+    onFilterChange(filter);
+  };
 
   onChangeSearch = (e) => {
     const query = e.target.value;
@@ -496,6 +509,7 @@ class SearchAndSort extends React.Component {
     const {
       parentResources,
       filterConfig,
+      renderFilters,
       disableFilters,
       newRecordPerms,
       viewRecordPerms,
@@ -709,13 +723,19 @@ class SearchAndSort extends React.Component {
                 <FormattedMessage id="stripes-smart-components.search" />
               </Button>
               {this.renderResetButton()}
-              <FilterGroups
-                config={filterConfig}
-                filters={filters}
-                onChangeFilter={this.onChangeFilter}
-                onClearFilter={this.onClearFilter}
-                disableNames={disableFilters}
-              />
+              {
+                renderFilters
+                  ? renderFilters(this.onFilterChangeHandler)
+                  : (
+                    <FilterGroups
+                      config={filterConfig}
+                      filters={filters}
+                      onChangeFilter={this.onChangeFilter}
+                      onClearFilter={this.onClearFilter}
+                      disableNames={disableFilters}
+                    />
+                  )
+              }
             </form>
           </Pane>
           :

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -28,6 +28,8 @@ filterConfig | array of structures | Configuration for the module's filters, as 
 initialFilters | string | The initial state of the filters when the application started up, used when resetting to the initial state. Takes the same form as the `filters` part of the URL: a comma-separated list of `group`.`name` filters that are selected.
 disableFilters | object whose keys are filter-group names | In the display of filter groups, those that are named in this object are greyed out and cannot be selected.
 filterChangeCallback | function | If provided, this function is invoked when the user changes a filter. It is passed the new set of filters, in the form of an object whose keys are the `group`.`name` specifiers of each selected filter.
+onFilterChange | function | Callback to be called after filter value is changed. Gets filter name and filter values in a form of an object `{ name: <String>, values: <Array> }`.
+renderFilters | function | Renders a set of filters. Gets onChange callback to be called after filter value change.
 initialResultCount | number | The number of records to fetch when a new search is executed (including the null search that is run when the module starts).
 resultCountIncrement | number | The amount by which to increase the number of records when scrolling close to the bottom of the loaded list.
 viewRecordComponent | component | A React component that displays a record of the appropriate type in full view. This is invoked with a specific set of properties that ought also to be documented, but for now, see the example of [`<ViewUser>` in ui-users](https://github.com/folio-org/ui-users/blob/master/ViewUser.js).


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-160

## Purpose
Make SearchAndSort component more flexible in case of filters. This allows creating a specific set of filters for each UI module in a declarative way.

## Approach
- add new props: `renderFilters` and `onFilterChange`
- add a condition to execute `renderFilters` when it exists or to render `FilterGroups` component as it was before. Is necessary to avoid breaking changes.
- update readme
