### PR TITLE
UIINV-6 support row parse

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -82,6 +82,7 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
+    parseRow: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
     readOnlyFields: PropTypes.arrayOf(PropTypes.string),
@@ -221,6 +222,14 @@ class ControlledVocab extends React.Component {
     return rows.filter(row => this.props.rowFilterFunction(row));
   }
 
+  parseRows(rows) {
+    if (!this.props.parseRow) {
+      return rows;
+    }
+
+    return rows.map(this.props.parseRow);
+  }
+
   hideConfirmDialog() {
     this.setState({
       showConfirmDialog: false,
@@ -357,7 +366,9 @@ class ControlledVocab extends React.Component {
       />
     );
 
-    const rows = this.filteredRows(this.props.resources.values.records || []);
+    const rows = this.parseRows(
+      this.filteredRows(this.props.resources.values.records || [])
+    );
 
     const hideList = this.props.listSuppressor && this.props.listSuppressor();
 


### PR DESCRIPTION
**ticket**: https://issues.folio.org/browse/UINV-6

**purpose**: tenant addresses will work with `mod-configs` and this module supports only `value` field. In this case value will be a JSON of `name` and  `address` so we need a way to parse value to work with this component in right way

**approach**: new property to parse row

related to https://github.com/folio-org/ui-tenant-settings/pull/17