### PR TITLE
Add id and data-test attributes to ControlledVocab. Part of UIORG-163

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { isEqual } from 'lodash';
+import { isEqual, uniqueId, pickBy } from 'lodash';
 
 import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -58,6 +58,7 @@ class ControlledVocab extends React.Component {
     columnMapping: PropTypes.object,
     formatter: PropTypes.object,
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
+    id: PropTypes.string,
     itemTemplate: PropTypes.object,
     label: PropTypes.node.isRequired,
     labelSingular: PropTypes.node.isRequired,
@@ -155,6 +156,7 @@ class ControlledVocab extends React.Component {
     this.showConfirmDialog = this.showConfirmDialog.bind(this);
     this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
     this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
+    this.id = props.id || uniqueId('controlled-vocab-');
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -360,9 +362,10 @@ class ControlledVocab extends React.Component {
     const rows = this.filteredRows(this.props.resources.values.records || []);
 
     const hideList = this.props.listSuppressor && this.props.listSuppressor();
+    const dataProps = pickBy(this.props, (_, key) => /^data-test/.test(key));
 
     return (
-      <Paneset>
+      <Paneset id={this.id} {...dataProps}>
         <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
           {this.props.rowFilter}
           { hideList && this.props.listSuppressorText && <div>{this.props.listSuppressorText}</div> }


### PR DESCRIPTION
I noticed that we often pass `id` to `ControlledVocab` for example: 

https://github.com/folio-org/ui-tenant-settings/blob/master/src/settings/LocationLibraries.js#L185

but that id is never present. I needed it to finalize testing in:

https://issues.folio.org/browse/UIORG-163
