### PR TITLE
provide element ids to assist with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `<SearchAndSortQuery>` component - a composable building block for search and sort patterns. [See Readme](https://github.com/folio-org/stripes-smart-components/lib/SearchAndSort/SearchAndSortQuery.md). Completes STSMACOM-179.
 * Increase location fetch limit. Refs STSMACOM-180.
+* Provide IDs for `<EntrySelector>`'s action menu buttons.
 
 ## [2.3.0](https://github.com/folio-org/stripes-smart-components/tree/v2.3.0) (2019-03-28)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.2.0...v2.3.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -114,6 +114,7 @@ class EntrySelector extends React.Component {
           <IfPermission perm={permissions.put}>
             <Button
               buttonStyle="dropdownItem"
+              id="dropdown-clickable-duplicate-item"
               onClick={() => {
                 onClone(item);
                 onToggle();
@@ -128,6 +129,7 @@ class EntrySelector extends React.Component {
         <IfPermission perm={permissions.post}>
           <Button
             buttonStyle="dropdownItem"
+            id="dropdown-clickable-edit-item"
             onClick={() => {
               onEdit(item);
               onToggle();
@@ -141,6 +143,7 @@ class EntrySelector extends React.Component {
         <IfPermission perm={permissions.delete}>
           <Button
             buttonStyle="dropdownItem"
+            id="dropdown-clickable-delete-item"
             onClick={() => {
               onToggle();
               this.changeDeleteState(true);


### PR DESCRIPTION
It's much easier to write integration tests when page elements have
unique attributes.

Refs [UICIRC-237](https://issues.folio.org/browse/UICIRC-237)