### PR TITLE
Changes required to handle the Refdata API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for stripes-smart-components
 
-## 2.7.3 (IN PROGRESS)
+## 2.8.0 (IN PROGRESS)
 
 * In `<EditableList>`, prevent changes of the vertical position of elements when a validation error message is displayed and prevent input field validation on cancel. Fixes UIORG-81.
+* `<ControlledVocab>` accepts optional new `actuatorType` property. If set to `'refdata'`, it performs different back-end operations to maintain the vocabulary, as described in [_API to the Refdata system_](https://github.com/openlibraryenvironment/ui-directory/blob/master/doc/refdata-api.md). Fixes [ReShare issue PR-189](https://openlibraryenvironment.atlassian.net/browse/PR-189). Available from v2.7.3.
 
 ## [2.7.2](https://github.com/folio-org/stripes-smart-components/tree/v2.7.2) (2019-06-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.1...v2.7.2)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -9,6 +9,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
 import css from './ControlledVocab.css';
+import makeRefdataActuatorsBoundTo from './actuators-refdata';
 
 class ControlledVocab extends React.Component {
   static manifest = Object.freeze({
@@ -27,6 +28,15 @@ class ControlledVocab extends React.Component {
       GET: {
         path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=500'
       }
+    },
+    // Only used when actuatorType="refdata"
+    refdataValues: {
+      type: 'okapi',
+      fetch: false,
+      clientGeneratePk: '!{clientGeneratePk}',
+      PUT: {
+        path: '!{baseUrl}',
+      },
     },
     activeRecord: {},
     updaters: {
@@ -166,11 +176,7 @@ class ControlledVocab extends React.Component {
     this.id = props.id || uniqueId('controlled-vocab-');
 
     if (this.props.actuatorType === 'refdata') {
-      this.actuators = {
-        onCreate: this.createRefdata.bind(this),
-        onDelete: this.deleteRefdata.bind(this),
-        onUpdate: this.updateRefdata.bind(this),
-      };
+      this.actuators = makeRefdataActuatorsBoundTo(this);
     } else {
       this.actuators = {
         onCreate: this.onCreateItem.bind(this),

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -50,6 +50,7 @@ class ControlledVocab extends React.Component {
   static propTypes = {
     actionProps: PropTypes.object,
     actionSuppressor: PropTypes.object,
+    actuatorType: PropTypes.string,
     baseUrl: PropTypes.string.isRequired,
     clientGeneratePk: PropTypes.oneOfType([
       PropTypes.bool,
@@ -138,6 +139,7 @@ class ControlledVocab extends React.Component {
     // default value "limit" right into the expression
     //  !{limitParam:-limit}
     // in the manifest above.
+    actuatorType: 'rest',
   };
 
   constructor(props) {
@@ -151,13 +153,24 @@ class ControlledVocab extends React.Component {
     };
 
     this.validate = this.validate.bind(this);
-    this.onCreateItem = this.onCreateItem.bind(this);
-    this.onUpdateItem = this.onUpdateItem.bind(this);
-    this.onDeleteItem = this.onDeleteItem.bind(this);
     this.showConfirmDialog = this.showConfirmDialog.bind(this);
     this.hideConfirmDialog = this.hideConfirmDialog.bind(this);
     this.hideItemInUseDialog = this.hideItemInUseDialog.bind(this);
     this.id = props.id || uniqueId('controlled-vocab-');
+
+    if (this.props.actuatorType === 'refdata') {
+      this.actuators = {
+        onCreate: this.createRefdata.bind(this),
+        onDelete: this.deleteRefdata.bind(this),
+        onUpdate: this.updateRefdata.bind(this),
+      };
+    } else {
+      this.actuators = {
+        onCreate: this.onCreateItem.bind(this),
+        onDelete: this.onDeleteItem.bind(this),
+        onUpdate: this.onUpdateItem.bind(this),
+      };
+    }
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -423,8 +436,8 @@ class ControlledVocab extends React.Component {
               ]}
               actionSuppression={this.props.actionSuppressor}
               actionProps={this.props.actionProps}
-              onUpdate={this.onUpdateItem}
-              onCreate={this.onCreateItem}
+              onUpdate={this.actuators.onUpdate}
+              onCreate={this.actuators.onCreate}
               onDelete={this.showConfirmDialog}
               isEmptyMessage={
                 <FormattedMessage
@@ -440,7 +453,7 @@ class ControlledVocab extends React.Component {
             open={this.state.showConfirmDialog}
             heading={<FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: type }} />}
             message={modalMessage}
-            onConfirm={this.onDeleteItem}
+            onConfirm={this.actuators.onDelete}
             onCancel={this.hideConfirmDialog}
             confirmLabel={<FormattedMessage id="stripes-core.button.delete" />}
           />

--- a/lib/ControlledVocab/actuators-refdata.js
+++ b/lib/ControlledVocab/actuators-refdata.js
@@ -4,7 +4,6 @@
 // Each of these should return a promise that resolves when the operation is complete
 
 function createRefdata(item) {
-  console.log('createRefdata', item); // eslint-disable-line no-console
   const tweakedItem = this.props.preCreateHook(item);
   const instruction = {
     values: [tweakedItem]
@@ -13,7 +12,6 @@ function createRefdata(item) {
 }
 
 function deleteRefdata() {
-  console.log('deleteRefdata'); // eslint-disable-line no-console
   const item = this.state.selectedItem;
   this.props.mutator.activeRecord.update({ id: item.id });
   const instruction = {
@@ -34,7 +32,6 @@ function deleteRefdata() {
 }
 
 function updateRefdata(item) {
-  console.log('updateRefdata', item); // eslint-disable-line no-console
   this.props.mutator.activeRecord.update({ id: item.id });
   const tweakedItem = this.props.preUpdateHook(item);
   const instruction = {

--- a/lib/ControlledVocab/actuators-refdata.js
+++ b/lib/ControlledVocab/actuators-refdata.js
@@ -1,0 +1,53 @@
+// Actuator functions for Refdata controlled vocabulary
+// Used when client code calls <ControlledVocab actuatorType="refdata">
+// For Refdata API, see https://github.com/openlibraryenvironment/ui-directory/blob/master/doc/refdata-api.md
+// Each of these should return a promise that resolves when the operation is complete
+
+function createRefdata(item) {
+  console.log('createRefdata', item); // eslint-disable-line no-console
+  const tweakedItem = this.props.preCreateHook(item);
+  const instruction = {
+    values: [tweakedItem]
+  };
+  return this.props.mutator.refdataValues.PUT(instruction);
+}
+
+function deleteRefdata() {
+  console.log('deleteRefdata'); // eslint-disable-line no-console
+  const item = this.state.selectedItem;
+  this.props.mutator.activeRecord.update({ id: item.id });
+  const instruction = {
+    values: [{ id: item.id, _delete: true }]
+  };
+
+  // XXX too much intelligence here: the handling should be moved up into a wrapper
+  return this.props.mutator.refdataValues.PUT(instruction)
+    .then(() => {
+      this.showDeletionSuccessCallout(item);
+      this.deleteItemResolve();
+    })
+    .catch(() => {
+      this.setState({ showItemInUseDialog: true });
+      this.deleteItemReject();
+    })
+    .finally(() => this.hideConfirmDialog());
+}
+
+function updateRefdata(item) {
+  console.log('updateRefdata', item); // eslint-disable-line no-console
+  this.props.mutator.activeRecord.update({ id: item.id });
+  const tweakedItem = this.props.preUpdateHook(item);
+  const instruction = {
+    // The item should already include its own ID
+    values: [tweakedItem]
+  };
+  return this.props.mutator.refdataValues.PUT(instruction);
+}
+
+export default function (that) {
+  return {
+    onCreate: createRefdata.bind(that),
+    onDelete: deleteRefdata.bind(that),
+    onUpdate: updateRefdata.bind(that),
+  };
+}

--- a/lib/ControlledVocab/tests/ControlledVocab-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocab-test.js
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import ControlledVocab from '../ControlledVocab';
-import makeRefdataActuatorsBoundTo from '../actuators-refdata';
 import ControlledVocabInteractor from './interactor';
 import { setupApplication, mount } from '../../../tests/helpers';
 import connectStripes from '../../../tests/connectStripes';

--- a/lib/ControlledVocab/tests/ControlledVocab-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocab-test.js
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import ControlledVocab from '../ControlledVocab';
+import makeRefdataActuatorsBoundTo from '../actuators-refdata';
 import ControlledVocabInteractor from './interactor';
 import { setupApplication, mount } from '../../../tests/helpers';
 import connectStripes from '../../../tests/connectStripes';

--- a/lib/ControlledVocab/tests/actuators-refdata-test.js
+++ b/lib/ControlledVocab/tests/actuators-refdata-test.js
@@ -1,0 +1,37 @@
+import makeRefdataActuatorsBoundTo from '../actuators-refdata';
+
+describe('ControlledVocab', () => {
+  describe('Refdata actuators run', () => {
+    const mock = {
+      state: {
+        selectedItem: { id: 123 },
+      },
+      props: {
+        mutator: {
+          activeRecord: {
+            update: (val) => {},
+          },
+          refdataValues: {
+            PUT: (instruction) => new Promise((resolve, reject) => {
+              resolve();
+            }),
+          }
+        },
+        preCreateHook: (rec) => rec,
+        preUpdateHook: (rec) => rec,
+      }
+    };
+
+    const actuators = makeRefdataActuatorsBoundTo(mock);
+
+    it('create function', () => {
+      actuators.onCreate({ id: 42, element: 'water' });
+    });
+    it('delete function', () => {
+      actuators.onDelete();
+    });
+    it('udate function', () => {
+      actuators.onUpdate({ id: 42, element: 'earth' });
+    });
+  });
+});

--- a/lib/ControlledVocab/tests/actuators-refdata-test.js
+++ b/lib/ControlledVocab/tests/actuators-refdata-test.js
@@ -1,3 +1,4 @@
+import { describe, it } from '@bigtest/mocha';
 import makeRefdataActuatorsBoundTo from '../actuators-refdata';
 
 describe('ControlledVocab', () => {
@@ -9,10 +10,10 @@ describe('ControlledVocab', () => {
       props: {
         mutator: {
           activeRecord: {
-            update: (val) => {},
+            update: (_val) => {},
           },
           refdataValues: {
-            PUT: (instruction) => new Promise((resolve, reject) => {
+            PUT: (_instruction) => new Promise((resolve, _reject) => {
               resolve();
             }),
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": [


### PR DESCRIPTION
Until now, the set of values maintained using `<ControlledVocab>` have all been CRUDable. But for the ReShare project immediately (and down the line for FOLIO's ERM modules) we need to also maintain controlled vocabularies using Knowledge Integration's Refdata API, documented at https://github.com/openlibraryenvironment/ui-directory/blob/master/doc/refdata-api.md

These changes make that possible. They abstract out the actual WSAPI operations performed by `<ControlledVocab>` into an "actuator", which is merely a set of three named functions (onCreate, onDelete and onUpdate). The existing functions are packaged into an anonymous actuator that behaves exactly as before. But if the new optional `actuatorType` prop is set to `'refdata'`, then a new actuator is used that works with the Refdata WSAPI.

(Note that this very simple actuator abstraction will generalise easily to any other controlled-vocabulary WSAPIs we may need to use down the line.)
