### PR TITLE
Replace mutator.query.update with history.push. Part of STCOM-302

### DIFF
--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -115,27 +115,20 @@ export default class EntryWrapper extends React.Component {
   }
 
   goTo(entry) {
-    const path = `${this.props.match.path}/${entry.id}`;
-    this.props.mutator.query.update({
-      _path: path,
-      layer: '',
-    });
-
+    const { history, match } = this.props;
+    const path = `${match.path}/${entry.id}`;
+    history.push(path);
     this.onSelect(entry);
   }
 
   hideLayer() {
-    this.props.mutator.query.update({
-      _path: this.props.location.pathname,
-      layer: '',
-    });
+    const { location, history } = this.props;
+    history.push(location.pathname);
   }
 
   showLayer(layer) {
-    this.props.mutator.query.update({
-      _path: this.props.location.pathname,
-      layer,
-    });
+    const { location, history } = this.props;
+    history.push(`${location.pathname}?layer=${layer}`);
   }
 
   showCalloutMessage(name) {


### PR DESCRIPTION
This PR fixes an issue with the unsaved changes reported in https://issues.folio.org/browse/STCOM-302

It replaces a `mutator.query.update` with `history.push`. This plays well with react-router and stripes-form and it should fix an issue recorded by Ann-Marie:

https://issues.folio.org/secure/attachment/15610/Get%20Stuck%20trying%20to%20cancel%20Continue%20Editing.mp4

Ideally we should try to move away from managing routing via `mutator.query.update` and replace it with `history` and `<Link>`.