### PR TITLE
STSMACOM-241: Add tests for notes-smart-accordion

### DIFF
--- a/lib/Notes/NotesSmartAccordion/tests/interactors/index.js
+++ b/lib/Notes/NotesSmartAccordion/tests/interactors/index.js
@@ -1,0 +1,2 @@
+export { default as NotesAccordion } from './notes-accordion';
+export { default as NotesModal } from './notes-modal';

--- a/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
+++ b/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
@@ -1,0 +1,33 @@
+import {
+  interactor,
+  isPresent,
+  clickable,
+  collection,
+  text,
+  isVisible,
+} from '@bigtest/interactor';
+
+@interactor class Button {
+  isDisplayed = isVisible();
+  click = clickable();
+}
+
+@interactor class NotesAccordion {
+  isDisplayed = isPresent('#notes-accordion');
+  assignButtonDisplayed = isPresent('[data-test-notes-accordion-assign-button]');
+  newButtonDisplayed = isPresent('[data-test-notes-accordion-new-button]');
+  clickAssignButton = clickable('[data-test-notes-accordion-assign-button]');
+  clickNewButton = clickable('[data-test-notes-accordion-new-button]');
+
+  newButton = new Button('[data-test-notes-accordion-new-button]');
+  assignButton = new Button('[data-test-notes-accordion-assign-button]');
+
+  notesListDisplayed = isPresent('#notes-list');
+  notes = collection('#notes-list [class^="mclRow"]', {
+    click: clickable(),
+    title: text('[class^="mclCell":last-child]'),
+  });
+}
+
+
+export default NotesAccordion;

--- a/lib/Notes/NotesSmartAccordion/tests/interactors/notes-modal.js
+++ b/lib/Notes/NotesSmartAccordion/tests/interactors/notes-modal.js
@@ -1,0 +1,47 @@
+import {
+  interactor,
+  isPresent,
+  fillable,
+  clickable,
+  collection,
+  is,
+  blurrable,
+  text,
+} from '@bigtest/interactor';
+
+import MultiSelectInteractor from '@folio/stripes-components/lib/MultiSelection/tests/interactor';
+
+class NoteTypeFilter extends MultiSelectInteractor {
+  clear() { return this.click('button[icon="times"]'); }
+}
+
+@interactor class NotesModal {
+  isDisplayed = isPresent('[data-test-notes-modal]');
+  searchButtonIsDisabled = is('[data-test-notes-modal-search-button]', ':disabled');
+  clickSearchButton = clickable('[data-test-notes-modal-search-button]');
+  enterSearchQuery = fillable('[data-test-notes-modal-search-field]');
+  searchQueryText = text('[data-test-notes-modal-search-field]');
+  resetAll = clickable('[data-test-notes-modal-reset-all-button]');
+  blurSearchInput = blurrable('[data-test-notes-modal-search-field]');
+  emptyMessageIsDisplayed = isPresent('[class^="mclEmptyMessage"]');
+  notesListIsDisplayed = isPresent('#notes-modal-notes-list');
+
+  noteTypeFilter = new NoteTypeFilter('#noteTypeSelect');
+  selectAssignedFilter = clickable('[data-test-checkbox-filter-data-option="assigned"');
+  selectUnassignedFilter = clickable('[data-test-checkbox-filter-data-option="unassigned"');
+  clickSaveButton = clickable('[data-test-notes-modal-save-button');
+  clickAssignUnassignAllCheckbox = clickable('#clickable-list-column-assigning input');
+  assignUnassignAllCheckboxIsDisabled = is('#clickable-list-column-assigning input', ':disabled');
+  notes = collection('#notes-modal-notes-list [class^="mclRow---"]', {
+    clickCheckbox: clickable('[class^="mclCell"]:first-child [data-test-notes-modal-assignment-checkbox]'),
+    checkboxIsSelected: is('[class^="mclCell"]:first-child [data-test-notes-modal-assignment-checkbox]', ':checked'),
+    checkboxIsDisabled: is('[class^="mclCell"]:first-child [data-test-notes-modal-assignment-checkbox]', ':disabled'),
+  });
+
+  performSearch(query) {
+    return this.enterSearchQuery(query)
+      .blurSearchInput();
+  }
+}
+
+export default NotesModal;

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -1,7 +1,6 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
 import React from 'react';
 import { expect } from 'chai';
-import { faker } from '@bigtest/mirage';
 
 import NotesSmartAccordion from '../NotesSmartAccordion';
 
@@ -12,58 +11,24 @@ const notesAccordion = new NotesAccordion();
 const notesModal = new NotesModal();
 
 describe('Notes smart accordion', () => {
-  setupApplication();
+  setupApplication({
+    scenarios: ['create-notes-with-note-types']
+  });
 
-  let provider;
-  let generalNoteType;
-  let urgentNoteType;
-  let providerNote;
-
-  beforeEach(function () {
+  beforeEach(async () => {
     const domainName = 'dummy';
 
     // Provider is an example of entity. Any another entity type can be used. e.g. User, Agreement...
-    provider = {
-      id: faker.random.uuid(),
-      name: 'Cool Provider'
-    };
-
-    generalNoteType = this.server.create('note-type', {
-      name: 'General',
-    });
-
-    urgentNoteType = this.server.create('note-type', {
-      name: 'Urgent',
-    });
-
-    providerNote = this.server.create('note', {
-      type: generalNoteType.name,
-      typeId: generalNoteType.id,
-      links: [{ type: 'provider', id: provider.id }],
-    });
-
-    this.server.create('note', {
-      type: generalNoteType.name,
-      typeId: generalNoteType.id,
-      links: [{ type: 'package', id: faker.random.uuid() }],
-    });
-
-    this.server.create('note', {
-      type: urgentNoteType.name,
-      typeId: urgentNoteType.id,
-      links: [{ type: 'package', id: faker.random.uuid() }],
-    });
-
-    mount(
+    await mount(
       <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
         <NotesSmartAccordion
           id="notes-accordion"
           open
           onToggle={() => {}}
           domainName={domainName}
-          entityName={provider.name}
+          entityName="Cool Provider"
           entityType="provider"
-          entityId={provider.id}
+          entityId="providerId"
           pathToNoteCreate={`${domainName}/notes/new`}
           pathToNoteDetails={`${domainName}/notes`}
         />
@@ -75,8 +40,8 @@ describe('Notes smart accordion', () => {
     expect(notesAccordion.isDisplayed).to.be.true;
   });
 
-  it('notes accordion should contain 1 note', () => {
-    expect(notesAccordion.notes().length).to.equal(1);
+  it('notes accordion should contain 2 assigned notes', () => {
+    expect(notesAccordion.notes().length).to.equal(2);
   });
 
   it('should display create note button', () => {
@@ -107,7 +72,7 @@ describe('Notes smart accordion', () => {
     });
 
     it('should redirect to note view page', function () {
-      expect(this.location.pathname + this.location.search).to.equal(`/dummy/notes/${providerNote.id}`);
+      expect(this.location.pathname + this.location.search).to.equal('/dummy/notes/providerNoteId');
     });
   });
 
@@ -140,19 +105,34 @@ describe('Notes smart accordion', () => {
       });
     });
 
+    describe('after click on note assigned to a couple of entities and hitting save', () => {
+      beforeEach(async () => {
+        await notesModal.selectAssignedFilter();
+        await notesModal.notes(1).clickCheckbox();
+        await notesModal.clickSaveButton();
+      });
+
+      it('should unassign it', () => {
+        expect(notesAccordion.notes().length).to.equal(1);
+      });
+    });
+
     describe('after click on "assign/unassign all" checkbox', () => {
       beforeEach(async () => {
         await notesModal.selectAssignedFilter();
         await notesModal.clickAssignUnassignAllCheckbox();
       });
 
-      it('should not allow to unassign notes assigned to only one entity', () => {
+      it('should not allow to uncheck notes assigned to only one entity', () => {
         expect(notesModal.notes(0).checkboxIsSelected).to.be.true;
-        expect(notesModal.assignUnassignAllCheckboxIsDisabled).to.be.true;
+      });
+
+      it('should uncheck notes assigned to more then one entity', () => {
+        expect(notesModal.notes(1).checkboxIsSelected).to.be.false;
       });
     });
 
-    describe('and search box and filters are not empty', () => {
+    describe('and search box and filters were reset', () => {
       beforeEach(async () => {
         await notesModal.enterSearchQuery('some note');
         await wait(300);
@@ -270,7 +250,7 @@ describe('Notes smart accordion', () => {
     });
 
     it('should redirect to note view page', function () {
-      expect(this.location.pathname + this.location.search).to.equal(`/dummy/notes/${providerNote.id}`);
+      expect(this.location.pathname + this.location.search).to.equal('/dummy/notes/providerNoteId');
     });
   });
 });

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -1,0 +1,276 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import React from 'react';
+import { expect } from 'chai';
+import { faker } from '@bigtest/mirage';
+
+import NotesSmartAccordion from '../NotesSmartAccordion';
+
+import { mount, setupApplication, wait } from '../../../../tests/helpers';
+import { NotesAccordion, NotesModal } from './interactors';
+
+const notesAccordion = new NotesAccordion();
+const notesModal = new NotesModal();
+
+describe('Notes smart accordion', () => {
+  setupApplication();
+
+  let provider;
+  let generalNoteType;
+  let urgentNoteType;
+  let providerNote;
+
+  beforeEach(function () {
+    const domainName = 'dummy';
+
+    // Provider is an example of entity. Any another entity type can be used. e.g. User, Agreement...
+    provider = {
+      id: faker.random.uuid(),
+      name: 'Cool Provider'
+    };
+
+    generalNoteType = this.server.create('note-type', {
+      name: 'General',
+    });
+
+    urgentNoteType = this.server.create('note-type', {
+      name: 'Urgent',
+    });
+
+    providerNote = this.server.create('note', {
+      type: generalNoteType.name,
+      typeId: generalNoteType.id,
+      links: [{ type: 'provider', id: provider.id }],
+    });
+
+    this.server.create('note', {
+      type: generalNoteType.name,
+      typeId: generalNoteType.id,
+      links: [{ type: 'package', id: faker.random.uuid() }],
+    });
+
+    this.server.create('note', {
+      type: urgentNoteType.name,
+      typeId: urgentNoteType.id,
+      links: [{ type: 'package', id: faker.random.uuid() }],
+    });
+
+    mount(
+      <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
+        <NotesSmartAccordion
+          id="notes-accordion"
+          open
+          onToggle={() => {}}
+          domainName={domainName}
+          entityName={provider.name}
+          entityType="provider"
+          entityId={provider.id}
+          pathToNoteCreate={`${domainName}/notes/new`}
+          pathToNoteDetails={`${domainName}/notes`}
+        />
+      </div>
+    );
+  });
+
+  it('should display notes accordion', () => {
+    expect(notesAccordion.isDisplayed).to.be.true;
+  });
+
+  it('notes accordion should contain 1 note', () => {
+    expect(notesAccordion.notes().length).to.equal(1);
+  });
+
+  it('should display create note button', () => {
+    expect(notesAccordion.newButtonDisplayed).to.be.true;
+  });
+
+  it('should display assign button', () => {
+    expect(notesAccordion.assignButtonDisplayed).to.be.true;
+  });
+
+  it('should display notes list', () => {
+    expect(notesAccordion.notesListDisplayed).to.be.true;
+  });
+
+  describe('when new button was clicked', () => {
+    beforeEach(async () => {
+      await notesAccordion.newButton.click();
+    });
+
+    it('should redirect to create note page', function () {
+      expect(this.location.pathname).to.equal('/dummy/notes/new');
+    });
+  });
+
+  describe('when a note in the notes list was clicked', () => {
+    beforeEach(async () => {
+      await notesAccordion.notes(0).click();
+    });
+
+    it('should redirect to note view page', function () {
+      expect(this.location.pathname + this.location.search).to.equal(`/dummy/notes/${providerNote.id}`);
+    });
+  });
+
+  describe('when assign button was clicked', () => {
+    beforeEach(async () => {
+      await notesAccordion.assignButton.click();
+    });
+
+    it('should open notes modal', () => {
+      expect(notesModal.isDisplayed).to.be.true;
+    });
+
+    it('should disable search button', () => {
+      expect(notesModal.searchButtonIsDisabled).to.be.true;
+    });
+
+    it('should display empty message', () => {
+      expect(notesModal.emptyMessageIsDisplayed).to.be.true;
+    });
+
+    describe('after click on note assigned to only one entity', () => {
+      beforeEach(async () => {
+        await notesModal.selectAssignedFilter();
+        await notesModal.notes(0).clickCheckbox();
+      });
+
+      it('should not allow to unassign', () => {
+        expect(notesModal.notes(0).checkboxIsDisabled).to.be.true;
+        expect(notesModal.notes(0).checkboxIsSelected).to.be.true;
+      });
+    });
+
+    describe('after click on "assign/unassign all" checkbox', () => {
+      beforeEach(async () => {
+        await notesModal.selectAssignedFilter();
+        await notesModal.clickAssignUnassignAllCheckbox();
+      });
+
+      it('should not allow to unassign notes assigned to only one entity', () => {
+        expect(notesModal.notes(0).checkboxIsSelected).to.be.true;
+        expect(notesModal.assignUnassignAllCheckboxIsDisabled).to.be.true;
+      });
+    });
+
+    describe('and search box and filters are not empty', () => {
+      beforeEach(async () => {
+        await notesModal.enterSearchQuery('some note');
+        await wait(300);
+        await notesModal.noteTypeFilter.options(1).clickOption();
+        await notesModal.selectUnassignedFilter();
+        await notesModal.resetAll();
+      });
+
+      it('should reset search box and all filters', () => {
+        expect(notesModal.searchQueryText).to.have.lengthOf(0);
+      });
+    });
+
+    describe('and "Urgent" note type was selected', () => {
+      beforeEach(async () => {
+        await notesModal.noteTypeFilter.options(1).clickOption();
+      });
+
+      it('notes list should contain 1 note', () => {
+        expect(notesModal.notes().length).to.equal(1);
+      });
+
+      describe('and note type filter was cleared', () => {
+        beforeEach(async () => {
+          await notesModal.noteTypeFilter.clear();
+        });
+
+        it('should display empty message', () => {
+          expect(notesModal.emptyMessageIsDisplayed).to.be.true;
+        });
+      });
+    });
+
+    describe('and search query was entered', () => {
+      beforeEach(async () => {
+        await notesModal.enterSearchQuery('some note');
+        await wait(300);
+      });
+
+      it('should enable search button', () => {
+        expect(notesModal.searchButtonIsDisabled).to.be.false;
+      });
+
+      describe('and the search button was clicked', () => {
+        beforeEach(async () => {
+          await notesModal.clickSearchButton();
+        });
+
+        it('should display notes list', () => {
+          expect(notesModal.notesListIsDisplayed).to.be.true;
+        });
+      });
+
+      describe('and unassigned filter was selected', () => {
+        beforeEach(async () => {
+          await notesModal.selectUnassignedFilter();
+        });
+
+        it('notes list should contain 2 notes', () => {
+          expect(notesModal.notes().length).to.equal(2);
+        });
+
+        it('notes list should display only unselected notes', () => {
+          expect(notesModal.notes(0).checkboxIsSelected).to.be.false;
+          expect(notesModal.notes(1).checkboxIsSelected).to.be.false;
+        });
+
+        describe('and the first note in the list was checked', () => {
+          beforeEach(async () => {
+            await notesModal.notes(0).clickCheckbox();
+          });
+
+          describe('and save button was clicked', () => {
+            beforeEach(async () => {
+              await notesModal.clickSaveButton();
+            });
+
+            it('should close notes modal', () => {
+              expect(notesModal.isDisplayed).to.be.false;
+            });
+
+            it('notes accordion should contain 2 notes', () => {
+              expect(notesAccordion.notes().length).to.equal(2);
+            });
+          });
+        });
+
+        describe('and "assign all" checkbox is clicked', () => {
+          beforeEach(async () => {
+            await notesModal.clickAssignUnassignAllCheckbox();
+          });
+
+          it('should mark as assigned all notes in the list', () => {
+            expect(notesModal.notes(0).checkboxIsSelected).to.be.true;
+            expect(notesModal.notes(1).checkboxIsSelected).to.be.true;
+          });
+
+          describe('and save button was clicked', () => {
+            beforeEach(async () => {
+              await notesModal.clickSaveButton();
+            });
+
+            it('should close notes modal', () => {
+              expect(notesModal.isDisplayed).to.be.false;
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('when a note in the notes list was clicked', () => {
+    beforeEach(async () => {
+      await notesAccordion.notes(0).click();
+    });
+
+    it('should redirect to note view page', function () {
+      expect(this.location.pathname + this.location.search).to.equal(`/dummy/notes/${providerNote.id}`);
+    });
+  });
+});

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -499,6 +499,7 @@ export default class NotesAssigningModal extends React.Component {
               }
             >
               <MultiSelectionFilter
+                id="noteTypeSelect"
                 name="noteTypes"
                 selectedValues={selectedNoteTypeFilters}
                 dataOptions={this.getNoteTypeOptions()}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -44,3 +44,5 @@ export function mount(component) {
     module: () => component
   }]);
 }
+
+export const wait = (ms = 1000) => new Promise(resolve => { setTimeout(resolve, ms); });

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -1,3 +1,62 @@
 // typical mirage config export
 export default function config() {
+  // okapi endpoints
+  this.get('/note-types');
+
+  this.get('/note-links/domain/dummy/type/:type/id/:id', ({ notes }, { params, queryParams }) => {
+    return notes.where((note) => {
+      const conditions = [];
+
+      if (queryParams.noteType) {
+        conditions.push(note.type === queryParams.noteType);
+      }
+
+      switch (queryParams.status) {
+        case 'assigned': {
+          conditions.push(note.links.some(link => {
+            return link.type === params.type && link.id === params.id;
+          }));
+
+          break;
+        }
+        case 'unassigned': {
+          conditions.push(note.links.every(link => {
+            return link.type !== params.type || link.id !== params.id;
+          }));
+
+          break;
+        }
+        default: {
+          conditions.push(true);
+        }
+      }
+
+      return conditions.every(cond => !!cond);
+    });
+  });
+
+  this.put('/note-links/type/:type/id/:id', ({ notes }, { params, requestBody }) => {
+    const body = JSON.parse(requestBody);
+
+    body.notes.forEach((note) => {
+      const dbNote = notes.find(note.id);
+      const links = [...dbNote.links];
+
+      if (note.status === 'ASSIGNED') {
+        links.push({
+          id: params.id,
+          type: params.type,
+        });
+      } else {
+        for (let i = 0; i < links.length; i++) {
+          if (links[i].type === params.type && links[i].id === params.id) {
+            links.splice(i, 1);
+            break;
+          }
+        }
+      }
+
+      dbNote.update({ links });
+    });
+  });
 }

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -31,7 +31,7 @@ export default function config() {
         }
       }
 
-      return conditions.every(cond => !!cond);
+      return conditions.every(condition => !!condition);
     });
   });
 

--- a/tests/network/factories/note-type.js
+++ b/tests/network/factories/note-type.js
@@ -1,0 +1,16 @@
+import { Factory, faker } from '@bigtest/mirage';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  name: () => faker.commerce.productName(),
+  metadata: {
+    createdByUserId: () => faker.random.uuid(),
+    createdByUsername: () => faker.name.firstName(),
+    createdDate: () => faker.date.past(2),
+    updatedByUserId: () => faker.random.uuid(),
+    updatedDate: () => faker.date.past(1),
+  },
+  usage: {
+    noteTotal: 0
+  },
+});

--- a/tests/network/factories/note.js
+++ b/tests/network/factories/note.js
@@ -1,0 +1,22 @@
+import { Factory, faker } from '@bigtest/mirage';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  title: () => faker.commerce.productName(),
+  type: null,
+  typeId: null,
+  domain: 'dummy',
+  content: faker.lorem.paragraph(),
+  creator: {
+    lastName: faker.name.lastName(),
+    firstName: faker.name.firstName()
+  },
+  metadata: {
+    createdDate: () => faker.date.past(2),
+    createdByUserId: () => faker.random.uuid(),
+    createdByUsername: () => faker.name.firstName(),
+    updatedByUserId: () => faker.random.uuid(),
+    updatedDate: () => faker.date.past(1),
+  },
+  links: [],
+});

--- a/tests/network/models/note-type.js
+++ b/tests/network/models/note-type.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/tests/network/models/note.js
+++ b/tests/network/models/note.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend();

--- a/tests/network/scenarios/create-notes-with-note-types.js
+++ b/tests/network/scenarios/create-notes-with-note-types.js
@@ -1,0 +1,44 @@
+import { faker } from '@bigtest/mirage';
+
+export default function (server) {
+  const provider = {
+    id: 'providerId',
+    name: 'Cool Provider'
+  };
+
+  const generalNoteType = server.create('note-type', {
+    name: 'General',
+  });
+
+  const urgentNoteType = server.create('note-type', {
+    name: 'Urgent',
+  });
+
+  server.create('note', {
+    type: generalNoteType.name,
+    typeId: generalNoteType.id,
+    id: 'providerNoteId',
+    links: [{ type: 'provider', id: provider.id }],
+  });
+
+  server.create('note', {
+    type: generalNoteType.name,
+    typeId: generalNoteType.id,
+    links: [{ type: 'package', id: faker.random.uuid() }],
+  });
+
+  server.create('note', {
+    type: generalNoteType.name,
+    typeId: generalNoteType.id,
+    links: [
+      { type: 'package', id: faker.random.uuid() },
+      { type: 'provider', id: provider.id },
+    ],
+  });
+
+  server.create('note', {
+    type: urgentNoteType.name,
+    typeId: urgentNoteType.id,
+    links: [{ type: 'package', id: faker.random.uuid() }],
+  });
+}

--- a/tests/network/serializers/note-type.js
+++ b/tests/network/serializers/note-type.js
@@ -1,0 +1,17 @@
+import { JSONAPISerializer } from '@bigtest/mirage';
+
+export default JSONAPISerializer.extend({
+  serialize(db) {
+    return db.models
+      ? db.models.reduce((response, noteType) => {
+        return {
+          noteTypes: [
+            ...response.noteTypes,
+            { ...noteType.attrs },
+          ],
+          totalRecords: ++response.totalRecords
+        };
+      }, { noteTypes: [], totalRecords: 0 })
+      : db.attrs;
+  }
+});

--- a/tests/network/serializers/note.js
+++ b/tests/network/serializers/note.js
@@ -1,0 +1,17 @@
+import { JSONAPISerializer } from '@bigtest/mirage';
+
+export default JSONAPISerializer.extend({
+  serialize(notes) {
+    return notes.models
+      ? notes.models.reduce((response, note) => {
+        return {
+          notes: [
+            ...response.notes,
+            { ...note.attrs },
+          ],
+          totalRecords: ++response.totalRecords
+        };
+      }, { notes: [], totalRecords: 0 })
+      : notes.attrs;
+  }
+});


### PR DESCRIPTION
## Purpose
For now testing for Notes is implemented in each app using it. Adding new functionality causes adding the same tests in every application. In this PR, tests for internal Notes accordion stuff is extracted and placed near NotesSmartAccordion component.

## TODO 
Clean up tests in ui-eholdings, ui-users, ui-agreements apps. Leave only stuff for testing integration of the notes accordion into an app.