### PR TITLE
Allow for passing queryTemplate as a function to makeQueryFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * add `renderNavigation` prop to `<SearchAndSort>`. Refs UIOR-27.
 * better test instrumentation for `<ControlledVocab>`. Refs UIORG-163.
 * add `parseRow` prop to `<ControlledVocab>` to store complex values. Refs UINV-6.
+* Allow for passing queryTemplate as a function to makeQueryFunction. Refs UIU-1068.
 
 ## [2.6.3](https://github.com/folio-org/stripes-smart-components/tree/v2.6.3) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.6.2...v2.6.3)

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -10,7 +10,7 @@ import { removeNsKeys } from './nsQueryFunctions';
 //     * An object containing the component's resources' data (as accessed by %{name}).
 //
 // @findAll string: CQL query to retrieve all records when there is a sort-clause but no CQL query
-// @queryTemplate string: CQL query to interpolate or function: which will return CQL as a string
+// @queryTemplate string|function: CQL query to interpolate or function which will return CQL as a string
 // @sortMap object: map from sort-keys to the CQL fields they match
 // @filterConfig array: list of filter objects with keys label, name, cql, values
 // @failOnCondition int:

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -10,7 +10,7 @@ import { removeNsKeys } from './nsQueryFunctions';
 //     * An object containing the component's resources' data (as accessed by %{name}).
 //
 // @findAll string: CQL query to retrieve all records when there is a sort-clause but no CQL query
-// @queryTemplate string: CQL query to interpolate
+// @queryTemplate string: CQL query to interpolate or function: which will return CQL as a string
 // @sortMap object: map from sort-keys to the CQL fields they match
 // @filterConfig array: list of filter objects with keys label, name, cql, values
 // @failOnCondition int:

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -35,13 +35,6 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       return null;
     }
 
-    // This check should remain '$QUERY' until all uses of the $QUERY syntax have been removed from stripes modules
-    if (queryTemplate.includes('$QUERY')) {
-      // eslint-disable-next-line
-      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution');
-      queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}'); // eslint-disable-line no-param-reassign
-    }
-
     let cql;
     if (query && qindex) {
       const t = qindex.split('/', 2);
@@ -51,7 +44,10 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
         cql = `${t[0]} =/${t[1]} "${query}*"`;
       }
     } else if (query) {
-      cql = compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: resourceQuery });
+      cql = (typeof queryTemplate === 'function')
+        ? queryTemplate(nsQueryParams, pathComponents, { query: resourceQuery })
+        : compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: resourceQuery });
+
       if (cql === null) {
         // Some part of the template requires something that we don't have.
         return null;


### PR DESCRIPTION
This PR allows for passing `queryTemplate` as a function to `makeQueryFunction`. This change is required to support work described in https://issues.folio.org/browse/UIU-1068 and https://github.com/folio-org/ui-users/pull/837