### PR TITLE
bump stripes-util to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@folio/stripes-core": "~4.0.0",
     "@folio/stripes-form": "~3.0.0",
     "@folio/stripes-logger": "~1.0.0",
-    "@folio/stripes-util": "^1.6.2",
+    "@folio/stripes-util": "~2.0.0",
     "classnames": "^2.2.6",
     "final-form": "^4.18.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
`stripes-util` was inadvertenly omitted from the original round of PRs
updating stripes-* libraries in preparation for `@folio/stripes`
`v3.0.0`. This PR simply brings in that update.