### PR TITLE
STSMACOM-167: Passing <AppIcon> component instead of an object to <Pane>

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -33,7 +33,8 @@ import {
 import { withModule } from '@folio/stripes-core/src/components/Modules';
 import {
   withStripes,
-  IfPermission
+  IfPermission,
+  AppIcon,
 } from '@folio/stripes-core';
 
 import {
@@ -935,10 +936,6 @@ class SearchAndSort extends React.Component {
     const source = makeConnectedSource(this.props, stripes.logger);
     const moduleName = this.getModuleName();
 
-    const appIcon = {
-      app: moduleName,
-    };
-
     const count = source.totalCount();
     const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
 
@@ -968,7 +965,7 @@ class SearchAndSort extends React.Component {
           padContent={false}
           defaultWidth="fill"
           actionMenu={actionMenu}
-          appIcon={appIcon}
+          appIcon={<AppIcon app={moduleName} />}
           paneTitle={module.displayName}
           paneSub={paneSub}
           lastMenu={this.renderNewRecordBtn()}


### PR DESCRIPTION
This is a follow-up ticket for:
https://github.com/folio-org/stripes-components/pull/894

Once the above STCOM-473 is merged we can merge this change in.