### PR TITLE
bump stripes deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": [
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.2",
-    "@folio/stripes-components": "~5.4.0",
-    "@folio/stripes-connect": "~5.2.0",
-    "@folio/stripes-core": "~3.6.0",
-    "@folio/stripes-form": "~2.6.0",
+    "@folio/stripes-components": "~5.5.0",
+    "@folio/stripes-connect": "~5.3.0",
+    "@folio/stripes-core": "~3.7.0",
+    "@folio/stripes-form": "~2.7.0",
     "@folio/stripes-logger": "~1.0.0",
     "classnames": "^2.2.6",
     "final-form": "^4.12.0",


### PR DESCRIPTION
New features in stripes dependencies mean we need to bump the minor
versions of everything in the stripes dependency chain.