### PR TITLE
Don't debounce on mount.

### DIFF
--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -223,7 +223,7 @@ class SearchAndSortQuery extends React.Component {
 
   componentDidMount() {
     if (this.props.syncToLocationSearch && Object.keys(this.state.searchFields).length > 0) {
-      this.onSubmitAll();
+      this.onSubmitAll(null, false);
     }
   }
 
@@ -320,7 +320,7 @@ class SearchAndSortQuery extends React.Component {
     });
   }
 
-  onSubmitAll = (e) => {
+  onSubmitAll = (e, dbounce = true) => {
     if (e) {
       e.preventDefault();
       e.stopPropagation();
@@ -335,7 +335,13 @@ class SearchAndSortQuery extends React.Component {
     // convert filters to params (similar to this.applyFilters())
     const filterParams = this.props.filtersToParams(filterFields);
 
-    this.performSearch({ ...searchFields, ...filterParams, ...sortFields });
+    const params = { ...searchFields, ...filterParams, ...sortFields };
+
+    if (dbounce) {
+      this.performSearch(params);
+    } else {
+      this.transitionToParams(params);
+    }
   }
 
   onSubmitSearch = (e) => {

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -223,7 +223,7 @@ class SearchAndSortQuery extends React.Component {
 
   componentDidMount() {
     if (this.props.syncToLocationSearch && Object.keys(this.state.searchFields).length > 0) {
-      this.onSubmitAll(null, false);
+      this.onSubmitAll(false);
     }
   }
 
@@ -320,12 +320,7 @@ class SearchAndSortQuery extends React.Component {
     });
   }
 
-  onSubmitAll = (e, dbounce = true) => {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-
+  onSubmitAll = (dbounce = true) => {
     const {
       searchFields,
       filterFields,
@@ -338,9 +333,9 @@ class SearchAndSortQuery extends React.Component {
     const params = { ...searchFields, ...filterParams, ...sortFields };
 
     if (dbounce) {
-      this.performSearch(params);
+      this.debouncedCallQuerySetter(params);
     } else {
-      this.transitionToParams(params);
+      this.callQuerySetter(params);
     }
   }
 
@@ -350,13 +345,13 @@ class SearchAndSortQuery extends React.Component {
       e.stopPropagation();
     }
 
-    this.performSearch(this.state.searchFields);
+    this.debouncedCallQuerySetter(this.state.searchFields);
   };
 
   // eslint-disable-next-line react/sort-comp
-  performSearch = debounce((searchFields) => {
+  debouncedCallQuerySetter = debounce((searchFields) => {
     // this.log('action', `searched for '${searchFields}'`);
-    this.transitionToParams({ ...searchFields });
+    this.callQuerySetter({ ...searchFields });
   }, 350);
 
   onClearSearchFields = () => {
@@ -444,10 +439,10 @@ class SearchAndSortQuery extends React.Component {
     const sortOrder = orders.slice(0, maxSortKeys).join(',');
 
     // this.log('action', `sorted by ${sortOrder}`);
-    this.transitionToParams({ sort: sortOrder });
+    this.callQuerySetter({ sort: sortOrder });
   };
 
-  transitionToParams = values => {
+  callQuerySetter = values => {
     const {
       location,
       history,
@@ -589,7 +584,7 @@ class SearchAndSortQuery extends React.Component {
     // packs it into an object with a "filters" key.
     // This behavior is overridden with the filtersToParams prop.
     const paramObject = this.props.filtersToParams(activeFilters);
-    this.transitionToParams(paramObject);
+    this.callQuerySetter(paramObject);
   }
 
   getActiveFilterState = () => {


### PR DESCRIPTION
SASQ uses a debounced call to update the search query in its `componentDidMount` lifecycle. This can be problematic in unit-tests as it could cause the correct url for filter/search/etc to be overwritten by the default URL once the debounce lands.

console before: 
```
componentDidMount - submitAll()
push url: https://localhost:3000/users?filters=active.inactive   // test clicks a filter
push url: https://localhost:3000/users?sort=Name    //default url applies when debounce lands. test fails!
```
console after:
```
componentDidMount - submitAll()
push url: https://localhost:3000/users?sort=Name
push url: https://localhost:3000/users?filters=active.inactive   // test success since filter stays put.
```

Additionally, mild cleanup work within the component... renamed internal methods `transitionToParams` to `callQuerySetter` and
`performSearch` to `debouncedCallQuerySetter`