### PR TITLE
pass data-* props directly, not in a wrapper

### DIFF
--- a/lib/EntryManager/EntryManager.js
+++ b/lib/EntryManager/EntryManager.js
@@ -19,9 +19,7 @@ class EntryManager extends React.Component {
   render() {
     const props = omit(this.props, 'mutator');
     return (
-      <div data-test-entry-manager>
-        <this.cEntryWrapper {...props} />
-      </div>
+      <this.cEntryWrapper {...props} />
     );
   }
 }

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -345,7 +345,7 @@ class EntrySelector extends React.Component {
     );
 
     return (
-      <Paneset defaultWidth={paneSetWidth}>
+      <Paneset defaultWidth={paneSetWidth} data-test-entry-manager>
         <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle}>
           {this.props.rowFilter}
           <NavList>

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "~5.2.0",
+    "@folio/stripes-components": "~5.3.0",
     "@folio/stripes-connect": "~5.1.2",
     "@folio/stripes-core": "~3.4.0",
     "@folio/stripes-form": "~2.4.0",


### PR DESCRIPTION
Wrapping the `<EntryManager>` element in a `<div>` in order to provide a
`data-test-*` attribute caused CSS trouble in `<Paneset>`s. Now that
`<Paneset>` spreads the `data-*` props it receives to its top-level
element, we can pass that value directly on `<EntrySelector>` without
needing to wrap it.

Refs [STCOM-527](https://issues.folio.org/browse/STCOM-527), [UIORG-166](https://issues.folio.org/browse/UIORG-166)