### PR TITLE
Set selectedIndex to empty string by default in order to correctly clear SearchField. Fixes UIIN-615

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * In `<EditableList>`, prevent changes of the vertical position of elements when a validation error message is displayed and prevent input field validation on cancel. Fixes UIORG-81.
 * `<ControlledVocab>` accepts optional new `actuatorType` property. If set to `'refdata'`, it performs different back-end operations to maintain the vocabulary, as described in [_API to the Refdata system_](https://github.com/openlibraryenvironment/ui-directory/blob/master/doc/refdata-api.md). Fixes [ReShare issue PR-189](https://openlibraryenvironment.atlassian.net/browse/PR-189). Available from v2.7.3.
 * Remove permissions related to the (deprecated and removed) earlier implementation of Notes (STSMACOM-224)
+* Set selectedIndex to empty string by default. Fixes UIIN-615.
 
 ## [2.7.2](https://github.com/folio-org/stripes-smart-components/tree/v2.7.2) (2019-06-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.1...v2.7.2)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -186,6 +186,7 @@ class SearchAndSort extends React.Component {
     getHelperComponent: noop,
     massageNewRecord: noop,
     renderNavigation: noop,
+    selectedIndex: ''
   };
 
   constructor(props) {


### PR DESCRIPTION
It turned out that the `select` doesn't like the `undefined` value after rerender. Setting `selectedIndex` to an empty string instead correctly resets the `select` to the original value.

https://issues.folio.org/browse/UIIN-615