### PR TITLE
CheckboxFilter: Stopped rendering some props to DOM

### DIFF
--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -46,12 +46,15 @@ export default class CheckboxFilter extends React.Component {
 
     return (
       dataOptions.map(({ value, label, disabled, readOnly }) => {
+        const name = typeof label === 'string' ? label : value;
+
         return (
           <Checkbox
             {...rest}
             data-test-checkbox-filter-data-option={value}
             key={value}
             label={label}
+            name={name}
             disabled={disabled}
             readOnly={readOnly}
             checked={selectedValues.includes(value)}

--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -41,13 +41,14 @@ export default class CheckboxFilter extends React.Component {
     const {
       dataOptions,
       selectedValues,
+      ...rest
     } = this.props;
 
     return (
       dataOptions.map(({ value, label, disabled, readOnly }) => {
         return (
           <Checkbox
-            {...this.props}
+            {...rest}
             data-test-checkbox-filter-data-option={value}
             key={value}
             label={label}


### PR DESCRIPTION
`Checkbox` passes its props down to the `<input type="checkbox">` and React complains when we tell it to render `dataOptions` and `selectedValues` to the DOM.

@Yurii-Danylenko, there may be a similar change needed for `MultiSelectionFilter` but I haven't looked yet and am just using `CheckboxFilter` right now. Feel free to look into it if you want, otherwise I'll find/fix it when I do get around to using those later this week or the week after next (am on vacation next week).