### PR TITLE
STSMACOM-270: Refactor notes form to use paneFooter component

### DIFF
--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -13,10 +13,10 @@ import {
   Row,
   Col,
   MetaSection,
-  Icon,
   IconButton,
   Button,
   Callout,
+  PaneFooter,
 } from '@folio/stripes-components';
 
 import NoteFields from './components/NoteFields';
@@ -108,6 +108,46 @@ export default class NoteForm extends Component {
     });
   }
 
+  renderPaneFooter(handleSubmit, pristine) {
+    const {
+      navigateBack,
+      submitIsPending,
+    } = this.props;
+
+    const noteTypesExist = this.areNoteTypesPresent();
+    const startButton = (
+      <Button
+        data-test-cancel-editing-note-form
+        buttonStyle="default mega"
+        id="clickable-cancel"
+        marginBottom0
+        onClick={navigateBack}
+      >
+        <FormattedMessage id="stripes-components.cancel" />
+      </Button>
+    );
+
+    const endButton = (
+      <Button
+        buttonStyle="primary mega"
+        data-test-save-note
+        disabled={pristine || submitIsPending || !noteTypesExist}
+        marginBottom0
+        onClick={handleSubmit}
+        type="submit"
+      >
+        <FormattedMessage id="stripes-components.saveAndClose" />
+      </Button>
+    );
+
+    return (
+      <PaneFooter
+        renderStart={startButton}
+        renderEnd={endButton}
+      />
+    );
+  }
+
   renderExpandAllButton = () => {
     return (
       <ExpandAllButton
@@ -141,23 +181,6 @@ export default class NoteForm extends Component {
     );
   }
 
-  renderLastMenu = (formIsPristine) => {
-    const { submitIsPending } = this.props;
-    const noteTypesExist = this.areNoteTypesPresent();
-
-    return (
-      <Button
-        type="submit"
-        buttonStyle="primary"
-        marginBottom0
-        disabled={formIsPristine || submitIsPending || !noteTypesExist}
-        data-test-save-note
-      >
-        <FormattedMessage id="stripes-smart-components.notes.saveAndClose" />
-      </Button>
-    );
-  }
-
   renderReferredRecord() {
     const {
       referredEntityData,
@@ -171,27 +194,6 @@ export default class NoteForm extends Component {
       />
     );
   }
-
-  getActionMenu = ({ onToggle }) => {
-    const { navigateBack } = this.props;
-
-    return this.isEditForm() && (
-      <Fragment>
-        <Button
-          buttonStyle="dropdownItem"
-          onClick={() => {
-            navigateBack();
-            onToggle();
-          }}
-          data-test-leave-note-form
-        >
-          <Icon icon="times-circle">
-            <FormattedMessage id="stripes-smart-components.notes.cancel" />
-          </Icon>
-        </Button>
-      </Fragment>
-    );
-  };
 
   isEditForm = () => {
     return !!this.props.noteData;
@@ -284,45 +286,44 @@ export default class NoteForm extends Component {
                 <Pane
                   paneTitle={paneTitle}
                   appIcon={paneTitleAppIcon}
-                  actionMenu={this.getActionMenu}
                   firstMenu={this.renderFirstMenu()}
-                  lastMenu={this.renderLastMenu(pristine)}
                   padContent={false}
                   defaultWidth="100%"
+                  footer={this.renderPaneFooter(handleSubmit, pristine)}
+                  id="notes-form"
                 >
                   <Paneset>
                     <Pane
                       lastMenu={this.renderExpandAllButton()}
-                      defaultWidth="fill"
+                      defaultWidth="50%"
+                      className={styles['note-form-content']}
                     >
-                      <div className={styles['note-form-content']}>
-                        <Accordion
-                          label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
-                          id="noteForm"
-                          open={noteForm}
-                          separator={false}
-                          onToggle={this.handleSectionToggle}
-                        >
-                          {isEditForm && this.renderNoteMetadata()}
-                          <NoteFields
-                            noteTypes={this.sortedNoteTypes}
-                            detailsEditorRef={this.detailsEditorRef}
-                          />
-                        </Accordion>
-                        <Accordion
-                          label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
-                          id="assigned"
-                          open={assigned}
-                          closedByDefault
-                          onToggle={this.handleSectionToggle}
-                        >
-                          {referredEntityData && this.renderReferredRecord()}
-                          <AssignmentsList
-                            links={links}
-                            entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
-                          />
-                        </Accordion>
-                      </div>
+                      <Accordion
+                        label={<FormattedMessage id="stripes-smart-components.notes.generalInformation" />}
+                        id="noteForm"
+                        open={noteForm}
+                        separator={false}
+                        onToggle={this.handleSectionToggle}
+                      >
+                        {isEditForm && this.renderNoteMetadata()}
+                        <NoteFields
+                          noteTypes={this.sortedNoteTypes}
+                          detailsEditorRef={this.detailsEditorRef}
+                        />
+                      </Accordion>
+                      <Accordion
+                        label={<FormattedMessage id="stripes-smart-components.notes.assigned" />}
+                        id="assigned"
+                        open={assigned}
+                        closedByDefault
+                        onToggle={this.handleSectionToggle}
+                      >
+                        {referredEntityData && this.renderReferredRecord()}
+                        <AssignmentsList
+                          links={links}
+                          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+                        />
+                      </Accordion>
                     </Pane>
                   </Paneset>
                 </Pane>

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -115,7 +115,7 @@ export default class NoteForm extends Component {
     } = this.props;
 
     const noteTypesExist = this.areNoteTypesPresent();
-    const startButton = (
+    const cancelButton = (
       <Button
         data-test-cancel-editing-note-form
         buttonStyle="default mega"
@@ -127,7 +127,7 @@ export default class NoteForm extends Component {
       </Button>
     );
 
-    const endButton = (
+    const saveButton = (
       <Button
         buttonStyle="primary mega"
         data-test-save-note
@@ -142,8 +142,8 @@ export default class NoteForm extends Component {
 
     return (
       <PaneFooter
-        renderStart={startButton}
-        renderEnd={endButton}
+        renderStart={cancelButton}
+        renderEnd={saveButton}
       />
     );
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^5.5.0",
-    "fake-xml-http-request": "2.0.0",
     "mocha": "^5.2.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -75,8 +74,5 @@
   },
   "peerDependencies": {
     "react": "*"
-  },
-  "resolutions": {
-    "fake-xml-http-request": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^5.5.0",
+    "fake-xml-http-request": "2.0.0",
     "mocha": "^5.2.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -74,5 +75,8 @@
   },
   "peerDependencies": {
     "react": "*"
+  },
+  "resolutions": {
+    "fake-xml-http-request": "2.0.0"
   }
 }


### PR DESCRIPTION
# Purpose
Move Save button to the bottom of form and display a cancel button
Fo this the new paneFooter component should be applied.

# TODO
The change in the notes form will require changing tests in the modules where notes functionality is integrated and tested, namely: ui-eholdings and ui-users.
 
# Screenshot
![Screen Shot 2019-11-29 at 11 40 56](https://user-images.githubusercontent.com/15856488/69859749-6dd40b80-129d-11ea-937b-850a37444ab4.png)
