### PR TITLE
UIU-1173: Update en.json in translations

### DIFF
--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -35,7 +35,7 @@
   "feesfines.policy.lost.duplicate": "The Lost item fee policy name entered already exists. Please enter a different name.",
 
   "cv.cannotDeleteTermHeader": "Cannot delete {type}",
-  "cv.cannotDeleteTermMessage": "This {type} cannot be deleted, as it is in use by one or more records.",
+  "cv.cannotDeleteTermMessage": "This {type} cannot be deleted, as it is associated with one or more manual {type} charges.",
   "cv.lastUpdated": "Last updated",
   "cv.updatedAtAndBy": "{date} by {user}",
   "cv.noExistingTerms": "There are no {terms}",


### PR DESCRIPTION
I modified the variable cv.cannotDeleteTermMessage so that it will adapt to the required message of the UIU-1173 issue:

JIRA:
Current message: This Fee/fine owner cannot be deleted, as it is in use by one or more records.
New message: This Fee/fine owner cannot be deleted, as it is associated with one or more manual fee/fine charges.

The other possibility is to create a personalized message through the UI-USERS module so as not to modify this variable cannotDeleteTermMessage

Thank you.