### PR TITLE
Corrected resultOffset to be defined as optional in propTypes

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -155,7 +155,7 @@ class SearchAndSort extends React.Component {
         replace: PropTypes.func.isRequired,
       }).isRequired,
       resultOffset: PropTypes.shape({
-        replace: PropTypes.func,
+        replace: PropTypes.func.isRequired,
       }),
     }).isRequired, // only needed when GraphQL is used
     parentResources: PropTypes.shape({

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -155,8 +155,8 @@ class SearchAndSort extends React.Component {
         replace: PropTypes.func.isRequired,
       }).isRequired,
       resultOffset: PropTypes.shape({
-        replace: PropTypes.func.isRequired,
-      }).isRequired,
+        replace: PropTypes.func,
+      }),
     }).isRequired, // only needed when GraphQL is used
     parentResources: PropTypes.shape({
       query: PropTypes.shape({


### PR DESCRIPTION
This prevents warnings from displaying in the console for modules that have not opted in to the new "load more" workflow for result lists.