### PR TITLE
STSMACOM-245: fix hidden quill tooltip on note form

### DIFF
--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -293,35 +293,36 @@ export default class NoteForm extends Component {
                   <Paneset>
                     <Pane
                       lastMenu={this.renderExpandAllButton()}
-                      defaultWidth="50%"
-                      className={styles['note-form-content']}
+                      defaultWidth="fill"
                     >
-                      <Accordion
-                        label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
-                        id="noteForm"
-                        open={noteForm}
-                        separator={false}
-                        onToggle={this.handleSectionToggle}
-                      >
-                        {isEditForm && this.renderNoteMetadata()}
-                        <NoteFields
-                          noteTypes={this.sortedNoteTypes}
-                          detailsEditorRef={this.detailsEditorRef}
-                        />
-                      </Accordion>
-                      <Accordion
-                        label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
-                        id="assigned"
-                        open={assigned}
-                        closedByDefault
-                        onToggle={this.handleSectionToggle}
-                      >
-                        {referredEntityData && this.renderReferredRecord()}
-                        <AssignmentsList
-                          links={links}
-                          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
-                        />
-                      </Accordion>
+                      <div className={styles['note-form-content']}>
+                        <Accordion
+                          label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
+                          id="noteForm"
+                          open={noteForm}
+                          separator={false}
+                          onToggle={this.handleSectionToggle}
+                        >
+                          {isEditForm && this.renderNoteMetadata()}
+                          <NoteFields
+                            noteTypes={this.sortedNoteTypes}
+                            detailsEditorRef={this.detailsEditorRef}
+                          />
+                        </Accordion>
+                        <Accordion
+                          label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
+                          id="assigned"
+                          open={assigned}
+                          closedByDefault
+                          onToggle={this.handleSectionToggle}
+                        >
+                          {referredEntityData && this.renderReferredRecord()}
+                          <AssignmentsList
+                            links={links}
+                            entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+                          />
+                        </Accordion>
+                      </div>
                     </Pane>
                   </Paneset>
                 </Pane>


### PR DESCRIPTION
The `NoteForm` markup was slightly adjusted to make the quill URL pop-up always fully visible

## Before
![image](https://user-images.githubusercontent.com/43514877/68402836-a001ba00-0184-11ea-82c3-e921d9c29fe1.png)

## After
![image](https://user-images.githubusercontent.com/43514877/68402884-b871d480-0184-11ea-8244-573eb06642f5.png)
