### PR TITLE
Use kebab case for the ids passed to a checkBox

### DIFF
--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Checkbox } from '@folio/stripes-components';
+import { kebabCase } from 'lodash';
 
 export default class CheckboxFilter extends React.Component {
   static propTypes = {
@@ -50,7 +51,7 @@ export default class CheckboxFilter extends React.Component {
         return (
           <Checkbox
             {...rest}
-            id={`clickable-filter-${this.props.name}-${name}`}
+            id={`clickable-filter-${this.props.name}-${kebabCase(name)}`}
             data-test-checkbox-filter-data-option={value}
             key={value}
             label={label}


### PR DESCRIPTION
- Some Ids that are passed to a CheckBox filter have spaces in between them and this is due to the fact that the _name_ here (which is the filter name) is sometimes of the form _In progress_ or _`Thesis and dissertation`_ and we would have an id eventually such as _clickable-select-filter-In Progress_ which is not selectable in our tests.

- Using Kebab case here would change it to _clickable-select-filter-in-progress_. This PR fixes this for a checkBox filter. But this also means that existing tests might break which are already using these filter Ids as selectors. 