### PR TITLE
Replace query resource with history push. Refs STCOM-302

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ export { default as makeQueryFunction } from './lib/SearchAndSort/makeQueryFunct
 
 export { default as makeConnectedSource } from './lib/SearchAndSort/ConnectedSource';
 export * from './lib/SearchAndSort/nsQueryFunctions';
+export { default as buildUrl } from './lib/SearchAndSort/buildUrl';
 
 export { default as Settings } from './lib/Settings';
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -46,6 +46,8 @@ import NoResultsMessage from './components/NoResultsMessage';
 import ResetButton from './components/ResetButton';
 import SearchButton from './components/SearchButton';
 
+import buildUrl from './buildUrl';
+
 import css from './SearchAndSort.css';
 
 class SearchAndSort extends React.Component {
@@ -383,13 +385,14 @@ class SearchAndSort extends React.Component {
 
   transitionToParams = values => {
     const {
+      location,
+      history,
       nsParams,
-      parentMutator: { query },
     } = this.props;
 
     const nsValues = mapNsKeys(values, nsParams);
-
-    query.update(nsValues);
+    const url = buildUrl(location, nsValues);
+    history.push(url);
   };
 
   onNeedMore = () => {
@@ -415,6 +418,8 @@ class SearchAndSort extends React.Component {
         return;
       }
     }
+
+    console.log('on select row...');
 
     this.log('action', `clicked ${meta.id}, selected record =`, meta);
     this.setState({ selectedItem: meta });

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -81,6 +81,9 @@ class SearchAndSort extends React.Component {
     ),
     finishedResourceName: PropTypes.string,
     getHelperResourcePath: PropTypes.func,
+    history: PropTypes.shape({ // provided by withRouter
+      push: PropTypes.string.isRequired,
+    }).isRequired,
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
     location: PropTypes.shape({ // provided by withRouter
@@ -203,6 +206,7 @@ class SearchAndSort extends React.Component {
     this.initialFilters = this.initialQuery.filters;
 
     const logger = stripes.logger;
+
     this.log = logger.log.bind(logger);
   }
 
@@ -221,8 +225,10 @@ class SearchAndSort extends React.Component {
 
       if (oldStateForFinalSource.records()) {
         const finishedResourceNextSM = newStateForFinalSource.successfulMutations();
+
         if (finishedResourceNextSM.length > oldStateForFinalSource.successfulMutations().length) {
           const sm = newState.successfulMutations();
+
           if (sm[0]) this.onSelectRow(undefined, { id: sm[0].record.id });
         }
       }
@@ -232,6 +238,7 @@ class SearchAndSort extends React.Component {
     if (oldState.pending() && !newState.pending()) {
       this.log('event', 'new search-result');
       const count = newState.totalCount();
+
       this.SRStatus.sendMessage(
         <FormattedMessage id="stripes-smart-components.searchReturnedResults" values={{ count }} />
       );
@@ -392,6 +399,7 @@ class SearchAndSort extends React.Component {
 
     const nsValues = mapNsKeys(values, nsParams);
     const url = buildUrl(location, nsValues);
+
     history.push(url);
   };
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -419,8 +419,6 @@ class SearchAndSort extends React.Component {
       }
     }
 
-    console.log('on select row...');
-
     this.log('action', `clicked ${meta.id}, selected record =`, meta);
     this.setState({ selectedItem: meta });
     this.transitionToParams({ _path: `${packageInfo.stripes.route}/view/${meta.id}` });

--- a/lib/SearchAndSort/buildUrl.js
+++ b/lib/SearchAndSort/buildUrl.js
@@ -1,0 +1,32 @@
+import queryString from 'query-string';
+import {
+  unset,
+  isEmpty,
+  forOwn,
+} from 'lodash';
+
+function getLocationQuery(location) {
+  return location.query ? location.query : queryString.parse(location.search);
+}
+
+function removeEmpty(obj) {
+  const cleanObj = {};
+  forOwn(obj, (value, key) => {
+    if (value) cleanObj[key] = value;
+  });
+
+  return cleanObj;
+}
+
+export default function buildUrl(location, values) {
+  const locationQuery = getLocationQuery(location);
+  let url = values._path || location.pathname;
+  const params = removeEmpty(Object.assign(locationQuery, values));
+  unset(params, '_path');
+
+  if (!isEmpty(params)) {
+    url += `?${queryString.stringify(params)}`;
+  }
+
+  return url;
+}

--- a/lib/SearchAndSort/buildUrl.js
+++ b/lib/SearchAndSort/buildUrl.js
@@ -11,6 +11,7 @@ function getLocationQuery(location) {
 
 function removeEmpty(obj) {
   const cleanObj = {};
+
   forOwn(obj, (value, key) => {
     if (value) cleanObj[key] = value;
   });
@@ -22,6 +23,7 @@ export default function buildUrl(location, values) {
   const locationQuery = getLocationQuery(location);
   let url = values._path || location.pathname;
   const params = removeEmpty(Object.assign(locationQuery, values));
+
   unset(params, '_path');
 
   if (!isEmpty(params)) {


### PR DESCRIPTION
This PR does something very similar to what was done in https://github.com/folio-org/stripes-smart-components/pull/394 but in SearchAndSort.

It should solve the issue reported in https://issues.folio.org/browse/STCOM-302

It also takes us one step closer to not rely on https://github.com/folio-org/stripes-core/blob/master/src/locationService.js#L53 for routing.  

@VictorSoroka1 would you mind giving it a try in your copy of SearchAndSort and see if you can reproduce the STCOM-302 issue?