### PR TITLE
Fix bug with unclosing note form dropdown

### DIFF
--- a/lib/Notes/NoteForm/NoteForm.js
+++ b/lib/Notes/NoteForm/NoteForm.js
@@ -143,14 +143,17 @@ export default class NoteForm extends Component {
     );
   }
 
-  getActionMenu = () => {
+  getActionMenu = ({ onToggle }) => {
     const { navigateBack } = this.props;
 
     return this.isEditForm() && (
       <Fragment>
         <Button
           buttonStyle="dropdownItem"
-          onClick={navigateBack}
+          onClick={() => {
+            navigateBack();
+            onToggle();
+          }}
           data-test-leave-note-form
         >
           <Icon icon="times-circle">


### PR DESCRIPTION
This small PR adds forgotten `onToggle` function call to dropdown item click handler