### PR TITLE
Added support for periods in filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 * Added integration point for `resultOffset`, which supports `stripes-components` result list "load more" button. Refs STCON-57.
 * Reset `resultCount` and `resultOffset` when sorting. Fixes STSMACOM-269.
 * `<EditableList>`: Disable the actions in existing rows when another item is being created or edited. Refs STCOM-624.
-* Improve accessibility, add attribute `aria-label` to `nav` tag in Settings. Refs UICAL-85.   
+* Improve accessibility, add attribute `aria-label` to `nav` tag in Settings. Refs UICAL-85.
 * Bump `<ControlledVocab>` fetch limit to 2000. Refs STSMACOM-296.
 * Increase of character limit for notes to 3500. Refs STSMACOM-295.
+* Added support for periods in filter values.
 
 ## [2.12.0](https://github.com/folio-org/stripes-smart-components/tree/v2.12.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.11.0...v2.12.0)

--- a/lib/EntryManager/tests/interactor.js
+++ b/lib/EntryManager/tests/interactor.js
@@ -28,7 +28,7 @@ import {
 @interactor class DetailsSection {
   defaultScope = '[data-test-detail-section]';
 
-  actionsButton = new Interactor('button[class^="paneHeaderCenterButton--"]');
+  actionsButton = new Interactor('button[data-test-pane-header-actions-button]');
   actionsDropdown = new ActionsDropdown();
   editItemButton = scoped('#clickable-edit-item');
 

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -49,11 +49,13 @@ const filterStringToObject = (str) => {
   const filterObject = {};
   const filterArray = str.split(',');
   filterArray.forEach(f => {
-    const filter = f.split('.');
-    if (filterObject[filter[0]]) {
-      filterObject[filter[0]].push(filter[1]);
+    const [filterName, ...rest] = f.split('.');
+    const filterValue = rest.join('.');
+
+    if (filterObject[filterName]) {
+      filterObject[filterName].push(filterValue);
     } else {
-      filterObject[filter[0]] = [filter[1]];
+      filterObject[filterName] = [filterValue];
     }
   });
   return filterObject;

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -50,7 +50,7 @@ const filterStringToObject = (str) => {
   const filterArray = str.split(',');
   filterArray.forEach(f => {
     const [filterName, ...rest] = f.split('.');
-    const filterValue = rest.join('.');
+    const filterValue = rest.join('.'); // support both filterName.value and filterName.value.with.dot
 
     if (filterObject[filterName]) {
       filterObject[filterName].push(filterValue);


### PR DESCRIPTION
Sometimes you _really_ want to be able to use dots in your filter values. This may come about because you have these [complex filters you want to build](https://issues.folio.org/browse/ERM-684), so you spend a day and a half figuring out the best way to write your own `filtersToString` and `filterParamsMapping` functions just so you can store a filter value that looks like `customProperties.foo.value>=15||customProperties.foo.value<=10`.

And then after nicely tidying everything up, you realise that the only difference between your implementation of those functions and the SASQ version is that you use `==` instead of `.` as a demarcator and rejoin the RHS after the `split()`.

Which makes you feel pretty annoyed, because you spent all this time and this little PR could've been enough from the get-go. But at least you now have a pretty damn good understanding of how those functions work in SASQ.