### PR TITLE
UIREQ-415: Add prop hasNewButton to SearchAndSort component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Custom fields: create page accordions for create/edit/view record. UIU-1279
 * Custom fields: apply checkbox vertical alignment. Refs UIU-1527.
+* Add optional prop `hasNewButton` to `SearchAndSort` component. Refs UIREQ-415.
 
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -105,6 +105,7 @@ class SearchAndSort extends React.Component {
     finishedResourceName: PropTypes.string,
     getHelperComponent: PropTypes.func,
     getHelperResourcePath: PropTypes.func,
+    hasNewButton: PropTypes.bool,
     history: PropTypes.shape({ // provided by withRouter
       push: PropTypes.func.isRequired,
     }).isRequired,
@@ -218,7 +219,8 @@ class SearchAndSort extends React.Component {
     getHelperComponent: noop,
     massageNewRecord: noop,
     renderNavigation: noop,
-    selectedIndex: ''
+    selectedIndex: '',
+    hasNewButton: true,
   };
 
   constructor(props) {
@@ -1070,6 +1072,7 @@ class SearchAndSort extends React.Component {
       module,
       resultCountMessageKey,
       title,
+      hasNewButton,
     } = this.props;
     const { filterPaneIsVisible } = this.state;
 
@@ -1122,7 +1125,7 @@ class SearchAndSort extends React.Component {
           appIcon={<AppIcon app={moduleName} />}
           paneTitle={title || (module && module.displayName)}
           paneSub={paneSub}
-          lastMenu={this.renderNewRecordBtn()}
+          lastMenu={hasNewButton ? this.renderNewRecordBtn() : null}
           firstMenu={this.renderResultsFirstMenu()}
           noOverflow
         >

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -57,6 +57,7 @@ notLoadedMessage | string | A message to show the user before a search has been 
 getHelperResourcePath | func | An optional function which can be used to return helper's resource path dynamically.
 getHelperComponent | func | An optional function which can be used to return connected helper component implementation.
 title | string/element | An optional property to specify title of results pane. By default module display name is used.
+hasNewButton | boolean | An optional property to specify appearance Of `New` button of results pane. By default pane displays with `New` button.
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 


### PR DESCRIPTION
# Approach
Add `hasNewButton` prop to `SearchAndSort` component. 

- By default `New` button of the pane appears and  `hasNewButton` sets to `true`.
- If  `hasNewButton` sets to `false` - `New` button of the pane does not appear.

# Link
https://issues.folio.org/browse/UIREQ-415

# Screenshots
**hasNewButton = true (by default)**

![image](https://user-images.githubusercontent.com/55694637/78016697-d1f20380-7353-11ea-94ff-2412ea043c4a.png)

**hasNewButton = false**

![image](https://user-images.githubusercontent.com/55694637/78016570-a838dc80-7353-11ea-8354-7d2e3a91cfb4.png)