### PR TITLE
Support optional `limitParam` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Case-insensitive location sort. Fixes STSMACOM-192.
 * Accept `props.onCloseNewRecord` so clients can do what they choose. Refs UIREQ-244.
 * Pass `clientGeneratePk` prop into manifest option, supporting server-side modules that supply IDs of new records.
+* `<ControlledVocab>` accepts optional `limitParam` prop, for when that parameter is not called `limit`.
 
 ## [2.5.0](https://github.com/folio-org/stripes-smart-components/tree/v2.5.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.4.0...v2.5.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -25,7 +25,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&limit=500'
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=500'
       }
     },
     activeRecord: {},
@@ -61,6 +61,7 @@ class ControlledVocab extends React.Component {
     itemTemplate: PropTypes.object,
     label: PropTypes.node.isRequired,
     labelSingular: PropTypes.node.isRequired,
+    limitParam: PropTypes.string,
     listSuppressor: PropTypes.func,
     listSuppressorText: PropTypes.node,
     mutator: PropTypes.shape({
@@ -127,6 +128,14 @@ class ControlledVocab extends React.Component {
     sortby: 'name',
     validate: () => ({}),
     clientGeneratePk: true,
+    // We would like to use
+    //  limitParam: 'limit'
+    // here, but that doesn't work as defaultProps are not visible to
+    // react-redux. As a result, they don't show up for substitution
+    // in a stripes-connect manifest, which is why we hardwire the
+    // default value "limit" right into the expression
+    //  !{limitParam:-limit}
+    // in the manifest above.
   };
 
   constructor(props) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": ["*.css"],


### PR DESCRIPTION
This parameter is called `limit` for RMB-based modules, but `perPage` for K-Int's ReShare modules. So when running against the lattr, we need to invoke `<ControlledVocab>` with `limitParam="perPage"`.

(The default behaviour is of course unchanged.)
