### PR TITLE
STSMACOM-260: avoid fetching note types when user has no corresponding permissions

### DIFF
--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -80,6 +80,8 @@ class NotesSmartAccordion extends Component {
     },
     noteTypes: {
       type: 'okapi',
+      accumulate: true,
+      fetch: false,
       GET: {
         path: 'note-types',
         params: {
@@ -100,6 +102,7 @@ class NotesSmartAccordion extends Component {
   componentDidMount() {
     if (this.props.stripes.hasPerm('ui-notes.item.view')) {
       this.props.mutator.assignedNotes.GET();
+      this.props.mutator.noteTypes.GET();
     }
   }
 

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -58,6 +58,7 @@ class NotesSmartAccordion extends Component {
     assignedNotes: {
       type: 'okapi',
       accumulate: true,
+      fetch: false,
       path: PATH,
       GET: {
         params: {


### PR DESCRIPTION
Currently, when a user doesn't have the permission to GET note types, a request for note types is still made.  In this PR, I'm GETting note types only if the user has `ui-notes.item.view` permission, which has `note.types.collection.get` as a child permission. 