### PR TITLE
UIOR-27 navigation for SearchAndSort

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -158,6 +158,7 @@ class SearchAndSort extends React.Component {
     path: PropTypes.string,
     queryFunction: PropTypes.func,
     renderFilters: PropTypes.func,
+    renderNavigation: PropTypes.func,
     resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
     resultsFormatter: PropTypes.shape({}),
@@ -181,6 +182,7 @@ class SearchAndSort extends React.Component {
     filterChangeCallback: noop,
     getHelperComponent: noop,
     massageNewRecord: noop,
+    renderNavigation: noop,
   };
 
   constructor(props) {
@@ -822,6 +824,7 @@ class SearchAndSort extends React.Component {
       objectName,
       filterConfig,
       renderFilters,
+      renderNavigation,
       disableFilters,
       onChangeIndex,
       searchableIndexes,
@@ -837,6 +840,7 @@ class SearchAndSort extends React.Component {
 
     return (
       <form onSubmit={this.onSubmitSearch}>
+        {renderNavigation()}
         <FormattedMessage
           id="stripes-smart-components.searchFieldLabel"
           values={{ moduleName: module.displayName }}

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -30,6 +30,7 @@ disableFilters | object whose keys are filter-group names | In the display of fi
 filterChangeCallback | function | If provided, this function is invoked when the user changes a filter. It is passed the new set of filters, in the form of an object whose keys are the `group`.`name` specifiers of each selected filter.
 onFilterChange | function | Callback to be called after filter value is changed. Gets filter name and filter values in a form of an object `{ name: <String>, values: <Array> }`.
 renderFilters | function | Renders a set of filters. Gets onChange callback to be called after filter value change.
+renderNavigation | function | Renders a component at the top of the first section (filters) to be used as navigation. Default `noop`.
 initialResultCount | number | The number of records to fetch when a new search is executed (including the null search that is run when the module starts).
 resultCountIncrement | number | The amount by which to increase the number of records when scrolling close to the bottom of the loaded list.
 viewRecordComponent | component | A React component that displays a record of the appropriate type in full view. This is invoked with a specific set of properties that ought also to be documented, but for now, see the example of [`<ViewUser>` in ui-users](https://github.com/folio-org/ui-users/blob/master/ViewUser.js).


### PR DESCRIPTION
https://issues.folio.org/browse/UIOR-27

purpose: we need a place to put navigation buttons in the first column
![navigation](https://user-images.githubusercontent.com/12440608/58174602-f0549080-7ca6-11e9-88aa-476572d7351f.png)

approach: new render prop

related https://github.com/folio-org/ui-orders/pull/405