### PR TITLE
STSMACOM-230 ViewMetaData shouldn't fetch constantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Set selectedIndex to empty string by default. Fixes UIIN-615.
 * Fix requests count and alert message after loan due date changed. Refs UIU-1070.
 * Pass `permissions` to `setupApplication` so tests can configure their own permissions. Fixes STSMACOM-231.
+* Fix `<ViewMetaData>` so it doesn't blow the stack when creator and updater differ. Fixes STSMACOM-230.
 
 ## [2.7.2](https://github.com/folio-org/stripes-smart-components/tree/v2.7.2) (2019-06-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.1...v2.7.2)

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { isEqual } from 'lodash';
+import { get } from 'lodash';
 
 import { MetaSection } from '@folio/stripes-components';
 import { stripesConnect } from '@folio/stripes-core';
@@ -12,30 +12,34 @@ class ViewMetaData extends React.Component {
       type: 'okapi',
       records: 'users',
       path: 'users',
-      GET: {
-        params: {
-          query: (queryParams, pathComponents, resourceValues) => {
-            if (resourceValues.updaterIds && resourceValues.updaterIds.length) {
-              return `(${resourceValues.updaterIds.join(' or ')})`;
-            }
-            return null;
-          },
-        }
-      }
+      params: (_q, _p, _r, _l, props) => {
+        const cId = get(props, 'metadata.createdByUserId');
+        const uId = get(props, 'metadata.updatedByUserId');
+
+        const userIds = [];
+        if (cId && cId !== props.systemId) userIds.push(cId);
+        if (uId && uId !== props.systemId) userIds.push(uId);
+        const query = [
+          ...new Set(userIds.map(i => `id==${i}`))
+        ].join(' or ');
+
+        return query ? { query } : null;
+      },
+      permissionsRequired: ['ui-users.view'],
     },
-    updaterIds: {},
   });
 
   static propTypes = {
+    contentId: PropTypes.string,
+    id: PropTypes.string,
     metadata: PropTypes.object,
     mutator: PropTypes.shape({
-      updaterIds: PropTypes.object,
       updaters: PropTypes.object,
     }).isRequired,
     resources: PropTypes.shape({
-      updaterIds: PropTypes.oneOfType([PropTypes.object, PropTypes.arrayOf(PropTypes.string)]),
       updaters: PropTypes.object,
     }).isRequired,
+    showUserLink: PropTypes.bool,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
     }).isRequired,
@@ -56,25 +60,8 @@ class ViewMetaData extends React.Component {
   static defaultProps = {
     metadata: {},
     systemUser: <FormattedMessage id="stripes-smart-components.system" />,
+    showUserLink: true,
   };
-
-  /**
-   * If the user has permission, push the metadata-userIds into the
-   * updaterIds resource in order to cause that query to fire.
-   */
-  componentDidUpdate() {
-    const { stripes, metadata } = this.props;
-    if (stripes.hasPerm('ui-users.view')) {
-      const userIds = [
-        `id=="${metadata.createdByUserId}"`,
-        `id=="${metadata.updatedByUserId}"`,
-      ];
-
-      if (!isEqual(userIds, this.props.resources.updaterIds)) {
-        this.props.mutator.updaterIds.replace(userIds);
-      }
-    }
-  }
 
   renderUser = (userId) => {
     const { systemId, systemUser } = this.props;
@@ -91,8 +78,9 @@ class ViewMetaData extends React.Component {
 
     return (
       <MetaSection
-        id="instanceRecordMeta"
-        contentId="instanceRecordMetaContent"
+        id={this.props.id}
+        contentId={this.props.contentId}
+        showUserLink={this.props.showUserLink}
         createdBy={this.renderUser(metadata.createdByUserId)}
         lastUpdatedBy={this.renderUser(metadata.updatedByUserId)}
         createdDate={metadata.createdDate}

--- a/lib/ViewMetaData/tests/ViewMetaData-test.js
+++ b/lib/ViewMetaData/tests/ViewMetaData-test.js
@@ -14,73 +14,117 @@ const ConnectedComponent = connectStripes(ViewMetaData);
 describe('ViewMetaData', () => {
   const vmd = new ViewMetaDataInteractor();
 
-  setupApplication();
-
-  beforeEach(async function () {
-    let usersLoaded = false;
-
-    this.server.get('users', (schema, request) => {
-      usersLoaded = true;
-      return new Response(200, { 'X-Request-URL': request.url }, {
-        'users': [
-          {
-            'username': 'ecornell',
-            'id': 'user-1',
-            'personal': {
-              'lastName': 'Cornell',
-              'firstName': 'Ezra',
-              'email': 'ecornell@example.edu'
-            }
-          }
-        ],
-        'totalRecords': 1,
-        'resultInfo': {
-          'totalRecords': 1,
-          'facets': [],
-          'diagnostics': []
-        }
-      });
+  describe('MetaData is displayed given proper permissions', () => {
+    setupApplication({
+      permissions: {
+        'ui-users.view': true,
+      },
     });
 
-    mount(
-      <ConnectedComponent
-        metadata={{
-          'createdDate' : '2019-04-01T00:22:44.885+0000',
-          'createdByUserId' : 'SYSTEM_USER',
-          'updatedDate' : '2019-04-15T11:33:55.885+0000',
-          'updatedByUserId' : 'user-1'
-        }}
-        systemId="SYSTEM_USER"
-        systemUser={{
-          'username': 'system',
-          'id': 'SYSTEM_USER',
-          'personal': {
-            'lastName': 'SYSTEM',
-            'firstName': 'USER',
-            'email': 'system@example.edu'
-          }
-        }}
-      />
-    );
+    beforeEach(async function () {
+      let usersLoaded = false;
 
-    await when(() => usersLoaded);
+      this.server.get('users', (schema, request) => {
+        usersLoaded = true;
+        return new Response(200, { 'X-Request-URL': request.url }, {
+          'users': [
+            {
+              'username': 'ecornell',
+              'id': 'user-1',
+              'personal': {
+                'lastName': 'Cornell',
+                'firstName': 'Ezra',
+                'email': 'ecornell@example.edu'
+              }
+            }
+          ],
+          'totalRecords': 1,
+          'resultInfo': {
+            'totalRecords': 1,
+            'facets': [],
+            'diagnostics': []
+          }
+        });
+      });
+
+      await mount(
+        <ConnectedComponent
+          showUserLink
+          metadata={{
+            'createdDate' : '2019-04-01T00:22:44.885+0000',
+            'createdByUserId' : 'SYSTEM_USER',
+            'updatedDate' : '2019-04-15T11:33:55.885+0000',
+            'updatedByUserId' : 'user-1'
+          }}
+          systemId="SYSTEM_USER"
+          systemUser={{
+            'username': 'system',
+            'id': 'SYSTEM_USER',
+            'personal': {
+              'lastName': 'SYSTEM',
+              'firstName': 'USER',
+              'email': 'system@example.edu'
+            }
+          }}
+        />
+      );
+
+      await when(() => usersLoaded);
+    });
+
+    it('Given system-id, system-user details display', () => {
+      expect(vmd.metaSection.createdByText).to.equal('Source: SYSTEM, USER');
+    });
+
+    // it('System-user details are not linked to a user profile', () => {
+    //   expect(vmd.metaSection.createdByLinkIsPresent).to.be.false;
+    // });
+
+    it('Given user-id, user details display', () => {
+      expect(vmd.metaSection.updatedByText).to.equal('Source: Cornell, Ezra');
+    });
+
+    it('Given user-id, user details are linked to a user profile', () => {
+      expect(vmd.metaSection.updatedByLinkIsPresent).to.be.true;
+    });
   });
 
-  describe('MetaData is displayed', () => {
-    it('Creator name is present', () => {
-      expect(vmd.creatorName).to.equal('Source: SYSTEM, USER');
+  describe('MetaData is NOT displayed without proper permissions', () => {
+    setupApplication();
+    beforeEach(async () => {
+      await mount(
+        <ConnectedComponent
+          showUserLink
+          metadata={{
+            'createdDate' : '2019-04-01T00:22:44.885+0000',
+            'createdByUserId' : 'SYSTEM_USER',
+            'updatedDate' : '2019-04-15T11:33:55.885+0000',
+            'updatedByUserId' : 'user-1'
+          }}
+          systemId="SYSTEM_USER"
+          systemUser={{
+            'username': 'system',
+            'id': 'SYSTEM_USER',
+            'personal': {
+              'lastName': 'SYSTEM',
+              'firstName': 'USER',
+              'email': 'system@example.edu'
+            }
+          }}
+        />
+      );
     });
 
-    it('Creator datestamp is present', () => {
-      expect(vmd.creatorDate).to.equal('Record created: 4/1/2019 12:22 AM');
+    it('Given system-id, system-user details display', () => {
+      expect(vmd.metaSection.createdByText).to.equal('Source: SYSTEM, USER');
     });
 
-    it('Updater name is present', () => {
-      expect(vmd.updaterName).to.equal('Source: Cornell, Ezra');
+    it('Given user-id, automated-process details display instead', () => {
+      expect(vmd.metaSection.updatedByText).to.equal('Source: Automated process');
     });
 
-    it('Updater datestamp is present', () => {
-      expect(vmd.updaterDate).to.equal('Record last updated: 4/15/2019 11:33 AM');
+    it('Given user-id, details are not linked to a user profile', () => {
+      expect(vmd.metaSection.updatedByLinkIsPresent).to.be.false;
     });
   });
 });

--- a/lib/ViewMetaData/tests/interactor.js
+++ b/lib/ViewMetaData/tests/interactor.js
@@ -1,11 +1,11 @@
 import {
   interactor,
-  text
+  scoped,
 } from '@bigtest/interactor';
 
+
+import MetaSectionInteractor from '@folio/stripes-components/lib/MetaSection/tests/interactor';
+
 export default interactor(class ViewMetaDataInteractor {
-  updaterName = text('#instanceRecordMeta div[class^="metaSectionContent"] div[class^="metaSectionContentBlock"]');
-  updaterDate = text('#instanceRecordMeta button');
-  creatorName = text('#instanceRecordMeta div[class^="metaSectionContent"] div[class^="metaSectionGroup"] div[class^=metaSectionContentBlock]:nth-of-type(2)');
-  creatorDate = text('#instanceRecordMeta div[class^="metaSectionContent"] div[class^="metaSectionGroup"] div[class^=metaSectionContentBlock]:nth-of-type(1)');
+  metaSection = scoped(MetaSectionInteractor.defaultScope, MetaSectionInteractor);
 });


### PR DESCRIPTION
Under some circumstances, `<ViewMetaData>` would get stuck in a loop and
React would eventually throw a Maximum Update Depth Exceeded error.
Debugging showed that it was receiving new props for creator-id and
updater-id but that, somehow, only the creator-id was being copied into
the `updaterIds` local resource. This meant the comparison of the props
to the resource always returned false and the query ran on each
iteration. Yuck.

Fixes [STSMACOM-230](https://issues.folio.org/browse/STSMACOM-230)