### PR TITLE
lift key attribute up in markup

### DIFF
--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -315,9 +315,8 @@ class EntrySelector extends React.Component {
 
     const rows = this.filteredRows(contentData);
     const links = _.sortBy(rows, [record => record[nameKey].toLowerCase()]).map(item => (
-      <div data-test-nav-list-item>
+      <div data-test-nav-list-item key={item.id}>
         <NavListItem
-          key={item.id}
           to={this.linkPath(item.id)}
           onClick={() => this.props.onClick(item)}
         >


### PR DESCRIPTION
PR #494 introduced some new markup required for unit-tests that wrapped
the child element of a list in a `div`. This means we need to move the
`key` attribute up from the child to the wrapper.