### PR TITLE
Add getHelperComponent to SearchAndSort

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,9 @@ export { default as Settings } from './lib/Settings';
 
 export { default as Tags } from './lib/Tags';
 export { default as withTags } from './lib/Tags/withTags';
+export { default as TagsForm } from './lib/Tags/TagsForm';
+export { default as TagsList } from './lib/Tags/TagsList';
+export { default as Tag } from './lib/Tags/Tag';
 
 export { default as UserName } from './lib/UserName';
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -81,6 +81,7 @@ class SearchAndSort extends React.Component {
       }),
     ),
     finishedResourceName: PropTypes.string,
+    getHelperComponent: PropTypes.func,
     getHelperResourcePath: PropTypes.func,
     history: PropTypes.shape({ // provided by withRouter
       push: PropTypes.func.isRequired,
@@ -177,6 +178,7 @@ class SearchAndSort extends React.Component {
     maxSortKeys: 2,
     onComponentWillUnmount: noop,
     filterChangeCallback: noop,
+    getHelperComponent: noop,
     massageNewRecord: noop,
   };
 
@@ -602,6 +604,11 @@ class SearchAndSort extends React.Component {
     );
   };
 
+  getHelperComponent(helperName) {
+    return this.props.getHelperComponent(helperName) ||
+      this.helperApps[helperName];
+  }
+
   renderHelperApp() {
     const {
       stripes,
@@ -611,7 +618,7 @@ class SearchAndSort extends React.Component {
 
     const moduleName = this.getModuleName();
     const helper = this.queryParam('helper');
-    const HelperAppComponent = this.helperApps[helper];
+    const HelperAppComponent = this.getHelperComponent(helper);
 
     if (!helper) {
       return null;

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -51,6 +51,7 @@ parentMutator | shape | The parent component's stripes-connect `mutator` propert
 nsParams | object or string | An object or string used to namespace search and sort parameters. More information can be found [here](https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md)
 notLoadedMessage | string | A message to show the user before a search has been submitted. Defaults to "Choose a filter or enter search query to show results".
 getHelperResourcePath | func | An optional function which can be used to return helper's resource path dynamically.
+getHelperComponent | func | An optional function which can be used to return connected helper component implementation.
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 
@@ -96,4 +97,4 @@ The five parameters are:
 
   ## Components for filtering
 
-  Please, pay attention, there is a set of components to be used for filtering inside SearchAndSort component. Each component represents a wrapper on existing form element component e.g. MultiSelect or renders a set of elements working like one filter e.g. CheckboxFilter. After change returns data in format: {name: <String>, values: <ArrayOfObjects>}, where name -- is a filter name and values -- filter values. 
+  Please, pay attention, there is a set of components to be used for filtering inside SearchAndSort component. Each component represents a wrapper on existing form element component e.g. MultiSelect or renders a set of elements working like one filter e.g. CheckboxFilter. After change returns data in format: {name: <String>, values: <ArrayOfObjects>}, where name -- is a filter name and values -- filter values.


### PR DESCRIPTION
The current helper components are hard coded in SearchAndSort. This worked fine for what we needed in the past but we are now running into a situation where a different implementation of the Tags component may be potentially used by the ERM team. 

This PR introduces a way to use a custom implementation of the given helper app without breaking our previous implementation (used in ui-users and ui-requests).