### PR TITLE
UIORG-81: Prevent changes of the vertical position of elements when a validation error message is displayed and prevent input field validation on cancel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 2.7.3 (IN PROGRESS)
+
+* In `<EditableList>`, prevent changes of the vertical position of elements when a validation error message is displayed and prevent input field validation on cancel. Fixes UIORG-81.
+
 ## [2.7.2](https://github.com/folio-org/stripes-smart-components/tree/v2.7.2) (2019-06-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.1...v2.7.2)
 

--- a/lib/EditableList/EditableList.css
+++ b/lib/EditableList/EditableList.css
@@ -19,6 +19,10 @@
   min-height: 40px;
 }
 
+.baselineListRow {
+  align-items: baseline;
+}
+
 .editListHeaders {
   display: flex;
   justify-content: flex-start;

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -356,6 +356,7 @@ class EditableListForm extends React.Component {
             Save
           </Button>
           <Button
+            data-type-button="cancel"
             marginBottom0
             id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onCancel(fields, item.rowIndex)}

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -1,8 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { Field } from 'redux-form';
 import { TextField } from '@folio/stripes-components';
 import css from './EditableList.css';
+
+// Prevents input field validation on cancel. Issue https://github.com/erikras/redux-form/issues/860
+function handleDefaultFieldBlur(event) {
+  const { relatedTarget } = event;
+
+  if (relatedTarget && relatedTarget.getAttribute('data-type-button') === 'cancel') {
+    event.preventDefault();
+  }
+}
 
 const ItemEdit = ({
   rowIndex,
@@ -48,6 +58,7 @@ const ItemEdit = ({
             fullWidth
             placeholder={name}
             autoFocus={autoFocus && fieldIndex === 0}
+            onBlur={handleDefaultFieldBlur}
           />
         </div>
       );
@@ -56,7 +67,7 @@ const ItemEdit = ({
   });
 
   return (
-    <div className={css.editListRow} role="row" aria-rowindex={rowIndex + 2}>
+    <div className={classnames(css.editListRow, css.baselineListRow)} role="row" aria-rowindex={rowIndex + 2}>
       {fields}
       { error &&
         <div className={css.editableListError}>


### PR DESCRIPTION
### Purpose
Prevent changes of the vertical position of elements when a validation error message is displayed and prevent input field validation on cancel.[Story UIORG-81](https://issues.folio.org/browse/UIORG-81).

**Before**

![Before](https://user-images.githubusercontent.com/49517355/59518869-4ba52780-8ecf-11e9-82ae-7d068da2988a.gif)

**After**

![After](https://user-images.githubusercontent.com/49517355/59518892-58c21680-8ecf-11e9-9051-ee0eda564f97.gif)
