### PR TITLE
case insensitive sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 2.6.0 (IN PROGRESS)
+
+* Case-insensitive location sort. Fixes STSMACOM-192.
+
 ## [2.5.0](https://github.com/folio-org/stripes-smart-components/tree/v2.5.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.4.0...v2.5.0)
 

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -56,9 +56,13 @@ class LocationForm extends React.Component {
     const institutionOpts = institutions.map(inst => ({ label: inst.name, value: inst.id }));
     const campusOpts = campuses.map(campus => ({ label: campus.name, value: campus.id }));
     const libraryOpts = libraries.map(library => ({ label: library.name, value: library.id }));
-    const locationOpts = sortBy(locations, ['name', 'code']).map((loc) => {
-      return { label: `${loc.name} - (${loc.code})`, value: loc.id };
-    });
+    const locationOpts = sortBy(
+      locations,
+      [loc => loc.name.toLowerCase(), loc => loc.code.toLowerCase()]
+    )
+      .map((loc) => {
+        return { label: `${loc.name} - (${loc.code})`, value: loc.id };
+      });
 
     return (
       <form id="location-form">


### PR DESCRIPTION
lodash's `sortBy` is case sensitive, so we gotta work around that.

Fixes [STSMACOM-192](https://issues.folio.org/browse/STSMACOM-192)