### PR TITLE
STSMACOM-200: make NavigationModal possible to use inside forms

### DIFF
--- a/lib/Notes/NavigationModal/navigation-modal.js
+++ b/lib/Notes/NavigationModal/navigation-modal.js
@@ -50,6 +50,7 @@ class NavigationModal extends Component {
 
   submit = (event) => {
     event.preventDefault();
+    event.stopPropagation();
     this.onCancel();
   };
 

--- a/lib/Notes/NoteForm/NoteForm.js
+++ b/lib/Notes/NoteForm/NoteForm.js
@@ -220,55 +220,57 @@ export default class NoteForm extends Component {
         validate={this.validateFormFields}
       >
         {({ handleSubmit, pristine }) => (
-          <form onSubmit={handleSubmit}>
-            <Paneset>
-              <Pane
-                paneTitle={paneTitle}
-                appIcon={paneTitleAppIcon}
-                actionMenu={this.getActionMenu}
-                firstMenu={this.renderFirstMenu()}
-                lastMenu={this.renderLastMenu(pristine)}
-                padContent={false}
-                defaultWidth="100%"
-              >
-                <Paneset>
-                  <Pane
-                    lastMenu={this.renderExpandAllButton()}
-                    defaultWidth="50%"
-                    className={styles['note-form-content']}
-                  >
-                    <Accordion
-                      label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
-                      id="noteForm"
-                      open={noteForm}
-                      separator={false}
-                      onToggle={this.handleSectionToggle}
+          <Fragment>
+            <form onSubmit={handleSubmit}>
+              <Paneset>
+                <Pane
+                  paneTitle={paneTitle}
+                  appIcon={paneTitleAppIcon}
+                  actionMenu={this.getActionMenu}
+                  firstMenu={this.renderFirstMenu()}
+                  lastMenu={this.renderLastMenu(pristine)}
+                  padContent={false}
+                  defaultWidth="100%"
+                >
+                  <Paneset>
+                    <Pane
+                      lastMenu={this.renderExpandAllButton()}
+                      defaultWidth="50%"
+                      className={styles['note-form-content']}
                     >
-                      {isEditForm && this.renderNoteMetadata()}
-                      <NoteFields
-                        detailsEditorRef={this.detailsEditorRef}
-                        noteTypes={noteTypes}
-                      />
-                    </Accordion>
-                    <Accordion
-                      label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
-                      id="assigned"
-                      open={assigned}
-                      onToggle={this.handleSectionToggle}
-                    >
-                      <AssignmentsList
-                        referredEntityData={referredEntityData}
-                        linkedEntitiesTypes={linkedEntitiesTypes}
-                        entityTypeTranslationKeyMap={entityTypeTranslationKeyMap}
-                        entityTypePluralizedTranslationKeyMap={entityTypePluralizedTranslationKeyMap}
-                      />
-                    </Accordion>
-                  </Pane>
-                </Paneset>
-              </Pane>
-            </Paneset>
+                      <Accordion
+                        label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
+                        id="noteForm"
+                        open={noteForm}
+                        separator={false}
+                        onToggle={this.handleSectionToggle}
+                      >
+                        {isEditForm && this.renderNoteMetadata()}
+                        <NoteFields
+                          detailsEditorRef={this.detailsEditorRef}
+                          noteTypes={noteTypes}
+                        />
+                      </Accordion>
+                      <Accordion
+                        label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
+                        id="assigned"
+                        open={assigned}
+                        onToggle={this.handleSectionToggle}
+                      >
+                        <AssignmentsList
+                          referredEntityData={referredEntityData}
+                          linkedEntitiesTypes={linkedEntitiesTypes}
+                          entityTypeTranslationKeyMap={entityTypeTranslationKeyMap}
+                          entityTypePluralizedTranslationKeyMap={entityTypePluralizedTranslationKeyMap}
+                        />
+                      </Accordion>
+                    </Pane>
+                  </Paneset>
+                </Pane>
+              </Paneset>
+            </form>
             <NavigationModal when={!pristine && !submitSucceeded} />
-          </form>
+          </Fragment>
         )}
       </Form>
     );


### PR DESCRIPTION
`NavigationModal` component has a button with `type=submit`. This makes it impossible to use the component inside forms. This small PR add `e.stopPropagation()` to the `NavigationModal` submit handler so that the modal can be used inside forms without risks to break things.
I also placed `NavigationModal` near the `form` element, because in this particular case there are no reasons to keep it inside `form`.