### PR TITLE
Pass clientGeneratePk prop into manifest option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Case-insensitive location sort. Fixes STSMACOM-192.
 * Accept `props.onCloseNewRecord` so clients can do what they choose. Refs UIREQ-244.
+* Pass `clientGeneratePk` prop into manifest option, supporting server-side modules that supply IDs of new records.
 
 ## [2.5.0](https://github.com/folio-org/stripes-smart-components/tree/v2.5.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.4.0...v2.5.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -17,6 +17,7 @@ class ControlledVocab extends React.Component {
       path: '!{baseUrl}',
       records: '!{records}',
       throwErrors: false,
+      clientGeneratePk: '!{clientGeneratePk}',
       PUT: {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
@@ -50,6 +51,10 @@ class ControlledVocab extends React.Component {
     actionProps: PropTypes.object,
     actionSuppressor: PropTypes.object,
     baseUrl: PropTypes.string.isRequired,
+    clientGeneratePk: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.string
+    ]),
     columnMapping: PropTypes.object,
     formatter: PropTypes.object,
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
@@ -121,6 +126,7 @@ class ControlledVocab extends React.Component {
     preUpdateHook: (row) => row,
     sortby: 'name',
     validate: () => ({}),
+    clientGeneratePk: true,
   };
 
   constructor(props) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": ["*.css"],
@@ -104,7 +104,7 @@
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
     "@folio/stripes-components": "~5.2.0",
-    "@folio/stripes-connect": "~5.1.0",
+    "@folio/stripes-connect": "~5.1.2",
     "@folio/stripes-core": "~3.4.0",
     "@folio/stripes-form": "~2.4.0",
     "@folio/stripes-logger": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": ["*.css"],


### PR DESCRIPTION
When this is turned on, a caller can pass in a falsy value such as an empty string to modify the behaviour of stripes-connect, allowing the back-end module to provide the ID of newly created records. This allows `<ControlledVocab>` to work correctly with back-end modules such as mod-rs and mod-directory created using Knowledge Integration's toolkit.

The `clientGeneratePk` prop explicitly defaults to true, matching the previous implicit default.

Requires stripes-connect ^5.1.2.