### PR TITLE
Added hasMargin-prop for SearchAndSort MCL.

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1049,6 +1049,7 @@ class SearchAndSort extends React.Component {
             loading={source.pending()}
             autosize
             virtualize
+            hasMargin
             rowFormatter={this.anchoredRowFormatter}
             containerRef={(ref) => { this.resultsList = ref; }}
             onRowClick={viewRecordPathById ? undefined : this.onSelectRow}


### PR DESCRIPTION
We made a change in the `<MultiColumnList>`-component that removes the horizontal margin by default, making the component span from edge to edge.

This works for most implementations but MCL's used in the result panes must have the `hasMargin`-prop applied to enable proper spacing and alignment.

This PR adds that prop for the MCL in `<SearchAndSort>`.

## Before
![image](https://user-images.githubusercontent.com/640976/77416890-c8512480-6dc4-11ea-87e0-4ed50c1a25af.png)

## After
![image](https://user-images.githubusercontent.com/640976/77416851-b7a0ae80-6dc4-11ea-95ba-d3f77e91f1c8.png)
