### PR TITLE
STCOM-624: Disable the actions in existing rows when another item is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Keep search term around after browser refresh. Fixes STSMACOM-271.
 * Added integration point for `resultOffset`, which supports `stripes-components` result list "load more" button. Refs STCON-57.
 * Reset `resultCount` and `resultOffset` when sorting. Fixes STSMACOM-269.
+* `<EditableList>`: Disable the actions in existing rows when another item is being created or edited. Refs STCOM-624.
 
 ## [2.12.0](https://github.com/folio-org/stripes-smart-components/tree/v2.12.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.11.0...v2.12.0)

--- a/lib/ControlledVocab/tests/ControlledVocab-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocab-test.js
@@ -6,13 +6,10 @@ import {
   it,
 } from '@bigtest/mocha';
 
-import React from 'react';
 import ControlledVocabInteractor from './interactor';
 import mountComponent from './mountComponent';
 
 import { setupApplication } from '../../../tests/helpers';
-
-import ControlledVocab from '../ControlledVocab';
 
 describe('ControlledVocab', () => {
   const cv = new ControlledVocabInteractor();
@@ -30,6 +27,14 @@ describe('ControlledVocab', () => {
 
       it('should disable New button', () => {
         expect(cv.disabledNewButton).to.be.true;
+      });
+
+      it('should disable Edit button', () => {
+        expect(cv.disabledEditButton).to.be.true;
+      });
+
+      it('should disable Delete button', () => {
+        expect(cv.disabledDeleteButton).to.be.true;
       });
 
       it('should display input field', () => {
@@ -51,6 +56,14 @@ describe('ControlledVocab', () => {
 
         it('should enable New button', () => {
           expect(cv.disabledNewButton).to.be.false;
+        });
+
+        it('should enable Edit button', () => {
+          expect(cv.disabledEditButton).to.be.false;
+        });
+
+        it('should enable Delete button', () => {
+          expect(cv.disabledDeleteButton).to.be.false;
         });
       });
     });
@@ -94,6 +107,14 @@ describe('ControlledVocab', () => {
         expect(cv.disabledNewButton).to.be.true;
       });
 
+      it('should disable Edit button', () => {
+        expect(cv.disabledEditButton).to.be.true;
+      });
+
+      it('should disable Delete button', () => {
+        expect(cv.disabledDeleteButton).to.be.true;
+      });
+
       it('should display input field', () => {
         expect(cv.inputField).to.exist;
       });
@@ -121,6 +142,14 @@ describe('ControlledVocab', () => {
 
         it('should display Edit icon', () => {
           expect(cv.editButton.isPresent).to.be.true;
+        });
+
+        it('should enable Edit button', () => {
+          expect(cv.disabledEditButton).to.be.false;
+        });
+
+        it('should enable Delete button', () => {
+          expect(cv.disabledDeleteButton).to.be.false;
         });
       });
     });

--- a/lib/ControlledVocab/tests/interactor.js
+++ b/lib/ControlledVocab/tests/interactor.js
@@ -26,7 +26,9 @@ export default interactor(class ControlledVocabInteractor {
 
   editButton = new ButtonInteractor('#clickable-edit-institutions-0');
   hasEditButton = isPresent('#clickable-edit-institutions-0');
-  hasDeleteButton = isPresent('#clickable-edit-institutions-0');
+  disabledEditButton = property('#clickable-edit-institutions-1', 'disabled');
+  hasDeleteButton = isPresent('#clickable-delete-institutions-0');
+  disabledDeleteButton = property('#clickable-delete-institutions-1', 'disabled');
   saveButton = clickable('#clickable-save-institutions-0');
   hasSaveButton = isPresent('#clickable-save-institutions-0');
   disabledSaveButton = property('#clickable-save-institutions-0', 'disabled');

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -389,6 +389,8 @@ class EditableListForm extends React.Component {
     } = this.props;
     const { status } = this.state;
 
+    const isEditing = status.some(el => el.editing === true);
+
     if (!editable) {
       return null;
     }
@@ -424,6 +426,7 @@ class EditableListForm extends React.Component {
           <FormattedMessage id="stripes-components.editThisItem">
             {ariaLabel => (
               <IconButton
+                disabled={isEditing}
                 icon="edit"
                 size="small"
                 id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
@@ -438,6 +441,7 @@ class EditableListForm extends React.Component {
           <FormattedMessage id="stripes-components.deleteThisItem">
             {ariaLabel => (
               <IconButton
+                disabled={isEditing}
                 icon="trash"
                 size="small"
                 id={`clickable-delete-${this.testingId}-${item.rowIndex}`}


### PR DESCRIPTION
## Purpose
In `<EditableList>` disable the actions in existing rows when another item is being created or edited. [Story](https://issues.folio.org/browse/STCOM-624).

## Demo
**Before**
![Before](https://user-images.githubusercontent.com/49517355/71979126-9f89ac00-3225-11ea-9fff-996c160bf7b9.gif)

**After**
![After](https://user-images.githubusercontent.com/49517355/71979160-b03a2200-3225-11ea-8b38-9e8537c690a6.gif)
