### PR TITLE
Helper-app rendering no-ops if the helper is undefined

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -750,7 +750,7 @@ class SearchAndSort extends React.Component {
     const helper = this.queryParam('helper');
     const HelperAppComponent = this.getHelperComponent(helper);
 
-    if (!helper) {
+    if (!HelperAppComponent) {
       return null;
     }
 


### PR DESCRIPTION
The previous version contained what looks like a straight-up bug where
the rendering no-opped only if the helper _name_ was undefined. This
meant you could invoke a URL with, say, `helper=noSuchThing`, and
`<SearchAndSort>` would fail to find that helper but still try to
render the component that implements it, even though it was undefined.

Thanks to @EthanFreestone for helping me spot this.

--

NB. I nominated @VictorSoroka1 to review this because the original test is in code he added, and I want to be sure I've not misunderstood his intent.