### PR TITLE
Fix locallyChangedSearchTerm. Refs UIIN-758

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## [2.12.0] (IN PROGRESS)
+
+* Update `locallyChangedSearchTerm` only when query from resourceQuery matches query param from URL. Refs UUIN-758.
+
 ## [2.11.0](https://github.com/folio-org/stripes-smart-components/tree/v2.11.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.10.0...v2.11.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.11.0](https://github.com/folio-org/stripes-smart-components/tree/v2.11.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.10.0...v2.11.0)
 
-* Better handling of server errors in `<ControlledVocab>`. STSMACOM-227. 
+* Better handling of server errors in `<ControlledVocab>`. STSMACOM-227.
 
 ## [2.10.0](https://github.com/folio-org/stripes-smart-components/tree/v2.10.0) (2019-09-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.9.0...v2.10.0)
@@ -12,7 +12,7 @@
 * Prevent multiple clicks on `<ControlledVocab>`'s `New` button. STCOM-539
 * Centralize `<Notes>` tests instead of distributing them across all implementing apps. Refs STSMACOM-241.
 * Move expand/collapse filter-pane button into the filter-pane itself. STSMACOM-233
-* Pass correct prop to `<AddressFieldGroup>` translation. 
+* Pass correct prop to `<AddressFieldGroup>` translation.
 * Suppress Okapi error related to reference constraint violations. ERM-390
 * Allow suppression of sort for some column headers. Refs UIOR-292
 * Use `rowUpdater` prop for `MultiColumnList` in `EditableList, ControlledVocab, ChangeDueDateDialog`. Refs STCOM-363

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -239,20 +239,7 @@ class SearchAndSort extends React.Component {
   }
 
   componentDidMount() {
-    const {
-      location: {
-        search,
-      },
-      browseOnly,
-    } = this.props;
-    const resQuery = this.queryParam('query');
-    const { query } = queryString.parse(search);
-
-    // update locallyChangedSearchTerm only
-    // when query from resourceQuery matches url query
-    const term = (browseOnly && resQuery === query) ? query : '';
-
-    this.setState({ locallyChangedSearchTerm: term });
+    this.updateLocallyChangedSearchTerm();
   }
 
   componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated
@@ -312,6 +299,23 @@ class SearchAndSort extends React.Component {
       query.replace(this.initialQuery);
     }
     onComponentWillUnmount(this.props);
+  }
+
+  updateLocallyChangedSearchTerm() {
+    const {
+      location: {
+        search,
+      },
+      browseOnly,
+    } = this.props;
+    const resQuery = this.queryParam('query');
+    const { query } = queryString.parse(search);
+
+    // update locallyChangedSearchTerm only
+    // when query from resourceQuery matches url query
+    const term = (browseOnly && resQuery === query) ? query : '';
+
+    this.setState({ locallyChangedSearchTerm: term });
   }
 
   get initiallySelectedRecord() {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -239,10 +239,20 @@ class SearchAndSort extends React.Component {
   }
 
   componentDidMount() {
-    const query = this.queryParam('query');
-    this.setState({
-      locallyChangedSearchTerm: query
-    });
+    const {
+      location: {
+        search,
+      },
+      browseOnly,
+    } = this.props;
+    const resQuery = this.queryParam('query');
+    const { query } = queryString.parse(search);
+
+    // update locallyChangedSearchTerm only
+    // when query from resourceQuery matches url query
+    const term = (browseOnly && resQuery === query) ? query : '';
+
+    this.setState({ locallyChangedSearchTerm: term });
   }
 
   componentWillReceiveProps(nextProps) {  // eslint-disable-line react/no-deprecated


### PR DESCRIPTION
I noticed this issue when switching between different search segments in ui-inventory and ui-orders. After performing search on the first segment and switching to another segment the search field would get repopulated with the value form the previous segment.

When a query resource is defined (it's configured via manifest) on multiple components (in the same ui package) its values get cached and are accessible between the components.

This PR doesn't populate locallyChangedSearchTerm if the query value from the query resource doesn't match the current query param in the url.