### PR TITLE
STSMACOM-165: Fix error display.

### DIFF
--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -57,6 +57,7 @@ const ItemEdit = ({
             marginBottom0
             fullWidth
             placeholder={name}
+            {...(error && { error })}
             autoFocus={autoFocus && fieldIndex === 0}
             onBlur={handleDefaultFieldBlur}
           />
@@ -69,12 +70,6 @@ const ItemEdit = ({
   return (
     <div className={classnames(css.editListRow, css.baselineListRow)} role="row" aria-rowindex={rowIndex + 2}>
       {fields}
-      { error &&
-        <div className={css.editableListError}>
-Error:
-          {error}
-        </div>
-      }
     </div>
   );
 };


### PR DESCRIPTION
# Description:
When a duplicate term is entered in controlled vocab CRUD component in Settings, the addition silently fails. It's good that it fails, but there should be some messaging that it failed because it was not unique. This applies in e.g. Settings > Inventory > Holdings, Holdings type, and Settings > Inventory > Instance, Holdings, Item > Call number type and more (basically everywhere this component is used in both Inventory and User settings.
# Screenshot
![Screen Shot 2019-06-26 at 2 56 44 PM](https://user-images.githubusercontent.com/42577309/60177887-b4bb6200-9822-11e9-861c-c713e1edf7ab.png)
