### PR TITLE
Remove .isRequired from 'records' propType

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -79,7 +79,7 @@ class ControlledVocab extends React.Component {
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
     readOnlyFields: PropTypes.arrayOf(PropTypes.string),
-    records: PropTypes.string.isRequired,
+    records: PropTypes.string,
     resources: PropTypes.shape({
       updaters: PropTypes.object,
       values: PropTypes.shape({


### PR DESCRIPTION
The actual code already allows for the situation where no value is
passed in for `records`, i.e. the top level of the JSON returned from
the WSAPI is an array of records rather than an object containing a
member whose value is this array. Since this works correctly, a valid
invocation should not yield a console error.