### PR TITLE
STSMACOM-226 -Assigned accordion should be closed by default on note view/edit

### DIFF
--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -57,7 +57,7 @@ export default class NoteView extends Component {
   state = {
     sections: {
       noteGeneralInfo: true,
-      assigned: true,
+      assigned: false,
     }
   };
 
@@ -275,6 +275,7 @@ export default class NoteView extends Component {
                 label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
                 id="assigned"
                 open={assigned}
+                closedByDefault
                 onToggle={this.handleSectionToggle}
               >
                 {referredEntityData && this.renderReferredRecord()}

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -63,7 +63,7 @@ export default class NoteForm extends Component {
   state = {
     sections: {
       noteForm: true,
-      assigned: true,
+      assigned: false,
     }
   };
 
@@ -305,6 +305,7 @@ export default class NoteForm extends Component {
                         label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
                         id="assigned"
                         open={assigned}
+                        closedByDefault
                         onToggle={this.handleSectionToggle}
                       >
                         {referredEntityData && this.renderReferredRecord()}


### PR DESCRIPTION
## Purpose
Per https://issues.folio.org/browse/STSMACOM-226 the assigned accordion section (on both note view and edit ) should be closed by default

## Approach
Adjust accordion attributes to indicate `closedByDefault` and set sections state to reflect default closed
Manually tested change -- set up platform for test
`stripes workspace --modules ui-eholdings stripes-components stripes-smart-components stripes-sample-platform`
Add `ui-notes` to platform
 https://github.com/folio-org/stripes/blob/master/doc/new-development-setup.md#platform-development-instructions
Gif shows manual test of accordion in platform
Added test coverage in eHoldings -- https://github.com/folio-org/ui-eholdings/pull/830 -- PR needs to wait until this change has been made.

## Screenshots
![2019-07-02 12 44 39](https://user-images.githubusercontent.com/19415226/60532169-af4e9380-9cca-11e9-8e46-10ee4cab5e92.gif)
