### PR TITLE
correct PropType for notLoadedMessage

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -101,7 +101,7 @@ class SearchAndSort extends React.Component {
     }),
     newRecordInitialValues: PropTypes.object,
     newRecordPerms: PropTypes.string,
-    notLoadedMessage: PropTypes.string,
+    notLoadedMessage: PropTypes.element,
     nsParams: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,


### PR DESCRIPTION
The message is translatable and therefore will be provided as a
`<FormattedMessage>`, not a `string`.