### PR TITLE
UIDATIMP-10: add TagsAccordion component

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ export { default as Settings } from './lib/Settings';
 export { default as Tags } from './lib/Tags';
 export { default as withTags } from './lib/Tags/withTags';
 export { default as TagsForm } from './lib/Tags/TagsForm';
+export { default as TagsAccordion } from './lib/Tags/TagsAccordion';
 
 export { default as UserName } from './lib/UserName';
 

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -1,12 +1,14 @@
-import { get, uniq, sortBy, difference } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { get, uniq, sortBy, difference, noop, isFunction } from 'lodash';
+
 import { Callout, Pane } from '@folio/stripes-components';
+import { stripesConnect } from '@folio/stripes-core';
 
 import TagsForm from './TagsForm';
 
-export default class Tags extends React.Component {
+class Tags extends React.Component {
   static manifest = Object.freeze({
     tags: {
       type: 'okapi',
@@ -25,6 +27,8 @@ export default class Tags extends React.Component {
   });
 
   static propTypes = {
+    children: PropTypes.func,
+    link: PropTypes.string.isRequired,
     mutator: PropTypes.shape({
       entities: PropTypes.shape({
         PUT: PropTypes.func.isRequired,
@@ -34,6 +38,7 @@ export default class Tags extends React.Component {
       }),
     }),
     onToggle: PropTypes.func,
+    refreshRemote: PropTypes.func.isRequired,
     resources: PropTypes.shape({
       entities: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -42,100 +47,118 @@ export default class Tags extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }).isRequired,
-    stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired,
-    }),
   };
 
-  constructor(props) {
-    super(props);
-    this.onAdd = this.onAdd.bind(this);
-    this.onRemove = this.onRemove.bind(this);
-    this.handleRemove = this.handleRemove.bind(this);
-    this.calloutRef = React.createRef();
+  static defaultProps = { onToggle: noop };
+
+  componentDidUpdate(prevProps) {
+    // TODO: remove the explicit `refreshRemote` call when https://issues.folio.org/browse/STCON-81 is done.
+    // Calling `refreshRemote` is needed to update entities resource when link prop is changed.
+    // `stripes-connect` is supposed to do it under the hood but there is a bug,
+    // and therefore it is needed to do it manually.
+    if (prevProps.link !== this.props.link) {
+      this.props.refreshRemote(this.props);
+    }
   }
 
-  onAdd(tags) {
+  calloutRef = React.createRef();
+
+  onAdd = tags => {
     this.saveEntityTags(tags);
     this.saveTags(tags);
-  }
+  };
 
-  onRemove(tag) {
+  onRemove = tag => {
     const entity = this.getEntity();
-    const tags = (entity.tags || {}).tagList || [];
+    const tags = this.getEntityTags();
     const tagList = tags.filter(t => t !== tag);
     entity.tags = { tagList };
     this.props.mutator.entities.PUT(entity);
-  }
+  };
 
   // add tag to the list of entity tags
   saveEntityTags(tags) {
     const entity = this.getEntity();
-    const tagList = (entity.tags || {}).tagList || [];
+    const tagList = this.getEntityTags();
     entity.tags = { tagList: sortBy(uniq([...tags, ...tagList])) };
     this.props.mutator.entities.PUT(entity);
   }
 
   // add tags to global list of tags
   saveTags(tags) {
-    const { mutator, resources } = this.props;
-    const records = (resources.tags || {}).records || [];
+    const records = this.getTags();
     const newTag = difference(tags, records.map(t => t.label.toLowerCase()));
 
     if (!newTag || !newTag.length) return;
 
-    mutator.tags.POST({
+    this.props.mutator.tags.POST({
       label: newTag[0],
       description: newTag[0],
     });
 
-    if (this.callout) {
+    if (this.calloutRef.current) {
       const message = <FormattedMessage id="stripes-smart-components.newTagCreated" />;
       this.calloutRef.current.sendCallout({ message });
     }
   }
 
-  handleRemove(tag) {
-    const entity = this.getEntity();
-    const tags = this.getEntityTags();
-    const tagList = tags.filter(t => (t !== tag));
-    entity.tags = { tagList };
-    this.props.mutator.entities.PUT(entity);
-  }
-
   getEntity() {
-    const entities = (this.props.resources.entities || {}).records || [];
-    return entities[0] || {};
+    return get(this.props, ['resources', 'entities', 'records', 0], {});
   }
 
   getEntityTags() {
     const entity = this.getEntity();
+
     return get(entity, ['tags', 'tagList'], []);
   }
 
-  render() {
-    const { resources, stripes } = this.props;
-    const entityTags = this.getEntityTags();
-    const tags = (resources.tags || {}).records || [];
+  getTags() {
+    return get(this.props, ['resources', 'tags', 'records'], []);
+  }
 
-    return (
-      <Pane
-        defaultWidth="20%"
-        paneTitle={<FormattedMessage id="stripes-smart-components.tags" />}
-        paneSub={<FormattedMessage id="stripes-smart-components.numberOfTags" values={{ count: entityTags.length }} />}
-        dismissible
-        onClose={this.props.onToggle}
-      >
+  render() {
+    const { children, onToggle } = this.props;
+    const entityTags = this.getEntityTags();
+    const tags = this.getTags();
+
+    const tagsForm = (
+      <React.Fragment>
         <TagsForm
           onRemove={this.onRemove}
           onAdd={this.onAdd}
           tags={tags}
           entityTags={entityTags}
-          stripes={stripes}
         />
-
         <Callout ref={this.calloutRef} />
+      </React.Fragment>
+    );
+
+    if (isFunction(children)) {
+      return children({
+        entityTags,
+        tags,
+        tagsForm,
+        tagsProps: this.props,
+      });
+    }
+
+    return (
+      <Pane
+        defaultWidth="20%"
+        paneTitle={<FormattedMessage id="stripes-smart-components.tags" />}
+        paneSub={(
+          <FormattedMessage
+            id="stripes-smart-components.numberOfTags"
+            values={{ count: entityTags.length }}
+          />
+        )}
+        dismissible
+        onClose={onToggle}
+      >
+        {tagsForm}
       </Pane>
     );
   }
 }
+
+export default stripesConnect(Tags);

--- a/lib/Tags/TagsAccordion.js
+++ b/lib/Tags/TagsAccordion.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormattedMessage,
+  FormattedNumber,
+} from 'react-intl';
+import {
+  Accordion,
+  Headline,
+  Badge,
+} from '@folio/stripes-components';
+
+import Tags from './Tags';
+
+const TagsAccordion = React.memo(({ link }) => (
+  <Tags link={link}>
+    {({
+      entityTags,
+      tagsForm,
+    }) => (
+      <Accordion
+        label={(
+          <Headline
+            size="large"
+            tag="h3"
+          >
+            <FormattedMessage id="stripes-smart-components.tags" />
+          </Headline>
+        )}
+        displayWhenClosed={(
+          <Badge size="small">
+            <FormattedNumber value={entityTags.length} />
+          </Badge>
+        )}
+      >
+        {tagsForm}
+      </Accordion>
+    )}
+  </Tags>
+));
+
+TagsAccordion.propTypes = { link: PropTypes.string.isRequired };
+
+export default TagsAccordion;

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -1,7 +1,8 @@
-import { isEqual, difference, sortBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { isEqual, difference, sortBy, noop } from 'lodash';
+
 import { MultiSelection } from '@folio/stripes-components';
 
 export default class TagsForm extends React.Component {
@@ -9,18 +10,17 @@ export default class TagsForm extends React.Component {
     entityTags: PropTypes.arrayOf(PropTypes.string),
     onAdd: PropTypes.func,
     onRemove: PropTypes.func,
-    stripes: PropTypes.shape({
-      connect: PropTypes.func.isRequired
-    }).isRequired,
     tags: PropTypes.arrayOf(PropTypes.object),
   };
 
-  constructor(props) {
-    super(props);
-    this.onChange = this.onChange.bind(this);
-    this.filterItems = this.filterItems.bind(this);
-    this.state = { entityTags: [] };
-  }
+  static defaultProps = {
+    entityTags: [],
+    onAdd: noop,
+    onRemove: noop,
+    tags: [],
+  };
+
+  state = { entityTags: [] };
 
   static getDerivedStateFromProps(nextProps, prevState) {
     if (!isEqual(nextProps.entityTags, prevState.entityTags)) {
@@ -30,7 +30,7 @@ export default class TagsForm extends React.Component {
     return null;
   }
 
-  onChange(tags) {
+  onChange = tags => {
     const entityTags = tags.map(t => t.value);
     if (tags.length < this.state.entityTags.length) {
       const tag = difference(this.state.entityTags, tags.map(t => t.value));
@@ -40,9 +40,9 @@ export default class TagsForm extends React.Component {
     }
 
     this.setState({ entityTags });
-  }
+  };
 
-  filterItems(filter, list) {
+  filterItems = (filter, list) => {
     if (!filter) {
       return { renderedItems: list };
     }
@@ -58,7 +58,7 @@ export default class TagsForm extends React.Component {
     });
 
     return { renderedItems };
-  }
+  };
 
   addTag = ({ inputValue }) => {
     const tag = inputValue.replace(/\s|\|/g, '').toLowerCase();

--- a/lib/Tags/index.js
+++ b/lib/Tags/index.js
@@ -1,6 +1,8 @@
 import withTags from './withTags';
+import TagsAccordion from './TagsAccordion';
 
 export { default } from './Tags';
 export {
   withTags,
+  TagsAccordion,
 };


### PR DESCRIPTION
Jira ticket: https://issues.folio.org/browse/UIDATIMP-10

The purpose of this PR is to add `TagsAccordion` component to provide an ability to use tags in an accordion (like in `ui-eholdings` module).
The PR also includes:
1) a bug fix for displaying a toast when creating a new tag;
1) code refactoring for the `Tags` and `TagsForm` components.
1) a "render props" support for `Tags` component to provide a way to use tags independently of a markup.

Note: there is a "refreshRemote"-hack in the `componentDidUpdate` method in `Tags` component. It is needed to update resources when the `link` prop changes and it should be removed when https://issues.folio.org/browse/STCON-81 is done.