### PR TITLE
STCOM-605: Add editor preview style class to Notes

### DIFF
--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -263,6 +263,7 @@ export default class NoteView extends Component {
                       label={<FormattedMessage id="stripes-smart-components.details" />}
                     >
                       <div
+                        className="editor-preview"
                         data-test-note-view-note-details
                         dangerouslySetInnerHTML={noteContentMarkup}
                       />


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-605

## Purpose
Apply style global class to remove margins between lines for Notes description section on preview mode