### PR TITLE
UIOR-345 common ui-plugin-find-* component based on `SearchAndSortQuery`

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,4 +62,4 @@ export { default as NoteViewPage } from './lib/Notes/NoteViewPage';
 export { default as NoteEditPage } from './lib/Notes/NoteEditPage';
 export { default as NotesSmartAccordion } from './lib/Notes/NotesSmartAccordion';
 
-export * from './lib/PluginFindRecord';
+export { PluginFindRecord, PluginFindRecordModal } from './lib/PluginFindRecord';

--- a/index.js
+++ b/index.js
@@ -61,3 +61,5 @@ export { default as NoteCreatePage } from './lib/Notes/NoteCreatePage';
 export { default as NoteViewPage } from './lib/Notes/NoteViewPage';
 export { default as NoteEditPage } from './lib/Notes/NoteEditPage';
 export { default as NotesSmartAccordion } from './lib/Notes/NotesSmartAccordion';
+
+export * from './lib/PluginFindRecord';

--- a/lib/PluginFindRecord/Filters.js
+++ b/lib/PluginFindRecord/Filters.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { FilterGroups } from '@folio/stripes-components';
+
+const Filters = ({
+  activeFilters,
+  onChangeHandlers: { checkbox, clearGroup },
+  config,
+}) => {
+  const groupFilters = {};
+
+  activeFilters.string.split(',').forEach(m => { groupFilters[m] = true; });
+
+  return (
+    <FilterGroups
+      config={config}
+      filters={groupFilters}
+      onChangeFilter={checkbox}
+      onClearFilter={clearGroup}
+    />
+  );
+};
+
+Filters.propTypes = {
+  activeFilters: PropTypes.object,
+  config: PropTypes.arrayOf(PropTypes.object),
+  onChangeHandlers: PropTypes.object.isRequired,
+};
+
+Filters.defaultProps = {
+  activeFilters: {},
+};
+
+export default Filters;

--- a/lib/PluginFindRecord/PluginFindRecord.css
+++ b/lib/PluginFindRecord/PluginFindRecord.css
@@ -1,0 +1,12 @@
+.searchControl {
+  margin-top: 8px;
+  display: flex;
+
+  &.marginBottom0 {
+    margin-bottom: 0;
+  }
+
+  &.marginTop0 {
+    margin-top: 0;
+  }
+}

--- a/lib/PluginFindRecord/PluginFindRecord.js
+++ b/lib/PluginFindRecord/PluginFindRecord.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import className from 'classnames';
+import noop from 'lodash/noop';
+
+import { Button } from '@folio/stripes-components';
+
+import css from './PluginFindRecord.css';
+
+class PluginFindRecord extends React.Component {
+  state = {
+    openModal: false,
+  }
+
+  getStyle() {
+    const { marginBottom0, marginTop0 } = this.props;
+
+    return className(
+      css.searchControl,
+      { [css.marginBottom0]: marginBottom0 },
+      { [css.marginTop0]: marginTop0 },
+    );
+  }
+
+  openModal = () => this.setState({
+    openModal: true,
+  });
+
+  closeModal = () => this.setState({
+    openModal: false,
+  });
+
+  passRecordsOut = records => {
+    this.props.selectRecordsCb(records);
+    this.closeModal();
+  }
+
+  passRecordOut = (e, record) => {
+    this.passRecordsOut([record]);
+  }
+
+  render() {
+    const {
+      children,
+      disabled,
+      searchButtonStyle,
+      searchLabel,
+    } = this.props;
+
+    return (
+      <div className={this.getStyle()}>
+        <Button
+          data-test-plugin-find-record-button
+          buttonStyle={searchButtonStyle}
+          disabled={disabled}
+          key="searchButton"
+          onClick={this.openModal}
+        >
+          {searchLabel}
+        </Button>
+        {this.state.openModal && children({
+          onSaveMultiple: this.passRecordsOut,
+          onSelectRow: this.passRecordOut,
+          closeModal: this.closeModal,
+        })}
+      </div>
+    );
+  }
+}
+
+PluginFindRecord.propTypes = {
+  children: PropTypes.func,
+  disabled: PropTypes.bool,
+  marginBottom0: PropTypes.bool,
+  marginTop0: PropTypes.bool,
+  searchButtonStyle: PropTypes.string,
+  searchLabel: PropTypes.node.isRequired,
+  selectRecordsCb: PropTypes.func,
+};
+
+PluginFindRecord.defaultProps = {
+  disabled: false,
+  marginBottom0: true,
+  marginTop0: true,
+  searchButtonStyle: 'primary',
+  selectRecordsCb: noop,
+};
+
+export default PluginFindRecord;

--- a/lib/PluginFindRecord/PluginFindRecord.js
+++ b/lib/PluginFindRecord/PluginFindRecord.js
@@ -3,9 +3,14 @@ import PropTypes from 'prop-types';
 import className from 'classnames';
 import noop from 'lodash/noop';
 
-import { Button } from '@folio/stripes-components';
+import {
+  Button,
+  Icon,
+} from '@folio/stripes-components';
 
 import css from './PluginFindRecord.css';
+
+const triggerId = 'find-record-trigger';
 
 class PluginFindRecord extends React.Component {
   state = {
@@ -39,25 +44,42 @@ class PluginFindRecord extends React.Component {
     this.passRecordsOut([record]);
   }
 
-  render() {
+  renderDefaultTrigger() {
+    const { disabled, searchButtonStyle, searchLabel } = this.props;
+
+    return (
+      <Button
+        buttonStyle={searchButtonStyle}
+        data-test-plugin-find-record-button
+        disabled={disabled}
+        id={triggerId}
+        key="searchButton"
+        onClick={this.openModal}
+      >
+        {searchLabel}
+      </Button>
+    );
+  }
+
+  renderTriggerButton() {
     const {
-      children,
-      disabled,
-      searchButtonStyle,
-      searchLabel,
+      renderTrigger,
     } = this.props;
+
+    return renderTrigger
+      ? renderTrigger({
+        id: triggerId,
+        onClick: this.openModal,
+      })
+      : this.renderDefaultTrigger();
+  }
+
+  render() {
+    const { children } = this.props;
 
     return (
       <div className={this.getStyle()}>
-        <Button
-          data-test-plugin-find-record-button
-          buttonStyle={searchButtonStyle}
-          disabled={disabled}
-          key="searchButton"
-          onClick={this.openModal}
-        >
-          {searchLabel}
-        </Button>
+        {this.renderTriggerButton()}
         {this.state.openModal && children({
           onSaveMultiple: this.passRecordsOut,
           onSelectRow: this.passRecordOut,
@@ -73,8 +95,9 @@ PluginFindRecord.propTypes = {
   disabled: PropTypes.bool,
   marginBottom0: PropTypes.bool,
   marginTop0: PropTypes.bool,
+  renderTrigger: PropTypes.func,
   searchButtonStyle: PropTypes.string,
-  searchLabel: PropTypes.node.isRequired,
+  searchLabel: PropTypes.node,
   selectRecordsCb: PropTypes.func,
 };
 
@@ -84,6 +107,7 @@ PluginFindRecord.defaultProps = {
   marginTop0: true,
   searchButtonStyle: 'primary',
   selectRecordsCb: noop,
+  searchLabel: <Icon icon="search" color="#fff" />,
 };
 
 export default PluginFindRecord;

--- a/lib/PluginFindRecord/PluginFindRecordModal.css
+++ b/lib/PluginFindRecord/PluginFindRecordModal.css
@@ -1,0 +1,61 @@
+@import "@folio/stripes-components/lib/variables";
+
+.searchField {
+  margin-bottom: calc(var(--control-margin-bottom) / 2);
+}
+
+/* reset button wrap - minor alignment adjustment */
+.resetButtonWrap {
+  & [disabled] :global .stripes__icon {
+    fill: rgba(0, 0, 0, 0.62);
+  }
+
+  &.resetButton {
+    border-color: rgba(0, 0, 0, 0.62);
+    color: rgba(0, 0, 0, 0.62);
+  }
+}
+
+.searchGroupWrap {
+  margin-bottom: 0.5rem;
+}
+
+.showButtonsBar {
+  & [class^="paneset--"] {
+    height: calc(100% - 50px);
+  }
+}
+
+.pluginModalFooter {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.pluginModalContent {
+  min-height: 400px;
+  padding: 0;
+  position: relative;
+
+  & [class^="paneset--"] {
+    height: 390px;
+  }
+
+  & [class^="mclRowContainer--"] {
+    max-width: 100%;
+
+    & div {
+      max-width: 100%;
+    }
+
+    & [class^="mclCell--"] {
+      word-break: break-word;
+    }
+  }
+
+  & .pluginModalNewBtnWrapper {
+    position: absolute;
+    right: 10px;
+    top: 8px;
+  }
+}

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -278,6 +278,7 @@ class PluginFindRecordModal extends React.Component {
                               marginBottom0
                               name="query"
                               onChange={getSearchHandlers().query}
+                              onClear={getSearchHandlers().reset}
                               value={searchValue.query}
                             />
                             <Button

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -121,6 +121,14 @@ class PluginFindRecordModal extends React.Component {
     });
   }
 
+  onRowClick = (e, row) => {
+    const { isMultiSelect, onSelectRow } = this.props;
+
+    if (!isMultiSelect) {
+      onSelectRow(e, row);
+    }
+  }
+
   render() {
     const {
       closeModal,
@@ -134,7 +142,6 @@ class PluginFindRecordModal extends React.Component {
       modalLabel,
       onComponentWillUnmount,
       onNeedMoreData,
-      onSelectRow,
       queryGetter,
       querySetter,
       renderFilters,
@@ -344,9 +351,10 @@ class PluginFindRecordModal extends React.Component {
                         formatter={mixedResultsFormatter}
                         id="list-plugin-find-records"
                         isEmptyMessage={resultsStatusMessage}
+                        key={`checkedRecordsLength_${checkedRecordsLength}`}
                         onHeaderClick={onSort}
                         onNeedMoreData={onNeedMoreData}
-                        onRowClick={!isMultiSelect && onSelectRow}
+                        onRowClick={this.onRowClick}
                         sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
                         sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
                         totalCount={count}

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -121,12 +121,6 @@ class PluginFindRecordModal extends React.Component {
     });
   }
 
-  saveMultiple = () => {
-    const selectedRecords = Object.values(pickBy(this.state.checkedMap));
-
-    this.props.onSaveMultiple(selectedRecords);
-  };
-
   render() {
     const {
       closeModal,

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -67,10 +67,10 @@ class PluginFindRecordModal extends React.Component {
             <FormattedMessage id={hideOrShowMessageId}>
               {hideOrShowMessage => (
                 <FilterPaneToggle
-                  visible={filterPaneIsVisible}
                   aria-label={`${hideOrShowMessage} \n\n${appliedFiltersMessage}`}
-                  onClick={this.toggleFilterPane}
                   badge={!filterPaneIsVisible && filterCount ? filterCount : undefined}
+                  onClick={this.toggleFilterPane}
+                  visible={filterPaneIsVisible}
                 />
               )}
             </FormattedMessage>
@@ -157,9 +157,9 @@ class PluginFindRecordModal extends React.Component {
         <div data-test-find-records-no-results-message>
           <NoResultsMessage
             data-test-find-records-no-results-message
-            source={source}
-            searchTerm={query.query || ''}
             filterPaneIsVisible
+            searchTerm={query.query || ''}
+            source={source}
             toggleFilterPane={noop}
           />
         </div>
@@ -201,11 +201,11 @@ class PluginFindRecordModal extends React.Component {
               />
             </div>
             <Button
-              marginBottom0
-              data-test-find-records-modal-save
-              onClick={this.saveMultiple}
-              disabled={!checkedRecordsLength}
               buttonStyle="primary"
+              data-test-find-records-modal-save
+              disabled={!checkedRecordsLength}
+              marginBottom0
+              onClick={this.saveMultiple}
             >
               <FormattedMessage id="stripes-smart-components.pfr.button.save" />
             </Button>
@@ -216,16 +216,16 @@ class PluginFindRecordModal extends React.Component {
 
     return (
       <Modal
+        contentClass={css.pluginModalContent}
         data-test-find-records-modal
         dismissible
         enforceFocus={false}
+        footer={footer}
         label={modalLabel}
         onClose={closeModal}
         open
-        contentClass={css.pluginModalContent}
-        style={{ minHeight: '500px' }}
         size="large"
-        footer={footer}
+        style={{ minHeight: '500px' }}
       >
         <div className={css.pluginModalNewBtnWrapper}>
           {renderNewBtn()}
@@ -235,24 +235,24 @@ class PluginFindRecordModal extends React.Component {
           className={isMultiSelect ? css.showButtonsBar : ''}
         >
           <SearchAndSortQuery
-            querySetter={querySetter}
-            queryGetter={queryGetter}
-            onComponentWillUnmount={onComponentWillUnmount}
             initialSearch={initialSearch}
             initialSearchState={{ qindex: '', query: '' }}
+            onComponentWillUnmount={onComponentWillUnmount}
+            queryGetter={queryGetter}
+            querySetter={querySetter}
             syncToLocationSearch={false}
           >
             {
               ({
-                searchValue,
-                getSearchHandlers,
-                onSubmitSearch,
-                onSort,
-                getFilterHandlers,
                 activeFilters,
                 filterChanged,
-                searchChanged,
+                getFilterHandlers,
+                getSearchHandlers,
+                onSort,
+                onSubmitSearch,
                 resetAll,
+                searchChanged,
+                searchValue,
               }) => {
                 const disableReset = () => {
                   if (filterChanged || searchChanged) {
@@ -318,17 +318,14 @@ class PluginFindRecordModal extends React.Component {
                       </Pane>
                     }
                     <Pane
-                      firstMenu={this.renderResultsFirstMenu(activeFilters)}
-                      paneTitle={RESULTS_HEADER}
-                      paneSub={resultPaneSub}
                       defaultWidth="fill"
+                      firstMenu={this.renderResultsFirstMenu(activeFilters)}
                       padContent={false}
+                      paneSub={resultPaneSub}
+                      paneTitle={RESULTS_HEADER}
                     >
                       <MultiColumnList
-                        visibleColumns={builtVisibleColumns}
-                        contentData={records}
-                        totalCount={count}
-                        id="list-plugin-find-records"
+                        autosize
                         columnMapping={{
                           isChecked: (
                             <Checkbox
@@ -341,16 +338,19 @@ class PluginFindRecordModal extends React.Component {
                           ...columnMapping,
 
                         }}
-                        formatter={mixedResultsFormatter}
-                        onRowClick={!isMultiSelect && onSelectRow}
-                        onNeedMoreData={onNeedMoreData}
-                        onHeaderClick={onSort}
-                        sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
-                        sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
-                        isEmptyMessage={resultsStatusMessage}
-                        autosize
-                        virtualize
                         columnWidths={columnWidths}
+                        contentData={records}
+                        formatter={mixedResultsFormatter}
+                        id="list-plugin-find-records"
+                        isEmptyMessage={resultsStatusMessage}
+                        onHeaderClick={onSort}
+                        onNeedMoreData={onNeedMoreData}
+                        onRowClick={!isMultiSelect && onSelectRow}
+                        sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
+                        sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
+                        totalCount={count}
+                        virtualize
+                        visibleColumns={builtVisibleColumns}
                       />
                     </Pane>
                   </Paneset>

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -1,0 +1,396 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import noop from 'lodash/noop';
+import pickBy from 'lodash/pickBy';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Checkbox,
+  Icon,
+  Modal,
+  MultiColumnList,
+  Pane,
+  PaneMenu,
+  Paneset,
+  SearchField,
+} from '@folio/stripes-components';
+
+import { SearchAndSortQuery } from '../SearchAndSort';
+import NoResultsMessage from '../SearchAndSort/components/NoResultsMessage';
+import FilterPaneToggle from '../SearchAndSort/components/SearchButton';
+import Filters from './Filters';
+import css from './PluginFindRecordModal.css';
+
+const RESULTS_HEADER = <FormattedMessage id="stripes-smart-components.pfr.resultsHeader" />;
+
+const reduceCheckedRecords = (records, isChecked = false) => {
+  const recordsReducer = (accumulator, record) => {
+    if (isChecked) {
+      accumulator[record.id] = record;
+    }
+
+    return accumulator;
+  };
+
+  return records.reduce(recordsReducer, {});
+};
+
+class PluginFindRecordModal extends React.Component {
+  state = {
+    filterPaneIsVisible: true,
+    checkedMap: {},
+    isAllChecked: false,
+  }
+
+  toggleFilterPane = () => {
+    this.setState(curState => ({
+      filterPaneIsVisible: !curState.filterPaneIsVisible,
+    }));
+  }
+
+  renderResultsFirstMenu(filters) {
+    const { filterPaneIsVisible } = this.state;
+
+    const filterCount = filters.string !== '' ? filters.string.split(',').length : 0;
+    const hideOrShowMessageId = filterPaneIsVisible
+      ? 'stripes-smart-components.hideSearchPane'
+      : 'stripes-smart-components.showSearchPane';
+
+    return (
+      <PaneMenu>
+        <FormattedMessage
+          id="stripes-smart-components.numberOfFilters"
+          values={{ count: filterCount }}
+        >
+          {appliedFiltersMessage => (
+            <FormattedMessage id={hideOrShowMessageId}>
+              {hideOrShowMessage => (
+                <FilterPaneToggle
+                  visible={filterPaneIsVisible}
+                  aria-label={`${hideOrShowMessage} \n\n${appliedFiltersMessage}`}
+                  onClick={this.toggleFilterPane}
+                  badge={!filterPaneIsVisible && filterCount ? filterCount : undefined}
+                />
+              )}
+            </FormattedMessage>
+          )}
+        </FormattedMessage>
+      </PaneMenu>
+    );
+  }
+
+  saveMultiple = () => {
+    const selectedRecords = Object.values(pickBy(this.state.checkedMap));
+
+    this.props.onSaveMultiple(selectedRecords);
+  };
+
+  toggleAll = () => {
+    this.setState((state, props) => {
+      const isAllChecked = !state.isAllChecked;
+      const { data: { records } } = props;
+      const checkedMap = reduceCheckedRecords(records, isAllChecked);
+
+      return {
+        checkedMap,
+        isAllChecked,
+      };
+    });
+  }
+
+  toggleRecord = toggledRecord => {
+    const { id } = toggledRecord;
+
+    this.setState((state, props) => {
+      const { data: { records } } = props;
+      const wasChecked = Boolean(state.checkedMap[id]);
+      const checkedMap = { ...state.checkedMap };
+
+      if (wasChecked) {
+        delete checkedMap[id];
+      } else {
+        checkedMap[id] = toggledRecord;
+      }
+      const isAllChecked = records.every(record => Boolean(checkedMap[record.id]));
+
+      return {
+        checkedMap,
+        isAllChecked,
+      };
+    });
+  }
+
+  saveMultiple = () => {
+    const selectedRecords = Object.values(pickBy(this.state.checkedMap));
+
+    this.props.onSaveMultiple(selectedRecords);
+  };
+
+  render() {
+    const {
+      closeModal,
+      columnMapping,
+      columnWidths,
+      data,
+      filterConfig,
+      idPrefix,
+      initialSearch,
+      isMultiSelect,
+      modalLabel,
+      onComponentWillUnmount,
+      onNeedMoreData,
+      onSelectRow,
+      queryGetter,
+      querySetter,
+      renderNewBtn,
+      resultsFormatter,
+      source,
+      visibleColumns,
+    } = this.props;
+    const { checkedMap, isAllChecked } = this.state;
+
+    const { records } = data;
+    const checkedRecordsLength = Object.keys(checkedMap).length;
+    const builtVisibleColumns = isMultiSelect ? ['isChecked', ...visibleColumns] : visibleColumns;
+
+    const query = queryGetter ? queryGetter() || {} : {};
+    const count = source ? source.totalCount() : 0;
+    const sortOrder = query.sort || '';
+    const resultsStatusMessage = source
+      ? (
+        <div data-test-find-records-no-results-message>
+          <NoResultsMessage
+            data-test-find-records-no-results-message
+            source={source}
+            searchTerm={query.query || ''}
+            filterPaneIsVisible
+            toggleFilterPane={noop}
+          />
+        </div>
+      )
+      : <FormattedMessage id="stripes-smart-components.pfr.noSourceYet" />;
+
+    let resultPaneSub = <FormattedMessage id="stripes-smart-components.searchCriteria" />;
+
+    if (source && source.loaded()) {
+      resultPaneSub = <FormattedMessage id="stripes-smart-components.searchResultsCountHeader" values={{ count }} />;
+    }
+
+    const mixedResultsFormatter = {
+      isChecked: record => (
+        <Checkbox
+          type="checkbox"
+          checked={Boolean(checkedMap[record.id])}
+          onChange={() => this.toggleRecord(record)}
+        />
+      ),
+      ...resultsFormatter,
+    };
+
+    const footer = isMultiSelect && (
+      <div className={css.pluginModalFooter}>
+        <Button
+          marginBottom0
+          onClick={closeModal}
+          className="left"
+        >
+          <FormattedMessage id="stripes-smart-components.pfr.button.close" />
+        </Button>
+        <div>
+          <FormattedMessage
+            id="stripes-smart-components.pfr.totalSelected"
+            values={{ count: checkedRecordsLength }}
+          />
+        </div>
+        <Button
+          marginBottom0
+          data-test-find-records-modal-save
+          onClick={this.saveMultiple}
+          disabled={!checkedRecordsLength}
+          buttonStyle="primary"
+        >
+          <FormattedMessage id="stripes-smart-components.pfr.button.save" />
+        </Button>
+      </div>
+    );
+
+    return (
+      <Modal
+        data-test-find-records-modal
+        dismissible
+        enforceFocus={false}
+        label={modalLabel}
+        onClose={closeModal}
+        open
+        contentClass={css.pluginModalContent}
+        style={{ minHeight: '500px' }}
+        size="large"
+        footer={footer}
+      >
+        <div className={css.pluginModalNewBtnWrapper}>
+          {renderNewBtn()}
+        </div>
+        <div
+          data-test-find-records
+          className={isMultiSelect ? css.showButtonsBar : ''}
+        >
+          <SearchAndSortQuery
+            querySetter={querySetter}
+            queryGetter={queryGetter}
+            onComponentWillUnmount={onComponentWillUnmount}
+            initialSearch={initialSearch}
+            initialSearchState={{ qindex: '', query: '' }}
+            syncToLocationSearch={false}
+          >
+            {
+              ({
+                searchValue,
+                getSearchHandlers,
+                onSubmitSearch,
+                onSort,
+                getFilterHandlers,
+                activeFilters,
+                filterChanged,
+                searchChanged,
+                resetAll,
+              }) => {
+                const disableReset = () => {
+                  if (filterChanged || searchChanged) {
+                    return false;
+                  }
+
+                  return true;
+                };
+
+                return (
+                  <Paneset id={`${idPrefix}-paneset`}>
+                    {this.state.filterPaneIsVisible &&
+                      <Pane
+                        defaultWidth="22%"
+                        paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
+                      >
+                        <form onSubmit={onSubmitSearch}>
+                          <div className={css.searchGroupWrap}>
+                            <SearchField
+                              autoFocus
+                              className={css.searchField}
+                              data-test-plugin-search-input
+                              marginBottom0
+                              name="query"
+                              onChange={getSearchHandlers().query}
+                              value={searchValue.query}
+                            />
+                            <Button
+                              buttonStyle="primary"
+                              data-test-plugin-search-submit
+                              disabled={(!searchValue.query || searchValue.query === '')}
+                              fullWidth
+                              marginBottom0
+                              type="submit"
+                            >
+                              <FormattedMessage id="stripes-smart-components.search" />
+                            </Button>
+                          </div>
+                          <div className={css.resetButtonWrap}>
+                            <Button
+                              buttonStyle="none"
+                              disabled={disableReset()}
+                              fullWidth
+                              id="clickable-reset-all"
+                              onClick={resetAll}
+                            >
+                              <Icon icon="times-circle-solid">
+                                <FormattedMessage id="stripes-smart-components.resetAll" />
+                              </Icon>
+                            </Button>
+                          </div>
+                          <Filters
+                            activeFilters={activeFilters}
+                            config={filterConfig}
+                            onChangeHandlers={getFilterHandlers()}
+                          />
+                        </form>
+                      </Pane>
+                    }
+                    <Pane
+                      firstMenu={this.renderResultsFirstMenu(activeFilters)}
+                      paneTitle={RESULTS_HEADER}
+                      paneSub={resultPaneSub}
+                      defaultWidth="fill"
+                      padContent={false}
+                    >
+                      <MultiColumnList
+                        visibleColumns={builtVisibleColumns}
+                        contentData={records}
+                        totalCount={count}
+                        id="list-plugin-find-records"
+                        columnMapping={{
+                          isChecked: (
+                            <Checkbox
+                              checked={isAllChecked}
+                              data-test-find-records-modal-select-all
+                              onChange={this.toggleAll}
+                              type="checkbox"
+                            />
+                          ),
+                          ...columnMapping,
+
+                        }}
+                        formatter={mixedResultsFormatter}
+                        onRowClick={!isMultiSelect && onSelectRow}
+                        onNeedMoreData={onNeedMoreData}
+                        onHeaderClick={onSort}
+                        sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
+                        sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
+                        isEmptyMessage={resultsStatusMessage}
+                        autosize
+                        virtualize
+                        columnWidths={columnWidths}
+                      />
+                    </Pane>
+                  </Paneset>
+                );
+              }}
+          </SearchAndSortQuery>
+        </div>
+      </Modal>
+    );
+  }
+}
+
+PluginFindRecordModal.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+  columnMapping: PropTypes.object,
+  columnWidths: PropTypes.object,
+  data: PropTypes.object,
+  filterConfig: PropTypes.arrayOf(PropTypes.object),
+  idPrefix: PropTypes.string.isRequired,
+  initialSearch: PropTypes.string,
+  isMultiSelect: PropTypes.bool.isRequired,
+  modalLabel: PropTypes.node,
+  onComponentWillUnmount: PropTypes.func,
+  onNeedMoreData: PropTypes.func,
+  onSaveMultiple: PropTypes.func,
+  onSelectRow: PropTypes.func,
+  queryGetter: PropTypes.func,
+  querySetter: PropTypes.func,
+  renderNewBtn: PropTypes.func,
+  resultsFormatter: PropTypes.object,
+  source: PropTypes.object,
+  visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+PluginFindRecordModal.defaultProps = {
+  columnMapping: {},
+  columnWidths: {},
+  data: {},
+  filterConfig: [],
+  initialSearch: '',
+  modalLabel: '',
+  onSaveMultiple: noop,
+  renderNewBtn: noop,
+  resultsFormatter: {},
+};
+
+export default PluginFindRecordModal;

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import noop from 'lodash/noop';
 import pickBy from 'lodash/pickBy';
@@ -137,6 +137,7 @@ class PluginFindRecordModal extends React.Component {
       onSelectRow,
       queryGetter,
       querySetter,
+      renderFilters,
       renderNewBtn,
       resultsFormatter,
       source,
@@ -182,7 +183,7 @@ class PluginFindRecordModal extends React.Component {
       ...resultsFormatter,
     };
 
-    const footer = isMultiSelect && (
+    const footer = (
       <div className={css.pluginModalFooter}>
         <Button
           marginBottom0
@@ -191,21 +192,25 @@ class PluginFindRecordModal extends React.Component {
         >
           <FormattedMessage id="stripes-smart-components.pfr.button.close" />
         </Button>
-        <div>
-          <FormattedMessage
-            id="stripes-smart-components.pfr.totalSelected"
-            values={{ count: checkedRecordsLength }}
-          />
-        </div>
-        <Button
-          marginBottom0
-          data-test-find-records-modal-save
-          onClick={this.saveMultiple}
-          disabled={!checkedRecordsLength}
-          buttonStyle="primary"
-        >
-          <FormattedMessage id="stripes-smart-components.pfr.button.save" />
-        </Button>
+        {isMultiSelect && (
+          <Fragment>
+            <div>
+              <FormattedMessage
+                id="stripes-smart-components.pfr.totalSelected"
+                values={{ count: checkedRecordsLength }}
+              />
+            </div>
+            <Button
+              marginBottom0
+              data-test-find-records-modal-save
+              onClick={this.saveMultiple}
+              disabled={!checkedRecordsLength}
+              buttonStyle="primary"
+            >
+              <FormattedMessage id="stripes-smart-components.pfr.button.save" />
+            </Button>
+          </Fragment>
+        )}
       </div>
     );
 
@@ -299,11 +304,16 @@ class PluginFindRecordModal extends React.Component {
                               </Icon>
                             </Button>
                           </div>
-                          <Filters
-                            activeFilters={activeFilters}
-                            config={filterConfig}
-                            onChangeHandlers={getFilterHandlers()}
-                          />
+                          {renderFilters
+                            ? renderFilters(activeFilters.state, getFilterHandlers())
+                            : (
+                              <Filters
+                                activeFilters={activeFilters}
+                                config={filterConfig}
+                                onChangeHandlers={getFilterHandlers()}
+                              />
+                            )
+                          }
                         </form>
                       </Pane>
                     }
@@ -369,6 +379,7 @@ PluginFindRecordModal.propTypes = {
   onSelectRow: PropTypes.func,
   queryGetter: PropTypes.func,
   querySetter: PropTypes.func,
+  renderFilters: PropTypes.func,
   renderNewBtn: PropTypes.func,
   resultsFormatter: PropTypes.object,
   source: PropTypes.object,

--- a/lib/PluginFindRecord/index.js
+++ b/lib/PluginFindRecord/index.js
@@ -1,0 +1,2 @@
+export { default as PluginFindRecordModal } from './PluginFindRecordModal';
+export { default as PluginFindRecord } from './PluginFindRecord';

--- a/lib/PluginFindRecord/readme.md
+++ b/lib/PluginFindRecord/readme.md
@@ -1,0 +1,55 @@
+# PluginFindRecord
+
+## Introduction
+
+To reduce copy-paste code in ui-plugin-find-* repos were created common components, PluginFindRecord and PluginFindRecordModal. They are based on ui-plugin-find-user code and use SearchAndSortQuery pattern instead of importing list components directly from repos (ui-users, ui-inventory, etc.).
+Since we have a lot of such plugins (ui-plugin-find-contact, ui-plugin-find-interface, etc.) we've put that common code inside stripes-smart-components.
+
+## Usage
+
+The following code shows how use the component:
+```javascript
+const FindPOLine = ({ addLines, isSingleSelect, ...rest }) => (
+  <PluginFindRecord
+    {...rest}
+    selectRecordsCb={addLines}
+  >
+    {(modalProps) => (
+      <FindPOLineContainer>
+        {(viewProps) => (
+          <PluginFindRecordModal
+            {...viewProps}
+            {...modalProps}
+            isMultiSelect={!isSingleSelect}
+          />
+        )}
+      </FindPOLineContainer>
+    )}
+  </PluginFindRecord>
+);
+```
+## Props of `PluginFindRecord`
+
+| Name | Type | Description | Required | Default |
+--- | --- | --- | --- | --- |
+| `renderTrigger` | function | render function of plugin's button (replaces `searchLabel` and `disabled`) | No | |
+| `selectRecordsCb` | function | Callback with selected array of records | No | `noop` |
+
+### Trigger button props
+
+If you don't use `renderTrigger` prop from above, you can provide some properties to the default plugin trigger button:
+
+| Name | Type | Description | Required | Default |
+--- | --- | --- | --- | --- |
+| `disabled` | boolean | Flag to control `disabled` property of plugin's button, since it's rendered inside the plugin | No | `false` |
+| `searchButtonStyle` | string | optional styling of plugin's button | No | `'primary'` |
+| `searchLabel` | React.node | jsx or string for plugin's button label | No | `<Icon icon="search" color="#fff" />` |
+| `marginBottom0` | boolean | Flag to control css style to remove bottom margin for trigger button | No | `true` |
+| `marginTop0` | boolean | Flag to control css style to remove top margin for trigger button | No | `true` |
+
+## Props of `PluginFindRecordModal`
+
+| Name | Type | Description | Required | Default |
+--- | --- | --- | --- | --- |
+| `isMultiSelect` | boolean | show checkboxes and make possible to select multiple records in plugin | Yes | |
+| `renderNewBtn` | function | render function to display button on the top of the results list, like `New` | No | `noop` |

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -69,6 +69,12 @@
   "sas.noResults.loading": "Loading…",
   "sas.createEntry": "Create entry",
 
+  "pfr.button.close": "Close",
+  "pfr.button.save": "Save",
+  "pfr.noSourceYet": "No source yet",
+  "pfr.resultsHeader": "Search results",
+  "pfr.totalSelected": "Total selected: {count}",
+
   "closeEntryDialog": "Close entry dialog",
   "editOrDeleteNote": "Edit or delete this note",
   "cancelEdit": "Cancel edit",


### PR DESCRIPTION
To reduce copy-paste code in ui-plugin-find-* repos were created common components, `PluginFindRecord` and `PluginFindRecordModal`. They are based on `ui-plugin-find-user` code and use `SearchAndSortQuery` pattern instead of importing list components directly from repos (ui-users, ui-inventory, etc.). 
Since we have a lot of such plugins (ui-plugin-find-contact, ui-plugin-find-interface, etc.) we've put that common code inside stripes-acq-components. However, it could be placed in stripes-smart-components repo, to be available for any module.
https://github.com/folio-org/stripes-acq-components/tree/master/lib/PluginFindRecord
https://issues.folio.org/browse/UIOR-345