### PR TITLE
UIDATIMP-156: change ViewMetaData component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Restore predictable `id` attributes to checkboxes created by `<CheckboxFilter>`. Refs UISE-97.
 * Extract static strings for translation. Fixes STSMACOM-169, STSMACOM-175.
 * Only clear resource query when SearchAndSort runs in a plugin mode. Refs ERM-72.
+* Modify `ViewMetaData` component to render system user (UIDATIMP-156)
+* Update user data when props changed in `ViewMetaData` component. Fix for STSMACOM-177
 
 ## [2.0.1](https://github.com/folio-org/stripes-smart-components/tree/v2.0.1) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.0.0...v2.0.1)

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -1,15 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MetaSection } from '@folio/stripes-components';
-import {
-  withStripes,
-  stripesShape,
-} from '@folio/stripes-core';
 
 class ViewMetaData extends React.Component {
+  static manifest = Object.freeze({
+    createdBy: {
+      type: 'okapi',
+      records: 'users',
+      path: 'users?query=(id==!{metadata.createdByUserId})',
+      fetch: false,
+      accumulate: true,
+    },
+    updatedBy: {
+      type: 'okapi',
+      records: 'users',
+      path: 'users?query=(id==!{metadata.updatedByUserId})',
+      fetch: false,
+      accumulate: true,
+    },
+  });
+
   static propTypes = {
     metadata: PropTypes.object,
-    stripes: stripesShape.isRequired,
+    mutator: PropTypes.shape({
+      createdBy: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }).isRequired,
+      updatedBy: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+    systemId: PropTypes.string,
     systemUser: PropTypes.oneOfType([
       PropTypes.shape({
         id: PropTypes.string,
@@ -34,10 +57,10 @@ class ViewMetaData extends React.Component {
   };
 
   componentDidMount() {
-    this.fetchUsers();
+    this.getUsers();
   }
 
-  async fetchUsers() {
+  async getUsers() {
     const {
       metadata: {
         createdByUserId,
@@ -47,7 +70,7 @@ class ViewMetaData extends React.Component {
 
     // fetch once if users are identical
     if (createdByUserId === updatedByUserId) {
-      const user = await this.fetchUser(createdByUserId);
+      const user = await this.getCreatedByUser();
 
       this.setState({
         createdBy: user,
@@ -58,8 +81,8 @@ class ViewMetaData extends React.Component {
     }
 
     const [createdBy, updatedBy] = await Promise.all([
-      this.fetchUser(createdByUserId),
-      this.fetchUser(updatedByUserId),
+      this.getCreatedByUser(),
+      this.getUpdatedByUser(),
     ]);
 
     this.setState({
@@ -68,35 +91,44 @@ class ViewMetaData extends React.Component {
     });
   }
 
-  async fetchUser(userId) {
-    const systemId = '00000000-0000-0000-0000-000000000000';
+  async getCreatedByUser() {
+    const {
+      mutator,
+      metadata: { createdByUserId },
+      systemId,
+      systemUser,
+    } = this.props;
 
-    // no unnecessary fetch if user is System
-    if (userId === systemId) {
-      const { systemUser } = this.props;
-
+    if (systemId && createdByUserId === systemId) {
       return systemUser;
     }
 
+    try {
+      mutator.createdBy.reset();
+      const [user] = await mutator.createdBy.GET();
+
+      return user;
+    } catch (error) {
+      // return null if user was not fetched
+      return null;
+    }
+  }
+
+  async getUpdatedByUser() {
     const {
-      stripes: {
-        okapi: {
-          tenant,
-          token,
-          url: host,
-        }
-      }
+      mutator,
+      metadata: { updatedByUserId },
+      systemId,
+      systemUser,
     } = this.props;
 
+    if (systemId && updatedByUserId === systemId) {
+      return systemUser;
+    }
+
     try {
-      const response = await fetch(`${host}/users?query=(id==${userId})`, {
-        method: 'GET',
-        headers: {
-          'X-Okapi-Tenant': tenant,
-          'X-Okapi-Token': token,
-        },
-      });
-      const { users: [user] } = await response.json();
+      mutator.updatedBy.reset();
+      const [user] = await mutator.updatedBy.GET();
 
       return user;
     } catch (error) {
@@ -130,4 +162,4 @@ class ViewMetaData extends React.Component {
   }
 }
 
-export default withStripes(ViewMetaData);
+export default ViewMetaData;

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { MetaSection } from '@folio/stripes-components';
 
 class ViewMetaData extends React.Component {
@@ -42,13 +43,13 @@ class ViewMetaData extends React.Component {
           middleName: PropTypes.string,
         }),
       }),
-      PropTypes.string,
+      PropTypes.node,
     ]),
   };
 
   static defaultProps = {
     metadata: {},
-    systemUser: 'System',
+    systemUser: <FormattedMessage id="stripes-smart-components.system" />,
   };
 
   state = {

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -61,6 +61,10 @@ class ViewMetaData extends React.Component {
     this.getUsers();
   }
 
+  componentDidUpdate(prevProps) {
+    this.updateUsers(prevProps);
+  }
+
   async getUsers() {
     const {
       metadata: {
@@ -90,6 +94,19 @@ class ViewMetaData extends React.Component {
       createdBy,
       updatedBy,
     });
+  }
+
+  async updateUsers(prevProps) {
+    if (prevProps.metadata.createdByUserId !== this.props.metadata.createdByUserId) {
+      const createdBy = await this.getCreatedByUser();
+
+      this.setState({ createdBy });
+    }
+    if (prevProps.metadata.updatedByUserId !== this.props.metadata.updatedByUserId) {
+      const updatedBy = await this.getUpdatedByUser();
+
+      this.setState({ updatedBy });
+    }
   }
 
   async getCreatedByUser() {

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -1,52 +1,133 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MetaSection } from '@folio/stripes-components';
+import {
+  withStripes,
+  stripesShape,
+} from '@folio/stripes-core';
 
 class ViewMetaData extends React.Component {
-  static manifest = Object.freeze({
-    createdBy: {
-      type: 'okapi',
-      records: 'users',
-      path: 'users?query=(id==!{metadata.createdByUserId})',
-    },
-    updatedBy: {
-      type: 'okapi',
-      records: 'users',
-      path: 'users?query=(id==!{metadata.updatedByUserId})',
-    },
-  });
-
   static propTypes = {
     metadata: PropTypes.object,
-    resources: PropTypes.shape({
-      createdBy: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
+    stripes: stripesShape.isRequired,
+    systemUser: PropTypes.oneOfType([
+      PropTypes.shape({
+        id: PropTypes.string,
+        personal: PropTypes.shape({
+          firstName: PropTypes.string,
+          lastName: PropTypes.string,
+          middleName: PropTypes.string,
+        }),
       }),
-      updatedBy: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-    }),
+      PropTypes.string,
+    ]),
   };
 
   static defaultProps = {
     metadata: {},
+    systemUser: 'System',
+  };
+
+  state = {
+    createdBy: null,
+    updatedBy: null,
+  };
+
+  componentDidMount() {
+    this.fetchUsers();
+  }
+
+  async fetchUsers() {
+    const {
+      metadata: {
+        createdByUserId,
+        updatedByUserId,
+      },
+    } = this.props;
+
+    // fetch once if users are identical
+    if (createdByUserId === updatedByUserId) {
+      const user = await this.fetchUser(createdByUserId);
+
+      this.setState({
+        createdBy: user,
+        updatedBy: user,
+      });
+
+      return;
+    }
+
+    const [createdBy, updatedBy] = await Promise.all([
+      this.fetchUser(createdByUserId),
+      this.fetchUser(updatedByUserId),
+    ]);
+
+    this.setState({
+      createdBy,
+      updatedBy,
+    });
+  }
+
+  async fetchUser(userId) {
+    const systemId = '00000000-0000-0000-0000-000000000000';
+
+    // no unnecessary fetch if user is System
+    if (userId === systemId) {
+      const { systemUser } = this.props;
+
+      return systemUser;
+    }
+
+    const {
+      stripes: {
+        okapi: {
+          tenant,
+          token,
+          url: host,
+        }
+      }
+    } = this.props;
+
+    try {
+      const response = await fetch(`${host}/users?query=(id==${userId})`, {
+        method: 'GET',
+        headers: {
+          'X-Okapi-Tenant': tenant,
+          'X-Okapi-Token': token,
+        },
+      });
+      const { users: [user] } = await response.json();
+
+      return user;
+    } catch (error) {
+      // return null if user was not fetched
+      return null;
+    }
   }
 
   render() {
-    const { metadata, resources: { createdBy, updatedBy } } = this.props;
+    const {
+      metadata: {
+        createdDate,
+        updatedDate,
+      },
+    } = this.props;
+    const {
+      createdBy,
+      updatedBy,
+    } = this.state;
 
-    return (createdBy && createdBy.hasLoaded && updatedBy && updatedBy.hasLoaded) ?
+    return (
       <MetaSection
         id="instanceRecordMeta"
         contentId="instanceRecordMetaContent"
-        lastUpdatedDate={metadata.updatedDate}
-        createdDate={metadata.createdDate}
-        lastUpdatedBy={updatedBy.records[0]}
-        createdBy={createdBy.records[0]}
+        createdBy={createdBy}
+        lastUpdatedBy={updatedBy}
+        createdDate={createdDate}
+        lastUpdatedDate={updatedDate}
       />
-      :
-      <div />;
+    );
   }
 }
 
-export default ViewMetaData;
+export default withStripes(ViewMetaData);

--- a/lib/ViewMetaData/readme.md
+++ b/lib/ViewMetaData/readme.md
@@ -1,0 +1,34 @@
+# ViewMetaData component
+
+## Introduction
+
+`ViewMetaData` component fetches user data and renders `MetaSection` component with fetched data. Renders system user if user id is system id.
+
+## Properties
+
+| Property     | Type            | Description                                                                                            |
+|--------------|-----------------|--------------------------------------------------------------------------------------------------------|
+| `metadata`   | `object`        | Object with user ids and dates.                                                                        |
+| `systemId`   | `string`        | Property to determine if user is system. Optional property. If not passed system will not be rendered. |
+| `systemUser` | `object | node` | Optional property. By default renders "System".                                                        |
+
+## Usage
+
+The following code shows how use the component:
+```javascript
+import { ViewMetaData } from '@folio/stripes-smart-components';
+
+constructor(props) {
+  // connect component via stripes so it becomes possible to fetch user data
+  this.connectedViewMetaData = props.stripes.connect(ViewMetaData);
+}
+
+render() {
+  return (
+    <this.connectedViewMetaData
+      metadata={metadata}
+      systemId={systemId}
+    />
+  );
+}
+```

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -97,5 +97,6 @@
   "password.whiteSpace.invalid": "The password must not contain whitespaces.",
   "password.lastTenPasswords.invalid": "Previously used password. Please enter a new password.",
   "address.addAddress": "Add address",
-  "searchFieldLabel": "Search {moduleName}"
+  "searchFieldLabel": "Search {moduleName}",
+  "system": "System"
 }


### PR DESCRIPTION
## Purpose
Make sure `ViewMetaData` component source fields for updated and created lines renders correctly for the record created by System

## Approach
Check the passed id from metadata and if it contains only zeros then assume that this is System. In that case component will not make unnecessary http request and will render system user wich has a default value "System" or can be passed as a property.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/44395295/53878671-2b82e400-4015-11e9-81a4-a3d63d6a4b05.png)

After:
![image](https://user-images.githubusercontent.com/44395295/53878372-5fa9d500-4014-11e9-95e1-73c6f6fc537d.png)
