### PR TITLE
STSMACOM-236: add possibility to hide assign button on notes accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Retain search query when returning to search and sort app. Part of STSMACOM-232.
 * Reset results when search field is cleared out manually. Fixes STCOM-549.
+* Add possibility to hide assign button on notes accordion. Refs STSMACOM-236
 
 ## [2.8.0](https://github.com/folio-org/stripes-smart-components/tree/v2.8.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.2...v2.8.0)

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -37,6 +37,7 @@ class NotesSmartAccordion extends Component {
     entityId: PropTypes.string.isRequired,
     entityName: PropTypes.string.isRequired,
     entityType: PropTypes.string.isRequired,
+    hideAssignButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     mutator: PropTypes.object.isRequired,
@@ -243,6 +244,7 @@ class NotesSmartAccordion extends Component {
       onToggle,
       open,
       id,
+      hideAssignButton,
     } = this.props;
 
     return (
@@ -262,6 +264,7 @@ class NotesSmartAccordion extends Component {
           fetchDomainNotes={this.fetchDomainNotes}
           id={id}
           open={open}
+          hideAssignButton={hideAssignButton}
           onToggle={onToggle}
         />
       </IfPermission>

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -50,6 +50,10 @@ class NotesSmartAccordion extends Component {
     }).isRequired,
   }
 
+  static defaultProps = {
+    hideAssignButton: false,
+  };
+
   static manifest = Object.freeze({
     assignedNotes: {
       type: 'okapi',

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -19,6 +19,7 @@ import styles from './NotesAccordion.css';
 
 export default class NotesAccordion extends Component {
   static propTypes = {
+    hideAssignButton: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onAssignedNoteClick: PropTypes.func.isRequired,
     onNoteCreateButtonClick: PropTypes.func.isRequired,
@@ -51,16 +52,20 @@ export default class NotesAccordion extends Component {
   };
 
   renderHeaderButtons() {
+    const { hideAssignButton } = this.props;
+
     return (
       <Fragment>
-        <IfPermission perm="ui-notes.item.assign-unassign">
-          <Button
-            onClick={this.onAssignButtonClick}
-            data-test-notes-accordion-assign-button
-          >
-            <FormattedMessage id="stripes-smart-components.assign" />
-          </Button>
-        </IfPermission>
+        {!hideAssignButton && (
+          <IfPermission perm="ui-notes.item.assign-unassign">
+            <Button
+              onClick={this.onAssignButtonClick}
+              data-test-notes-accordion-assign-button
+            >
+              <FormattedMessage id="stripes-smart-components.assign" />
+            </Button>
+          </IfPermission>
+        )}
         <IfPermission perm="ui-notes.item.create">
           <Button
             buttonClass={styles['new-button']}

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -29,6 +29,10 @@ export default class NotesAccordion extends Component {
     open: PropTypes.bool,
   };
 
+  static defaultProps = {
+    hideAssignButton: false,
+  };
+
   state = { modalIsOpen: false };
 
   onCloseModal = () => {


### PR DESCRIPTION
In some cases, libraries may want to hide to assign button on the notes accordion. I've added a `hideAssignButton` prop to NotesSmartAccordion which makes it possible to do it.