### PR TITLE
STCOM-488: Remove disappering of the reset button and animation. Reset button disables when search string is empty or at least one filter is choosen

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -191,6 +191,7 @@ class SearchAndSort extends React.Component {
     this.state = {
       selectedItem: this.initiallySelectedRecord,
       filterPaneIsVisible: true,
+      locallyChangedSearchTerm: '',
     };
 
     this.handleFilterChange = handleFilterChange.bind(this);
@@ -579,20 +580,22 @@ class SearchAndSort extends React.Component {
     return name.replace(/.*\//, '');
   }
 
-  renderResetButton = () => {
+  isResetButtonDisabled() {
     const initialFilters = this.initialFilters || '';
     const currentFilters = this.queryParam('filters') || '';
-    const hasFiltersChanged = currentFilters !== initialFilters;
-    const searchTerm = this.state.locallyChangedSearchTerm || '';
-    const searchIndex = this.queryParam('qindex') || '';
-    const hasSearchChanged = searchTerm !== '' || searchIndex !== '';
+    const noFiltersChoosen = currentFilters === initialFilters;
+    const searchTermFieldIsEmpty = this.state.locallyChangedSearchTerm.length === 0;
 
+    return noFiltersChoosen && searchTermFieldIsEmpty;
+  }
+
+  renderResetButton = () => {
     return (
       <div className={css.resetButtonWrap}>
         <ResetButton
           id="clickable-reset-all"
           label={<FormattedMessage id="stripes-smart-components.resetAll" />}
-          visible={hasFiltersChanged || hasSearchChanged}
+          disabled={this.isResetButtonDisabled()}
           onClick={this.onClearSearchAndFilters}
         />
       </div>

--- a/lib/SearchAndSort/components/ResetButton/ResetButton.css
+++ b/lib/SearchAndSort/components/ResetButton/ResetButton.css
@@ -4,32 +4,4 @@
 
 .resetButtonRoot .button {
   padding: 0 6px 0 3px;
-  background: none !important; /* Remove gray background color from disabled button */
-}
-
-/**
- * Transition styles
- */
-
-.transition {
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.transitionEntered,
-.transitionEntering {
-  max-height: 250px;
-  overflow: visible;
-  opacity: 1;
-  transition: max-height 1000ms linear 750ms, opacity 300ms ease-in 750ms;
-}
-
-.transitionExiting,
-.transitionExited {
-  transition: max-height 1000ms linear 750ms, opacity 500ms ease-out 1300ms;
-}
-
-.fasterExitTransition.transition {
-  transition: max-height 1000ms linear, opacity 600ms ease-out 500ms;
 }

--- a/lib/SearchAndSort/components/ResetButton/ResetButton.js
+++ b/lib/SearchAndSort/components/ResetButton/ResetButton.js
@@ -6,86 +6,42 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import camelCase from 'lodash/camelCase';
 import classnames from 'classnames'; /* eslint-disable-line import/no-extraneous-dependencies */
-import { Transition } from 'react-transition-group'; /* eslint-disable-line import/no-extraneous-dependencies */
 import { Button, Icon } from '@folio/stripes-components';
 import css from './ResetButton.css';
 
 export default class ResetButton extends Component {
   static propTypes = {
     className: PropTypes.string,
+    disabled: PropTypes.bool,
     id: PropTypes.string,
     label: PropTypes.node,
     onClick: PropTypes.func.isRequired,
-    visible: PropTypes.bool,
-  }
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      fasterExitTransition: false,
-    };
-
-    this.handleClick = this.handleClick.bind(this);
-    this.onExited = this.onExited.bind(this);
-  }
-
-  /**
-   * Handle button click
-   */
-  handleClick(e) {
-    // Activate a faster transition when the button is clicked
-    this.setState({
-      fasterExitTransition: true,
-    });
-
-    // Fire onClick callback passed as a required prop
-    this.props.onClick(e);
-  }
-
-  /**
-   * Disable/reset fast transition once the reset button is faded out
-   */
-  onExited() {
-    this.setState({
-      fasterExitTransition: false,
-    });
   }
 
   render() {
-    const { id, label, className, visible, ...rest } = this.props;
+    const {
+      id,
+      label,
+      className,
+      disabled,
+      onClick,
+      ...restProps
+    } = this.props;
     return (
       <div className={css.resetButtonRoot}>
-        <Transition in={visible} timeout={1000} onExited={this.onExited}>
-          {
-            state => (
-              <div
-                className={
-                  classnames(
-                    css.transition,
-                    css[camelCase(`transition ${state}`)],
-                    { [css.fasterExitTransition]: this.state.fasterExitTransition }
-                  )
-                }
-              >
-                <Button
-                  buttonStyle="none"
-                  id={id}
-                  {...rest}
-                  onClick={this.handleClick}
-                  disabled={!visible}
-                  buttonClass={classnames(css.button, className)}
-                >
-                  <Icon size="small" icon="times-circle-solid">
-                    {label}
-                  </Icon>
-                </Button>
-              </div>
-            )
-          }
-        </Transition>
+        <Button
+          buttonStyle="none"
+          id={id}
+          onClick={onClick}
+          disabled={disabled}
+          buttonClass={classnames(css.button, className)}
+          {...restProps}
+        >
+          <Icon size="small" icon="times-circle-solid">
+            {label}
+          </Icon>
+        </Button>
       </div>
     );
   }


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-488

## Purpose
Disable reset button when search field is empty or there is no selected filters

## Approach
- Add a condition to make the button disabled
- Delete animation wrapper with styles for the button

## Screenshots
![2019-04-02 17 17 53](https://user-images.githubusercontent.com/43621626/55409780-56f0e400-556b-11e9-81f3-99d5a7b543e3.gif)



