### PR TITLE
UIEH-742: change NotesAssigningModal to pass correct props to accordion

### DIFF
--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -457,7 +457,11 @@ export default class NotesAssigningModal extends React.Component {
                   <FormattedMessage id="stripes-smart-components.notes.noteAssignmentStatus" />
                 </Headline>
               }
-              displayWhenOpen={thereAreSelectedFilters && this.renderResetFiltersButton()}
+              displayWhenOpen={
+                thereAreSelectedFilters
+                  ? this.renderResetFiltersButton()
+                  : null
+              }
             >
               <CheckboxFilter
                 dataOptions={this.getNotesStatusOptions()}


### PR DESCRIPTION
Accordion's `displayWhenOpen` prop is expected to be a react element. Currently, in some cases, `false` (which is not a react element) is passed to Accordion by NotesAssigningModal. In this PR, I've replaced `false` with `null`.