### PR TITLE
STSMACOM-218: Notes modal UI updates

### DIFF
--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.css
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.css
@@ -24,22 +24,22 @@
 .search-field {
   margin-bottom: var(--gutter-static);
 }
+
 .modal-content {
   padding: 0;
 }
+
 .footer-button {
   margin-bottom: 0;
 }
+
 .caution-message {
   margin: 0 5px;
   width: 100%;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);
-  line-height: 1.2;  
-  
-  & span {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.css
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.css
@@ -18,9 +18,28 @@
 }
 
 .save-button {
-  margin-right: var(--gutter-static);
+  margin-left: var(--gutter-static);
 }
 
 .search-field {
   margin-bottom: var(--gutter-static);
+}
+.modal-content {
+  padding: 0;
+}
+.footer-button {
+  margin-bottom: 0;
+}
+.caution-message {
+  margin: 0 5px;
+  width: 100%;
+  color: var(--color-text-p2);
+  font-size: var(--font-size-small);
+  line-height: 1.2;  
+  
+  & span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -488,9 +488,7 @@ export default class NotesAssigningModal extends React.Component {
           >
             {notes.totalCount > 0 && (
               <p className={styles['caution-message']}>
-                <span>
-                  <FormattedMessage id="stripes-smart-components.notes.cautionMessage" />
-                </span>
+                <FormattedMessage id="stripes-smart-components.notes.cautionMessage" />
               </p>
             )}
             <MultiColumnList

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -5,6 +5,7 @@ import {
   get,
   debounce,
 } from 'lodash';
+import classnames from 'classnames';
 
 import {
   Modal,
@@ -189,17 +190,19 @@ export default class NotesAssigningModal extends React.Component {
     return (
       <Fragment>
         <Button
-          onClick={this.props.onClose}
-          data-test-notes-modal-cancel-button
-        >
-          <FormattedMessage id="stripes-core.button.cancel" />
-        </Button>
-        <Button
           onClick={this.onSaveAndClose}
-          buttonClass={styles['save-button']}
+          buttonStyle="primary"
+          buttonClass={classnames(styles['save-button'], styles['footer-button'])}
           data-test-notes-modal-save-button
         >
           <FormattedMessage id="stripes-core.button.save" />
+        </Button>
+        <Button
+          onClick={this.props.onClose}
+          data-test-notes-modal-cancel-button
+          buttonClass={styles['footer-button']}
+        >
+          <FormattedMessage id="stripes-core.button.cancel" />
         </Button>
       </Fragment>
     );
@@ -290,6 +293,7 @@ export default class NotesAssigningModal extends React.Component {
       ),
       [columnNames.TITLE]: <FormattedMessage id="stripes-smart-components.title" />,
       [columnNames.STATUS]: <FormattedMessage id="stripes-smart-components.status" />,
+      [columnNames.COUNT]: <FormattedMessage id="stripes-smart-components.notes.assigned.count" />
     };
   }
 
@@ -408,6 +412,7 @@ export default class NotesAssigningModal extends React.Component {
     return (
       <Modal
         size="large"
+        contentClass={styles['modal-content']}
         open={open}
         label={<FormattedMessage id="stripes-smart-components.notes.assignNote" />}
         onClose={onClose}
@@ -481,8 +486,15 @@ export default class NotesAssigningModal extends React.Component {
             )}
             defaultWidth="70%"
           >
+            {notes.totalCount > 0 && (
+              <p className={styles['caution-message']}>
+                <span>
+                  <FormattedMessage id="stripes-smart-components.notes.cautionMessage" />
+                </span>
+              </p>
+            )}
             <MultiColumnList
-              visibleColumns={[columnNames.ASSIGNING, columnNames.TITLE, columnNames.STATUS]}
+              visibleColumns={[columnNames.ASSIGNING, columnNames.TITLE, columnNames.STATUS, columnNames.COUNT]}
               contentData={this.getNotes()}
               totalCount={notes.totalCount}
               columnMapping={this.getColumnMapping()}
@@ -495,7 +507,7 @@ export default class NotesAssigningModal extends React.Component {
               virtualize
               onNeedMoreData={this.fetchNotes}
               loading={notes.loading}
-              height={220}
+              height={202}
               id="notes-modal-notes-list"
             />
           </Pane>

--- a/lib/Notes/constants.js
+++ b/lib/Notes/constants.js
@@ -19,9 +19,15 @@ const assigningModalColumnNames = {
   ASSIGNING: 'assigning',
   TITLE: 'title',
   STATUS: 'status',
+  COUNT: 'linksNumber',
 };
 
 export const assigningModalColumnsConfig = {
   names: assigningModalColumnNames,
-  widths: { [assigningModalColumnNames.ASSIGNING]: '5%' },
+  widths: {
+    [assigningModalColumnNames.ASSIGNING]: '5%',
+    [assigningModalColumnNames.COUNT]: '25%',
+    [assigningModalColumnNames.TITLE]: '50%',
+    [assigningModalColumnNames.STATUS]: '20%',
+  },
 };

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -128,6 +128,8 @@
   "details": "Details",
   "notes.generalInformation": "General information",
   "notes.assigned": "Assigned",
+  "notes.assigned.count": "# of assignments",
+  "notes.cautionMessage": "Notes with one assignment cannot be unassigned.",
   "notes.newNote": "New note",
   "notes.editNote": "Edit note",
   "notes.saveAndClose": "Save & close",


### PR DESCRIPTION
## Purpose

This PR approaches the following UI updates in notes assignment modal:
- Fixed borders
- Added caution message (Notes with one assignment cannot be unassigned)
- Added the # of assignments column on the results list
- Place Cancel and Save buttons in the order as outlined on the mockup

## Screenshot
![Screen Shot 2019-07-10 at 18 29 28](https://user-images.githubusercontent.com/15856488/60982498-ed8a2980-a340-11e9-858b-d576d4a697b0.png)
