### PR TITLE
EAF passes through on lack of values.personal.

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -160,7 +160,7 @@ class EmbeddedAddressForm extends React.Component {
           if (fieldName === 'addressType') {
             const list = omitUsedOptions(
               mergedFieldComponents[fieldName].props.dataOptions,
-              values.personal.addresses,
+              values.personal ? values.personal.addresses : [],
               'addressType',
               fieldKey,
             );


### PR DESCRIPTION
## Purpose
Context changes happen. In a blink, redux-form context will go from a containing a fully populated user to merely `sponsors` or some other less important field than the very important `values.personal`... 

## Approach
If no `values.personal` field is available on context, simply use an empty array rather than error out on trying to reach `values.personal.addresses`.