### PR TITLE
UIF-115 When you access the app the focus should be in the Search box

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -869,6 +869,7 @@ class SearchAndSort extends React.Component {
           {ariaLabel => (
             <SearchField
               id={`input-${objectName}-search`}
+              autoFocus
               ariaLabel={ariaLabel}
               className={css.searchField}
               searchableIndexes={searchableIndexes}


### PR DESCRIPTION
purpose:
https://issues.folio.org/browse/UIF-115
search box should be autofocused

approach:
`autoFocus` prop for `SearchField` component