### PR TITLE
SASQ: Only clear the filter group passed in

### DIFF
--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -29,11 +29,13 @@ const defaultStateReducer = (state, nextState) => nextState;
 
 // output is ?filters=name.value,name.value,name.value
 const buildFilterString = (activeFilters) => {
-  const newFiltersString = Object.keys(activeFilters).map((filterName) => {
-    return activeFilters[filterName].map((filterValue) => {
-      return `${filterName}.${filterValue}`;
+  const newFiltersString = Object.keys(activeFilters)
+    .filter((filterName) => Array.isArray(activeFilters[filterName]) && activeFilters[filterName].length)
+    .map((filterName) => {
+      return activeFilters[filterName].map((filterValue) => {
+        return `${filterName}.${filterValue}`;
+      }).join(',');
     }).join(',');
-  }).join(',');
 
   return newFiltersString;
 };
@@ -155,14 +157,30 @@ class SearchAndSortQuery extends React.Component {
 
   onChangeSearchValue = (value, name) => {
     // this.setState({ [fieldName]: query }, () => this.props.searchChangeCallback(query));
-    this.internalSetState({ searchFields: { [name]: value } }, 'search.value');
+    this.internalSetState(
+      {
+        searchFields: {
+          ...this.state.searchFields,
+          [name]: value,
+        }
+      },
+      'search.value',
+    );
   };
 
   onChangeSearchEvent = (e) => {
     const query = e.target.value;
     const fieldName = e.target.name;
     // this.setState({ [fieldName]: query }, () => this.props.searchChangeCallback(query));
-    this.internalSetState({ searchFields: { [fieldName]: query } }, 'search.event');
+    this.internalSetState(
+      {
+        searchFields: {
+          ...this.state.searchFields,
+          [fieldName]: query,
+        }
+      },
+      'search.event',
+    );
   };
 
   internalSetState = (stateToSet, changeType, callbacks) => {
@@ -214,7 +232,7 @@ class SearchAndSortQuery extends React.Component {
     const { searchChangeCallback } = this.props;
     // this.log('action', 'cleared search');
     this.internalSetState(
-      {},
+      { searchFields: {} },
       'search.clear',
       [
         searchChangeCallback
@@ -382,7 +400,10 @@ class SearchAndSortQuery extends React.Component {
 
     this.internalSetState(
       {
-        filterFields: { [name]: [] }
+        filterFields: {
+          ...this.state.filterFields,
+          [name]: [],
+        }
       },
       'filter.clearGroup',
       [

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -286,7 +286,7 @@ class SearchAndSortQuery extends React.Component {
       {
         searchFields: initialSearchState || this.initialSearch,
         filterFields: initialFilterState || this.initialFilters,
-        sortFields: initialSortState || this.initialFilters,
+        sortFields: initialSortState || this.initialSort,
       },
       'reset.all',
       [


### PR DESCRIPTION
`filterHandlers.clearGroup()` currently clears _all_ the `filterFields` because `setState` doesn't expand nested properties all the way down. By expanding the current `filterFields` we retain other filter groups.

I extended this to `onChangeSearchEvent` and `onChangeSearchValue` because it looked like they might suffer from the same quirks.

Also, `clearGroup` sets the filter group to an empty array but `buildFiltersString` doesn't handle empty arrays properly and tries to set filters like `undefined.value`. Added a `.filter` to skip empty filter groups.
