### PR TITLE
STSMACOM-211: fix NoteForm crashing when no note types exist

### DIFF
--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -16,6 +16,7 @@ import {
   Icon,
   IconButton,
   Button,
+  Callout,
 } from '@folio/stripes-components';
 
 import NoteFields from './components/NoteFields';
@@ -66,7 +67,22 @@ export default class NoteForm extends Component {
     }
   };
 
+  componentDidMount() {
+    if (!this.areNoteTypesPresent()) {
+      this.displayMissingNoteTypesNotification();
+    }
+  }
+
   detailsEditorRef = React.createRef();
+  calloutRef = React.createRef();
+
+  displayMissingNoteTypesNotification() {
+    this.calloutRef.current.sendCallout({
+      type: 'error',
+      message: <FormattedMessage id="stripes-smart-components.notes.noteTypesMissing" />,
+      timeout: 0,
+    });
+  }
 
   handleSectionToggle = ({ id }) => {
     this.setState(prevState => ({
@@ -118,13 +134,14 @@ export default class NoteForm extends Component {
 
   renderLastMenu = (formIsPristine) => {
     const { submitIsPending } = this.props;
+    const noteTypesExist = this.areNoteTypesPresent();
 
     return (
       <Button
         type="submit"
         buttonStyle="primary"
         marginBottom0
-        disabled={formIsPristine || submitIsPending}
+        disabled={formIsPristine || submitIsPending || !noteTypesExist}
         data-test-save-note
       >
         <FormattedMessage id="stripes-smart-components.notes.saveAndClose" />
@@ -169,6 +186,10 @@ export default class NoteForm extends Component {
 
   isEditForm = () => {
     return !!this.props.noteData;
+  }
+
+  areNoteTypesPresent() {
+    return this.props.noteTypes.length;
   }
 
   validateFormFields = (values) => {
@@ -235,7 +256,7 @@ export default class NoteForm extends Component {
     const paneTitleAppIcon = <AppIcon app={paneHeaderAppIcon} size="small" />;
     const noteTypeInitialValue = isEditForm
       ? noteData.type
-      : noteTypes[0].value;
+      : get(noteTypes, '[0].value');
 
     const initialValues = {
       ...noteData,
@@ -276,8 +297,8 @@ export default class NoteForm extends Component {
                       >
                         {isEditForm && this.renderNoteMetadata()}
                         <NoteFields
-                          detailsEditorRef={this.detailsEditorRef}
                           noteTypes={noteTypes}
+                          detailsEditorRef={this.detailsEditorRef}
                         />
                       </Accordion>
                       <Accordion
@@ -298,6 +319,7 @@ export default class NoteForm extends Component {
               </Paneset>
             </form>
             <NavigationModal when={!pristine && !submitSucceeded} />
+            <Callout ref={this.calloutRef} />
           </Fragment>
         )}
       </Form>

--- a/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.css
+++ b/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.css
@@ -1,0 +1,3 @@
+.disabled-field {
+  background-color: #ebebe4;
+}

--- a/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
+++ b/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
@@ -13,17 +13,27 @@ import {
 
 import { noteTypesShape } from '../../noteShapes';
 
+import styles from './NoteFields.css';
+
 export default class NoteFields extends Component {
   static propTypes = {
     detailsEditorRef: PropTypes.object,
     noteTypes: noteTypesShape.isRequired,
   };
 
+  getEditorClassName() {
+    return this.props.noteTypes.length
+      ? ''
+      : styles['disabled-field'];
+  }
+
   render() {
     const {
       noteTypes,
       detailsEditorRef,
     } = this.props;
+
+    const fieldsAreDisabled = !noteTypes.length;
 
     return (
       <Fragment>
@@ -36,6 +46,7 @@ export default class NoteFields extends Component {
               dataOptions={noteTypes}
               label={<FormattedMessage id="stripes-smart-components.noteType" />}
               data-test-note-types-field
+              disabled={fieldsAreDisabled}
             />
           </Col>
         </Row>
@@ -47,6 +58,7 @@ export default class NoteFields extends Component {
               component={TextField}
               label={<FormattedMessage id="stripes-smart-components.noteTitle" />}
               data-test-note-title-field
+              disabled={fieldsAreDisabled}
             />
           </Col>
         </Row>
@@ -59,6 +71,8 @@ export default class NoteFields extends Component {
               component={Editor}
               label={<FormattedMessage id="stripes-smart-components.details" />}
               data-test-note-content-field
+              readOnly={fieldsAreDisabled}
+              editorClassName={this.getEditorClassName()}
             />
           </Col>
         </Row>

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -146,5 +146,6 @@
   "notes.deleteNote": "Delete note",
   "notes.unassignNote": "Unassign note",
   "notes.unassign.confirm.message": "The note {title} will be unassigned.",
-  "notes.delete.confirm.message": "The note {title} will be permanently deleted from:"
+  "notes.delete.confirm.message": "The note {title} will be permanently deleted from:",
+  "notes.noteTypesMissing": "Unable to save note. A note type must be selected"
 }


### PR DESCRIPTION
On the note create page, when there are no note types created, a toast notification telling the user to create a note type will be displayed. Also the form fields and submit button will be disabled.