### PR TITLE
STSMACOM-269 load more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-smart-components
 
+## 2.13.0 (IN PROGRESS)
+
+* Added integration point for `resultOffset`, which supports `stripes-components` result list "load more" button. Refs STCON-57.
+* Reset `resultCount` and `resultOffset` when sorting. Fixes STSMACOM-269.
+
 ## [2.12.1](https://github.com/folio-org/stripes-smart-components/tree/v2.12.1) (2019-12-19)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v2.12.0...v2.12.1)
 

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -75,8 +75,8 @@ export default class StripesConnectedSource {
     // ... and stripes-connect notices this change and does the rest by magic
   }
 
-  // fetch by offset which is passed in as index. _askAmount is ignored.
-  fetchOffset(_askAmount, index) {
+  // fetch by offset which is passed in as index.
+  fetchOffset(index) {
     this.mutator.resultOffset.replace(index);
   }
 

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -13,12 +13,6 @@ export default class StripesConnectedSource {
     this.mutator = props.parentMutator || props.mutator;
   }
 
-  resultOffset() {
-    const res = this.resources.resultOffset;
-    this.logger.log('source', 'resultOffset:', res);
-    return res;
-  }
-
   records() {
     const res = this.recordsObj.records || [];
     this.logger.log('source', 'records:', res);
@@ -80,8 +74,10 @@ export default class StripesConnectedSource {
     // ... and stripes-connect notices this change and does the rest by magic
   }
 
-  fetchOffset(offset) {
-    this.mutator.resultOffset.replace(this.resultOffset() + offset);
+  // fetch by offset which is calculated by adding the user's current index to the ask amount
+  fetchOffset(askAmount, index) {
+    const offset = askAmount + index;
+    this.mutator.resultOffset.replace(offset);
   }
 
   successfulMutations() {

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -36,7 +36,8 @@ export default class StripesConnectedSource {
     if (!this.recordsObj.hasLoaded) {
       res = null;
     } else {
-      res = this.recordsObj.other.totalRecords !== UNKNOWN_RECORDS_COUNT ? this.recordsObj.other.totalRecords : undefined;
+      res = this.recordsObj.other.totalRecords !== UNKNOWN_RECORDS_COUNT ?
+        this.recordsObj.other.totalRecords : undefined;
     }
     this.logger.log('source', 'totalCount:', res);
     return res;

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -13,6 +13,12 @@ export default class StripesConnectedSource {
     this.mutator = props.parentMutator || props.mutator;
   }
 
+  resultOffset() {
+    const res = this.resources.resultOffset;
+    this.logger.log('source', 'resultOffset:', res);
+    return res;
+  }
+
   records() {
     const res = this.recordsObj.records || [];
     this.logger.log('source', 'records:', res);
@@ -36,7 +42,7 @@ export default class StripesConnectedSource {
     if (!this.recordsObj.hasLoaded) {
       res = null;
     } else {
-      res = this.recordsObj.other.totalRecords !== 999999999 ? this.recordsObj.other.totalRecords : undefined;
+      res = this.recordsObj.other.totalRecords !== UNKNOWN_RECORDS_COUNT ? this.recordsObj.other.totalRecords : undefined;
     }
     this.logger.log('source', 'totalCount:', res);
     return res;
@@ -72,6 +78,10 @@ export default class StripesConnectedSource {
   fetchMore(increment) {
     this.mutator.resultCount.replace(this.resultCount() + increment);
     // ... and stripes-connect notices this change and does the rest by magic
+  }
+
+  fetchOffset(offset) {
+    this.mutator.resultOffset.replace(this.resultOffset() + offset);
   }
 
   successfulMutations() {

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -74,10 +74,9 @@ export default class StripesConnectedSource {
     // ... and stripes-connect notices this change and does the rest by magic
   }
 
-  // fetch by offset which is calculated by adding the user's current index to the ask amount
-  fetchOffset(askAmount, index) {
-    const offset = askAmount + index;
-    this.mutator.resultOffset.replace(offset);
+  // fetch by offset which is passed in as index. _askAmount is ignored.
+  fetchOffset(_askAmount, index) {
+    this.mutator.resultOffset.replace(index);
   }
 
   successfulMutations() {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -502,7 +502,12 @@ class SearchAndSort extends React.Component {
   };
 
   onSort = (e, meta) => {
-    const { maxSortKeys, sortableColumns } = this.props;
+    const {
+      parentMutator: { resultCount },
+      initialResultCount,
+      maxSortKeys,
+      sortableColumns
+    } = this.props;
 
     const newOrder = meta.name;
 
@@ -522,6 +527,8 @@ class SearchAndSort extends React.Component {
     const sortOrder = orders.slice(0, maxSortKeys).join(',');
 
     this.log('action', `sorted by ${sortOrder}`);
+    // Reset result count when sorting so that only 1 page is initially retrieved
+    resultCount.replace(initialResultCount);
     this.transitionToParams({ sort: sortOrder });
   };
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -142,6 +142,8 @@ class SearchAndSort extends React.Component {
         route: PropTypes.string, // base route; used to construct URLs
       }).isRequired,
     }),
+    pageAmount: PropTypes.number,
+    pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
       query: PropTypes.shape({
@@ -362,7 +364,11 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(0);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
     onFilterChange(filter);
   };
 
@@ -392,7 +398,10 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(0);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
 
     const newFilters = this.handleFilterChange(e);
 
@@ -487,7 +496,7 @@ class SearchAndSort extends React.Component {
 
     // If module provides offset mutator and index parameter, opt-in to fetch by offset.
     if (resultOffset && index >= 0) {
-      source.fetchOffset(askAmount, index);
+      source.fetchOffset(index);
     } else {
       source.fetchMore(resultCountIncrement);
     }
@@ -540,7 +549,11 @@ class SearchAndSort extends React.Component {
     this.log('action', `sorted by ${sortOrder}`);
     // Reset result count when sorting so that only 1 page is initially retrieved
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(0);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
     this.transitionToParams({ sort: sortOrder });
   };
 
@@ -643,7 +656,11 @@ class SearchAndSort extends React.Component {
 
     this.log('action', `searched for '${query}'`);
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(0);
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
     this.transitionToParams({ query });
   }, 350);
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -362,7 +362,7 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(0);
     onFilterChange(filter);
   };
 
@@ -392,7 +392,7 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(0);
 
     const newFilters = this.handleFilterChange(e);
 
@@ -486,7 +486,7 @@ class SearchAndSort extends React.Component {
     const source = makeConnectedSource(this.props, logger);
 
     // If module provides offset mutator and index parameter, opt-in to fetch by offset.
-    if (resultOffset && index) {
+    if (resultOffset && index >= 0) {
       source.fetchOffset(askAmount, index);
     } else {
       source.fetchMore(resultCountIncrement);
@@ -540,7 +540,7 @@ class SearchAndSort extends React.Component {
     this.log('action', `sorted by ${sortOrder}`);
     // Reset result count when sorting so that only 1 page is initially retrieved
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(0);
     this.transitionToParams({ sort: sortOrder });
   };
 
@@ -643,7 +643,7 @@ class SearchAndSort extends React.Component {
 
     this.log('action', `searched for '${query}'`);
     resultCount.replace(initialResultCount);
-    if (resultOffset) resultOffset.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(0);
     this.transitionToParams({ query });
   }, 350);
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -487,7 +487,7 @@ class SearchAndSort extends React.Component {
 
     // If module provides offset mutator and index parameter, opt-in to fetch by offset.
     if (resultOffset && index) {
-      source.fetchOffset(index);
+      source.fetchOffset(askAmount, index);
     } else {
       source.fetchMore(resultCountIncrement);
     }

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -972,6 +972,8 @@ class SearchAndSort extends React.Component {
       objectName,
       notLoadedMessage,
       viewRecordPathById,
+      pageAmount,
+      pagingType,
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1019,6 +1021,8 @@ class SearchAndSort extends React.Component {
             onRowClick={viewRecordPathById ? undefined : this.onSelectRow}
             onHeaderClick={this.onSort}
             onNeedMoreData={this.onNeedMore}
+            pageAmount={pageAmount}
+            pagingType={pagingType}
           />
         )}
       </FormattedMessage>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -151,6 +151,9 @@ class SearchAndSort extends React.Component {
       resultCount: PropTypes.shape({
         replace: PropTypes.func.isRequired,
       }).isRequired,
+      resultOffset: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
+      }).isRequired,
     }).isRequired, // only needed when GraphQL is used
     parentResources: PropTypes.shape({
       query: PropTypes.shape({
@@ -353,12 +356,13 @@ class SearchAndSort extends React.Component {
 
   onFilterChangeHandler = (filter) => {
     const {
-      parentMutator: { resultCount },
+      parentMutator: { resultCount, resultOffset },
       initialResultCount,
       onFilterChange,
     } = this.props;
 
     resultCount.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(initialResultCount);
     onFilterChange(filter);
   };
 
@@ -382,12 +386,13 @@ class SearchAndSort extends React.Component {
 
   onChangeFilter = (e) => {
     const {
-      parentMutator: { resultCount },
+      parentMutator: { resultCount, resultOffset },
       initialResultCount,
       filterChangeCallback,
     } = this.props;
 
     resultCount.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(initialResultCount);
 
     const newFilters = this.handleFilterChange(e);
 
@@ -472,14 +477,20 @@ class SearchAndSort extends React.Component {
     }
   };
 
-  onNeedMore = () => {
+  onNeedMore = (askAmount, index) => {
     const {
+      parentMutator: { resultOffset },
       stripes: { logger },
       resultCountIncrement,
     } = this.props;
     const source = makeConnectedSource(this.props, logger);
 
-    source.fetchMore(resultCountIncrement);
+    // If module provides offset mutator and index parameter, opt-in to fetch by offset.
+    if (resultOffset && index) {
+      source.fetchOffset(index);
+    } else {
+      source.fetchMore(resultCountIncrement);
+    }
   };
 
   onSelectRow = (e, meta) => {
@@ -503,7 +514,7 @@ class SearchAndSort extends React.Component {
 
   onSort = (e, meta) => {
     const {
-      parentMutator: { resultCount },
+      parentMutator: { resultCount, resultOffset },
       initialResultCount,
       maxSortKeys,
       sortableColumns
@@ -529,6 +540,7 @@ class SearchAndSort extends React.Component {
     this.log('action', `sorted by ${sortOrder}`);
     // Reset result count when sorting so that only 1 page is initially retrieved
     resultCount.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(initialResultCount);
     this.transitionToParams({ sort: sortOrder });
   };
 
@@ -625,12 +637,13 @@ class SearchAndSort extends React.Component {
   // eslint-disable-next-line react/sort-comp
   performSearch = debounce((query) => {
     const {
-      parentMutator: { resultCount },
+      parentMutator: { resultCount, resultOffset },
       initialResultCount,
     } = this.props;
 
     this.log('action', `searched for '${query}'`);
     resultCount.replace(initialResultCount);
+    if (resultOffset) resultOffset.replace(initialResultCount);
     this.transitionToParams({ query });
   }, 350);
 

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -29,6 +29,9 @@ describe('SearchAndSort', () => {
           resultCount: {
             replace: () => { }
           },
+          resultOffset: {
+            replace: () => { }
+          },
         }}
         filterConfig={[]}
         packageInfo={{

--- a/lib/SearchAndSort/tests/record-count-test.js
+++ b/lib/SearchAndSort/tests/record-count-test.js
@@ -61,6 +61,34 @@ describe('SearchAndSort results', () => {
     });
   });
 
+  describe('99999 results found', () => {
+    setupApplication();
+    const searchAndSort = new SearchAndSortInteractor();
+    const ConnectedComponent = connectStripes(SearchAndSort);
+
+    beforeEach(async () => {
+      const localProps = {
+        parentResources: {
+          records: {
+            hasLoaded: true,
+            other: { totalRecords: 99999 }
+          }
+        },
+      };
+      const testProps = Object.assign({}, defaultProps, localProps);
+
+      await mount(
+        <ConnectedComponent
+          {...testProps}
+        />
+      );
+    });
+
+    it('should show 99,999 records found', () => {
+      expect(searchAndSort.resultsSubtitle).to.equal('99,999 records found');
+    });
+  });
+
   /**
    * Okapi uses a `totalRecords` value of 999,999,999 to indicate
    * an unknown number of totalRecords.

--- a/lib/SearchAndSort/tests/record-count-test.js
+++ b/lib/SearchAndSort/tests/record-count-test.js
@@ -22,7 +22,10 @@ const defaultProps = {
   },
   parentMutator: {
     resultCount: {
-      replace: () => { },
+      replace: () => { }
+    },
+    resultOffset: {
+      replace: () => { }
     },
   },
   filterConfig: [],
@@ -62,7 +65,7 @@ describe('SearchAndSort results', () => {
    * Okapi uses a `totalRecords` value of 999,999,999 to indicate
    * an unknown number of totalRecords.
    */
-  describe('99999 results found', () => {
+  describe('999999999 results found', () => {
     setupApplication();
     const searchAndSort = new SearchAndSortInteractor();
     const ConnectedComponent = connectStripes(SearchAndSort);
@@ -72,7 +75,7 @@ describe('SearchAndSort results', () => {
         parentResources: {
           records: {
             hasLoaded: true,
-            other: { totalRecords: 99999 }
+            other: { totalRecords: 999999999 }
           }
         },
       };
@@ -85,8 +88,8 @@ describe('SearchAndSort results', () => {
       );
     });
 
-    it('should show 99999 records found', () => {
-      expect(searchAndSort.resultsSubtitle).to.equal('99,999 records found');
+    it('should show More than 10,000 records found', () => {
+      expect(searchAndSort.resultsSubtitle).to.equal('More than 10,000 records found');
     });
   });
 


### PR DESCRIPTION
Accept the `pageAmount` and `pagingType` props from an app so it may opt-in to the "Load more" features of [stripes-components](https://github.com/folio-org/stripes-components/pull/1117) and [stripes-connect](https://github.com/folio-org/stripes-connect/pull/117).

It's a cherry-pick of the commits in #684 onto a patch branch in order to make that feature, and that feature alone, available as a patch to the [2019-q4 stripes release](https://github.com/folio-org/stripes/releases/tag/v2.12.1). 