### PR TITLE
Removed margin from NavListSection

### DIFF
--- a/lib/Settings/Settings.css
+++ b/lib/Settings/Settings.css
@@ -1,3 +1,0 @@
-.listSection {
-  margin-bottom: 1.5rem;
-}

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -12,8 +12,6 @@ import {
   PaneBackLink,
 } from '@folio/stripes-components';
 
-import css from './Settings.css';
-
 class Settings extends Component {
   constructor(props) {
     super(props);
@@ -63,7 +61,7 @@ class Settings extends Component {
       }).filter(x => x !== null);
 
       return (
-        <NavListSection activeLink={activeLink} label={section.label} className={css.listSection}>
+        <NavListSection activeLink={activeLink} label={section.label}>
           {navItems}
         </NavListSection>
       );


### PR DESCRIPTION
Removed margin from NavListSection because it's now added by default when stacking NavListSection's.

## Before
![image](https://user-images.githubusercontent.com/640976/77424401-592dfd00-6dd1-11ea-823f-d91c585823cc.png)

## After
![image](https://user-images.githubusercontent.com/640976/77424371-49aeb400-6dd1-11ea-85ca-68cbb9846ed6.png)
