### PR TITLE
STSMACOM-257 STSMACOM-294: Disable regex search

### DIFF
--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -48,7 +48,12 @@ export default class TagsForm extends React.Component {
     }
 
     const filtered = list.filter(item => item.value.toLowerCase().includes(filter.toLowerCase()));
-    const renderedItems = filtered.sort((a, b) => a.value.localeCompare(b.value))
+    const renderedItems = filtered.sort((a, b) => {
+      if (a.value.toLowerCase().startsWith(filter.toLowerCase())) return -1;
+      if (b.value.toLowerCase().startsWith(filter.toLowerCase())) return 1;
+
+      return a.value.localeCompare(b.value);
+    });
 
     return { renderedItems };
   };

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -47,24 +47,10 @@ export default class TagsForm extends React.Component {
       return { renderedItems: list };
     }
 
-    try {
-      const filtered = list.filter(item => item.value.match(new RegExp(filter, 'i')));
-      const renderedItems = filtered.sort((tag1, tag2) => {
-        const regex = new RegExp(`^${filter}`, 'i');
-        const match1 = tag1.value.match(regex);
-        const match2 = tag2.value.match(regex);
-        if (match1) return -1;
-        if (match2) return 1;
-        return (tag1.value < tag2.value) ? -1 : 1;
-      });
+    const filtered = list.filter(item => item.value.toLowerCase().includes(filter.toLowerCase()));
+    const renderedItems = filtered.sort((a, b) => a.value.localeCompare(b.value))
 
-      return { renderedItems };
-    } catch (e) {
-      return {
-        error: <FormattedMessage id="stripes-smart-components.tags.filterError" values={{ error: e.message }} />,
-        renderedItems: [],
-      };
-    }
+    return { renderedItems };
   };
 
   addTag = ({ inputValue }) => {


### PR DESCRIPTION
Disabled regex search in TagsForm to free up the ability to use square brackets and parens.