### PR TITLE
UIOR-292 disable sorting for columns in SearchAndSort

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -9,6 +9,7 @@ import { withRouter } from 'react-router';
 import { FormattedMessage } from 'react-intl';
 import queryString from 'query-string';
 import {
+  includes,
   debounce,
   get,
   upperFirst,
@@ -166,6 +167,7 @@ class SearchAndSort extends React.Component {
     searchableIndexesPlaceholder: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
+    sortableColumns: PropTypes.arrayOf(PropTypes.string),
     stripes: PropTypes.shape({
       connect: PropTypes.func,
       hasPerm: PropTypes.func.isRequired
@@ -451,9 +453,12 @@ class SearchAndSort extends React.Component {
   };
 
   onSort = (e, meta) => {
-    const { maxSortKeys } = this.props;
+    const { maxSortKeys, sortableColumns } = this.props;
 
     const newOrder = meta.name;
+
+    if (sortableColumns && !includes(sortableColumns, newOrder)) return;
+
     const oldOrder = this.queryParam('sort');
     const orders = oldOrder ? oldOrder.split(',') : [];
     const mainSort = orders[0];

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -24,6 +24,7 @@ searchableIndexesPlaceholder | string | If this is provided and is a string, the
 selectedIndex | string | When `searchableIndexes` is provided, this must also be supplied, its value matching one of those in the provided array.
 onChangeIndex | function | If provided, this function is invoked, and passed an event structure, when the user changes which index is selected.
 maxSortKeys | number | If provided, specifies that maximum number of sort-keys that should be remembered for "stable sorting". Defaults to 2 if not specified.
+sortableColumns | array | If provided, specifies the columns that can be sorted.
 filterConfig | array of structures | Configuration for the module's filters, as documented [in the `<FilterGroups>` readme](https://github.com/folio-org/stripes-components/tree/master/lib/FilterGroups#filter-configuration).
 initialFilters | string | The initial state of the filters when the application started up, used when resetting to the initial state. Takes the same form as the `filters` part of the URL: a comma-separated list of `group`.`name` filters that are selected.
 disableFilters | object whose keys are filter-group names | In the display of filter groups, those that are named in this object are greyed out and cannot be selected.


### PR DESCRIPTION
https://issues.folio.org/browse/UIOR-292

purpose: have an option to disable sorting for columns

approach: new property that defines list of columns that can be sorted