### PR TITLE
*sigh* fix propTypes declaration for resources.updaterId

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -92,7 +92,10 @@ class ControlledVocab extends React.Component {
     readOnlyFields: PropTypes.arrayOf(PropTypes.string),
     records: PropTypes.string,
     resources: PropTypes.shape({
-      updaterIds: PropTypes.string,
+      updaterIds: PropTypes.oneOfType([
+        PropTypes.object, // It comes back as this early in the lifecycle
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
       updaters: PropTypes.object,
       values: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
This is a double fix. First, I incorrectly specified it as type string
rather than arrayOf(string). But also, it seems that early in the
lifecycle it gets furnished to this component as an empty _object_
rather than array -- I suspect because this is stripes-connect's
default. So we use oneOfType to accept either.