### PR TITLE
UIU-1293: Retrieve up to 100k of requested user loans instead of 10 in change due date dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.12.0] (IN PROGRESS)
 
 * Update `locallyChangedSearchTerm` only when query from resourceQuery matches query param from URL. Refs UUIN-758.
+* Retrieve up to 100k of requested user loans instead of 10 in change due date dialog. Refs UIU-1293.
 
 ## [2.11.0](https://github.com/folio-org/stripes-smart-components/tree/v2.11.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.10.0...v2.11.0)

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -35,7 +35,7 @@ class ChangeDueDateDialog extends React.Component {
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)',
+      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=100000',
       throwErrors: false,
       accumulate: true,
       PUT: {


### PR DESCRIPTION
## Purposes 
Retrieve up to 100k of requested user loans instead of 10 in change due date dialog to fix the [issue](https://issues.folio.org/browse/UIU-1293).

## Screenshots

![more_than_10_items_in_dialog](https://user-images.githubusercontent.com/50317804/68209887-08159c00-ffdd-11e9-9463-ef51ab520d4a.png)
