### PR TITLE
accept props.onCloseNewRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.6.0 (IN PROGRESS)
 
 * Case-insensitive location sort. Fixes STSMACOM-192.
+* Accept `props.onCloseNewRecord` so clients can do what they choose. Refs UIREQ-244.
 
 ## [2.5.0](https://github.com/folio-org/stripes-smart-components/tree/v2.5.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.4.0...v2.5.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -517,12 +517,16 @@ class SearchAndSort extends React.Component {
   };
 
   closeNewRecord = (e) => {
-    if (e) {
-      e.preventDefault();
-    }
-
     this.log('action', 'clicked "close new record"');
-    this.transitionToParams({ layer: null });
+    if (this.props.onCloseNewRecord) {
+      this.props.onCloseNewRecord(e);
+    } else {
+      if (e) {
+        e.preventDefault();
+      }
+
+      this.transitionToParams({ layer: null });
+    }
   };
 
   collapseDetails = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": ["*.css"],


### PR DESCRIPTION
A client may want to override the default behavior when closing a new
record. Now, they can.

Refs [UIREQ-244](https://issues.folio.org/browse/UIREQ-244)