### PR TITLE
UIORGS-79 Hide route for New record if no permission

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -55,6 +55,23 @@ import buildUrl from './buildUrl';
 
 import css from './SearchAndSort.css';
 
+const NO_PERMISSION_NODE = (
+  <div
+    style={{
+      position: 'absolute',
+      right: '1rem',
+      bottom: '1rem',
+      width: '34%',
+      zIndex: '9999',
+      padding: '1rem',
+      backgroundColor: '#fff',
+    }}
+  >
+    <h2><FormattedMessage id="stripes-smart-components.permissionError" /></h2>
+    <p><FormattedMessage id="stripes-smart-components.permissionsDoNotAllowAccess" /></p>
+  </div>
+);
+
 class SearchAndSort extends React.Component {
   static propTypes = {
     actionMenu: PropTypes.func, // parameter properties provided by caller
@@ -781,22 +798,7 @@ class SearchAndSort extends React.Component {
       );
     }
 
-    return (
-      <div
-        style={{
-          position: 'absolute',
-          right: '1rem',
-          bottom: '1rem',
-          width: '34%',
-          zIndex: '9999',
-          padding: '1rem',
-          backgroundColor: '#fff',
-        }}
-      >
-        <h2><FormattedMessage id="stripes-smart-components.permissionError" /></h2>
-        <p><FormattedMessage id="stripes-smart-components.permissionsDoNotAllowAccess" /></p>
-      </div>
-    );
+    return NO_PERMISSION_NODE;
   }
 
   renderCreateRecordLayer(source) {
@@ -810,6 +812,8 @@ class SearchAndSort extends React.Component {
       location,
       stripes,
       objectName,
+      disableRecordCreation,
+      newRecordPerms,
     } = this.props;
 
     if (browseOnly || !editRecordComponent) {
@@ -820,25 +824,29 @@ class SearchAndSort extends React.Component {
     const isOpen = urlQuery.layer ? urlQuery.layer === 'create' : false;
     const EditRecordComponent = editRecordComponent;
 
-    return (
-      <IntlConsumer>
-        {intl => (
-          <Layer isOpen={isOpen} contentLabel={intl.formatMessage({ id: 'stripes-smart-components.sas.createEntry' })}>
-            <EditRecordComponent
-              stripes={stripes}
-              id={`${objectName}form-add${objectName}`}
-              initialValues={newRecordInitialValues}
-              connectedSource={source}
-              parentResources={parentResources}
-              parentMutator={parentMutator}
-              onSubmit={record => this.createRecord(record)}
-              onCancel={this.closeNewRecord}
-              {...detailProps}
-            />
-          </Layer>
-        )}
-      </IntlConsumer>
-    );
+    if (!disableRecordCreation && stripes.hasPerm(newRecordPerms)) {
+      return (
+        <IntlConsumer>
+          {intl => (
+            <Layer isOpen={isOpen} contentLabel={intl.formatMessage({ id: 'stripes-smart-components.sas.createEntry' })}>
+              <EditRecordComponent
+                stripes={stripes}
+                id={`${objectName}form-add${objectName}`}
+                initialValues={newRecordInitialValues}
+                connectedSource={source}
+                parentResources={parentResources}
+                parentMutator={parentMutator}
+                onSubmit={record => this.createRecord(record)}
+                onCancel={this.closeNewRecord}
+                {...detailProps}
+              />
+            </Layer>
+          )}
+        </IntlConsumer>
+      );
+    }
+
+    return NO_PERMISSION_NODE;
   }
 
   renderSearch(source) {


### PR DESCRIPTION
Per https://issues.folio.org/browse/UIORGS-79 we need to hide route under Create permission, I think it's the only way to do it in SearchAndSort.
Any comments are welcome, thanks.