### PR TITLE
correctly define EntryManager's PropTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Reset results when search field is cleared out manually. Fixes STCOM-549.
 * Add possibility to hide assign button on notes accordion. Refs STSMACOM-236
 * Bump react-final-form version to 6, consistent with other modules.
+* Correctly describe `<EntryManager>`'s PropTypes to avoid erroneous console warnings.
 
 ## [2.8.0](https://github.com/folio-org/stripes-smart-components/tree/v2.8.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.7.2...v2.8.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -55,15 +55,15 @@ class EntrySelector extends React.Component {
     parentResources: PropTypes.object,
     permissions: PropTypes.object,
     prohibitItemDelete: PropTypes.shape({
-      close: PropTypes.oneOf([
+      close: PropTypes.oneOfType([
         PropTypes.node,
         PropTypes.string,
       ]),
-      label: PropTypes.oneOf([
+      label: PropTypes.oneOfType([
         PropTypes.node,
         PropTypes.string,
       ]),
-      message: PropTypes.oneOf([
+      message: PropTypes.oneOfType([
         PropTypes.node,
         PropTypes.string,
       ]),


### PR DESCRIPTION
Whoops; one-of-type (for arg-types) is not the same as one-of (for
arg-values). Look, ma! No crap in the console!