### PR TITLE
STSMACOM-252: Remove width params from notes list

### DIFF
--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -4,6 +4,7 @@ import {
   FormattedMessage,
   FormattedDate,
 } from 'react-intl';
+import { isUndefined } from 'lodash';
 
 import { MultiColumnList } from '@folio/stripes-components';
 
@@ -11,17 +12,14 @@ const defaultColumnsConfig = [
   {
     name: 'date',
     title: <FormattedMessage id="stripes-smart-components.date" />,
-    width: '20%',
   },
   {
     name: 'title',
     title: <FormattedMessage id="stripes-smart-components.title" />,
-    width: '40%',
   },
   {
     name: 'type',
     title: <FormattedMessage id="stripes-smart-components.type" />,
-    width: '40%',
   },
 ];
 
@@ -35,7 +33,7 @@ const noteShape = PropTypes.shape({
 const columnsConfigShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
   title: PropTypes.node.isRequired,
-  width: PropTypes.string.isRequired,
+  width: PropTypes.string,
 });
 
 export default class NotesList extends React.Component {
@@ -94,13 +92,18 @@ export default class NotesList extends React.Component {
       }, {});
   }
 
+  /* eslint-disable consistent-return */
   getColumnWidths() {
+    if (this.props.columnsConfig.every(column => isUndefined(column.width))) return;
+
     return this.props.columnsConfig
       .reduce((columnsWidths, { name, width }) => {
-        columnsWidths[name] = width;
+        if (width) { columnsWidths[name] = width; }
+
         return columnsWidths;
       }, {});
   }
+  /* eslint-enable consistent-return */
 
   render() {
     const {


### PR DESCRIPTION
## Purpose
Remove width default params defined in percents to adjust columns width according to content

## Screenshots
before
<img width="828" alt="Снимок экрана 2019-10-04 в 15 55 21" src="https://user-images.githubusercontent.com/43621626/66209148-6c340000-e6bf-11e9-9a69-742ce75e5fc4.png">

after
<img width="828" alt="Снимок экрана 2019-10-04 в 15 54 40" src="https://user-images.githubusercontent.com/43621626/66209156-6f2ef080-e6bf-11e9-99d6-bcb399dec62f.png">
