### PR TITLE
extract strings for translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update ARIA-roles in SearchAndSort and EditableList. Fix for STCOM-365
 * Use columns' static labels, not their translated aliases, for sorting in `<SearchAndSort>`. Fixes STSMACOM-93.
 * Restore predictable `id` attributes to checkboxes created by `<CheckboxFilter>`. Refs UISE-97.
+* Extract static strings for translation. Fixes STSMACOM-169.
 
 ## [2.0.1](https://github.com/folio-org/stripes-smart-components/tree/v2.0.1) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.0.0...v2.0.1)

--- a/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
+++ b/lib/SearchAndSort/components/NoResultsMessage/NoResultsMessage.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { Button, Icon } from '@folio/stripes-components';
 import css from './NoResultsMessage.css';
 
@@ -13,24 +14,24 @@ const NoResultsMessage = ({ source, searchTerm, filterPaneIsVisible, toggleFilte
   const failure = source.failure();
 
   let icon = 'search';
-  let label = `No results found for "${searchTerm}". Please check your spelling and filters.`;
+  let label = <FormattedMessage id="stripes-smart-components.sas.noResults.default" values={{ searchTerm }} />;
 
   // No search term entered or filters selected
   if (!source.loaded()) {
     icon = filterPaneIsVisible ? 'arrow-left' : null;
-    label = notLoadedMessage || 'Choose a filter or enter search query to show results';
+    label = notLoadedMessage || <FormattedMessage id="stripes-smart-components.sas.noResults.noTerms" />;
   }
 
   // Filters selected and no search term but no results
   if (source.loaded() && !searchTerm) {
     icon = 'search';
-    label = 'No results found. Please check your filters.';
+    label = <FormattedMessage id="stripes-smart-components.sas.noResults.noResults" />;
   }
 
   // Loading results
   if (source.pending()) {
     icon = 'spinner-ellipsis';
-    label = 'Loading...';
+    label = <FormattedMessage id="stripes-smart-components.sas.noResults.loading" />;
   }
 
   // Request failure

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -51,6 +51,11 @@
   "pm.continue": "Continue",
   "pm.cancel": "Cancel",
 
+  "sas.noResults.default": "No results found for \"{searchTerm}\". Please check your spelling and filters.",
+  "sas.noResults.noTerms": "Choose a filter or enter a search query to show results.",
+  "sas.noResults.noResults": "No results found. Please check your filters.",
+  "sas.noResults.loading": "Loading…",
+
   "closeEntryDialog": "Close entry dialog",
   "editOrDeleteNote": "Edit or delete this note",
   "cancelEdit": "Cancel edit",


### PR DESCRIPTION
`SearchAndSort` contained some untranslated, hard-coded strings.

Fixes [STSMACOM-169](https://issues.folio.org/browse/STSMACOM-169)