### PR TITLE
Only clear resource query when SearchAndSort runs in a plugin mode. Refs ERM-72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Use columns' static labels, not their translated aliases, for sorting in `<SearchAndSort>`. Fixes STSMACOM-93.
 * Restore predictable `id` attributes to checkboxes created by `<CheckboxFilter>`. Refs UISE-97.
 * Extract static strings for translation. Fixes STSMACOM-169, STSMACOM-175.
+* Only clear resource query when SearchAndSort runs in a plugin mode. Refs ERM-72.
 
 ## [2.0.1](https://github.com/folio-org/stripes-smart-components/tree/v2.0.1) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.0.0...v2.0.1)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -260,10 +260,13 @@ class SearchAndSort extends React.Component {
   componentWillUnmount() {
     const {
       parentMutator: { query },
-      onComponentWillUnmount
+      onComponentWillUnmount,
+      packageInfo: { stripes: { type } },
     } = this.props;
 
-    query.replace(this.initialQuery);
+    if (type === 'plugin') {
+      query.replace(this.initialQuery);
+    }
     onComponentWillUnmount(this.props);
   }
 
@@ -277,9 +280,8 @@ class SearchAndSort extends React.Component {
   }
 
   get initialSearch() {
-    const { packageInfo } = this.props;
-
-    const initialPath = (get(packageInfo, ['stripes', 'home']) || get(packageInfo, ['stripes', 'route']));
+    const { packageInfo: { stripes } } = this.props;
+    const initialPath = get(stripes, 'home') || get(stripes, 'route') || '';
 
     return initialPath.indexOf('?') === -1
       ? initialPath


### PR DESCRIPTION
The previous implementation was replacing query resource with the initial query on `componentWillUnmount`. This is required when `SearchAndSort` is used via plugin in order to clean the filters when the plugin is reopened again. For example:

1. Open `find user plugin` and perform search
2. Choose user and close the plugin
3. Open `find user plugin` again 
4. The filters from `#1` should not be visible.

Unfortunately this also started causing issues in https://issues.folio.org/browse/ERM-72 when there are multiple instances of `SearchAndSort` being used in the same module.
 
This PR is an attempt to fix it.  