### PR TITLE
FOLIO-2369: Handle the issue with tests upon the loading of translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^5.5.0",
+    "fake-xml-http-request": "2.0.0",
     "mocha": "^5.2.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -74,5 +75,8 @@
   },
   "peerDependencies": {
     "react": "*"
+  },
+  "resolutions": {
+    "fake-xml-http-request": "2.0.0"
   }
 }


### PR DESCRIPTION
## Purpose

Handle the issue with tests upon the loading of translations by downgrading the [fake-xml-http-request](https://github.com/pretenderjs/FakeXMLHttpRequest) which updated [recently](https://github.com/pretenderjs/FakeXMLHttpRequest/releases/tag/v2.1.1) in the scope of [FOLIO-2369](https://issues.folio.org/browse/FOLIO-2369).

See: related issue merged PR in  [stripes-core](https://github.com/folio-org/stripes-core/pull/759)