### PR TITLE
STSMACOM-216 - Fix Plural handling in notes.found key

### DIFF
--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -116,7 +116,7 @@
   "notes.assignNote": "Assign note",
   "notes.noteSearch": "Note search",
   "notes.noteAssignmentStatus": "Note assignment status",
-  "notes.found": "{quantity} notes found",
+  "notes.found": "{quantity, number} {quantity, plural, one {note found} other {notes found}}",
   "date": "Date",
   "title": "Title",
   "updatedBy": "Updated by",


### PR DESCRIPTION
Per https://issues.folio.org/browse/STSMACOM-216 we need to fix plural handling for notes.found key

Made updates accordingly based on https://github.com/folio-org/stripes/blob/master/doc/i18n.md#details and other examples.

I did not find `notes.found` key in use yet when searching folio-org for `stripes-smart-components.notes.Found` - so possible alternative solution would be to remove this translation key.