### PR TITLE
Retain search query when returning to search and sort app. Part of STSMACOM-232.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 2.9.0 (IN PROGRESS)
+
+# Retain search query when returning to search and sort app. Part of STSMACOM-232.
+
 ## [2.8.0](https://github.com/folio-org/stripes-smart-components/tree/v2.8.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.2...v2.8.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -14,6 +14,7 @@ import {
   get,
   upperFirst,
   noop,
+  isEmpty,
 } from 'lodash';
 
 import FilterGroups, {
@@ -600,7 +601,8 @@ class SearchAndSort extends React.Component {
     const initialFilters = this.initialFilters || '';
     const currentFilters = this.queryParam('filters') || '';
     const noFiltersChoosen = currentFilters === initialFilters;
-    const searchTermFieldIsEmpty = this.state.locallyChangedSearchTerm.length === 0;
+    const currentQuery = this.queryParam('query');
+    const searchTermFieldIsEmpty = isEmpty(this.state.locallyChangedSearchTerm || currentQuery);
 
     return noFiltersChoosen && searchTermFieldIsEmpty;
   }
@@ -841,9 +843,7 @@ class SearchAndSort extends React.Component {
 
     const filters = filterState(this.queryParam('filters'));
     const query = this.queryParam('query') || '';
-    const searchTerm = (locallyChangedSearchTerm !== undefined)
-      ? locallyChangedSearchTerm
-      : query;
+    const searchTerm = locallyChangedSearchTerm || query;
 
     return (
       <form onSubmit={this.onSubmitSearch}>


### PR DESCRIPTION
It looks like the `locallyChangedSearchTerm` can be also an empty string (not just `undefined`). This PR adjusts couple conditions to make sure the issue in  STSMACOM-232 is solved.

https://issues.folio.org/browse/STSMACOM-232