### PR TITLE
STRIPES-581 Set sideEffects to false to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-smart-components
 
+## 2.4.1 (IN-PROGRESS)
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
+
 ## [2.4.0](https://github.com/folio-org/stripes-smart-components/tree/v2.4.0) (2019-04-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.3.0...v2.4.0)
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.4.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Fulfills STRIPES-564 and STRIPES-581. 
- Tested with sample "Hello World" UI app.

Before:

![Screen Shot 2019-04-23 at 10 06 35 AM](https://user-images.githubusercontent.com/28395235/56590070-64225100-65b4-11e9-83e3-042f2d2b5cba.png)

After:

![Screen Shot 2019-04-23 at 10 33 10 AM](https://user-images.githubusercontent.com/28395235/56590076-684e6e80-65b4-11e9-8c43-d0ebc5b63591.png)
