### PR TITLE
restore predictable ids to CheckboxFilter elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update ARIA-roles in SearchAndSort and EditableList. Fix for STCOM-365
 * Use columns' static labels, not their translated aliases, for sorting in `<SearchAndSort>`. Fixes STSMACOM-93.
+* Restore predictable `id` attributes to checkboxes created by `<CheckboxFilter>`. Refs UISE-97.
 
 ## [2.0.1](https://github.com/folio-org/stripes-smart-components/tree/v2.0.1) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.0.0...v2.0.1)

--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -47,9 +47,6 @@ export default class CheckboxFilter extends React.Component {
     return (
       dataOptions.map(({ value, label, disabled, readOnly }) => {
         const name = typeof label === 'string' ? label : value;
-        console.log('label', label)
-        console.log('value', value)
-
         return (
           <Checkbox
             {...rest}

--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -47,10 +47,13 @@ export default class CheckboxFilter extends React.Component {
     return (
       dataOptions.map(({ value, label, disabled, readOnly }) => {
         const name = typeof label === 'string' ? label : value;
+        console.log('label', label)
+        console.log('value', value)
 
         return (
           <Checkbox
             {...rest}
+            id={`clickable-filter-${this.props.name}-${name}`}
             data-test-checkbox-filter-data-option={value}
             key={value}
             label={label}


### PR DESCRIPTION
The refactoring in folio-org/ui-search/pull/128 inadvertently removed predictable id attributes
from checkboxes. This made it very difficult for Nightmare tests to
programmatically interact with filters. This PR restores predictable ids.

Refs [UISE-97](https://issues.folio.org/browse/UISE-97).