### PR TITLE
STSMACOM-296 bump ControlledVocab limit to 2000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reset `resultCount` and `resultOffset` when sorting. Fixes STSMACOM-269.
 * `<EditableList>`: Disable the actions in existing rows when another item is being created or edited. Refs STCOM-624.
 * Improve accessibility, add attribute `aria-label` to `nav` tag in Settings. Refs UICAL-85.   
+* Bump `<ControlledVocab>` fetch limit to 2000. Refs STSMACOM-296.
 
 ## [2.12.0](https://github.com/folio-org/stripes-smart-components/tree/v2.12.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.11.0...v2.12.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -26,7 +26,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=500'
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=2000'
       }
     },
     // Only used when actuatorType="refdata"


### PR DESCRIPTION
Increase the `<ControlledVocab>` fetch limit from 500 to 2000 because
people want to have lots of things.

Refs [STSMACOM-296](https://issues.folio.org/browse/STSMACOM-296), [UIIN-819](https://issues.folio.org/browse/UIIN-819)