### PR TITLE
STSMACOM-256 - The Settings component does not scale. The result is data are jumping around

### DIFF
--- a/lib/EditableList/EditableList.css
+++ b/lib/EditableList/EditableList.css
@@ -18,7 +18,6 @@
   background-color: #efefef;
   margin-bottom: 4px;
   min-height: 40px;
-  flex-wrap: wrap;
 }
 
 .baselineListRow {


### PR DESCRIPTION
# Purpose
To fix scaling issue for EditableList smart component

# Link
https://issues.folio.org/browse/STSMACOM-256

# Approach
Remove flex-wrap property to prevent moving data to another position

# Screenshot
<img width="1350" alt="Screen Shot 2019-10-17 at 3 12 02 PM" src="https://user-images.githubusercontent.com/43472449/67007632-81ae1e80-f0f0-11e9-9533-8651ed871f26.png">

