### PR TITLE
Fix search when SearchAndSort is used via plugin. Refs STCOM-302

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -395,12 +395,21 @@ class SearchAndSort extends React.Component {
       location,
       history,
       nsParams,
+      browseOnly,
+      parentMutator: { query },
     } = this.props;
 
     const nsValues = mapNsKeys(values, nsParams);
     const url = buildUrl(location, nsValues);
 
-    history.push(url);
+    // react-router doesn't work well with our 'plugin' setup
+    // so unfortunately we still have to rely on query resource
+    // in those cases.
+    if (browseOnly) {
+      query.update(nsValues);
+    } else {
+      history.push(url);
+    }
   };
 
   onNeedMore = () => {


### PR DESCRIPTION
Unfortunately the previous PR #429 doesn't work well when SearchAndSort is used via plugin (for example when we perform users lookup from the checkout screen). This PR goes back to what we had previously (rely on query resource) for those case. 