### PR TITLE
STSMACOM-156: fix font size of radio button in AddressFieldGroup

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -93,7 +93,7 @@
 .primaryToggle {
   padding: 4px 8px;
   color: #555;
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-medium);
   cursor: pointer;
   margin-bottom: 0;
 


### PR DESCRIPTION
The font size of the radio button in AddressFieldGroup was incorrect
Relates to [STCOM-414](https://issues.folio.org/browse/STCOM-414), [STSMACOM-156](https://issues.folio.org/browse/STSMACOM-156)