### PR TITLE
STSMACOM-329: Use filter delimiter instead of comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Custom fields: create page accordions for create/edit/view record. UIU-1279
 * Custom fields: apply checkbox vertical alignment. Refs UIU-1527.
 * Add optional prop `hasNewButton` to `SearchAndSort` component. Refs UIREQ-415.
+* Use filter delimiter instead of comma for filter splitting. Fixes STSMACOM-329.
 
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -9,11 +9,12 @@ import cloneDeep from 'lodash/cloneDeep';
 import queryString from 'query-string';
 import { withRouter } from 'react-router';
 
+import { FILTER_DELIMITER } from '@folio/stripes-components';
+
 import {
   mapNsKeys,
   getNsKey,
 } from './nsQueryFunctions';
-
 import buildUrl from './buildUrl';
 
 const locationQuerySetter = ({ location, history, nsValues }) => {
@@ -34,8 +35,8 @@ const buildFilterString = (activeFilters) => {
     .map((filterName) => {
       return activeFilters[filterName].map((filterValue) => {
         return `${filterName}.${filterValue}`;
-      }).join(',');
-    }).join(',');
+      }).join(FILTER_DELIMITER);
+    }).join(FILTER_DELIMITER);
 
   return newFiltersString;
 };
@@ -47,7 +48,7 @@ const buildFilterParams = (activeFilters) => {
 
 const filterStringToObject = (str) => {
   const filterObject = {};
-  const filterArray = str.split(',');
+  const filterArray = str.split(FILTER_DELIMITER);
   filterArray.forEach(f => {
     const [filterName, ...rest] = f.split('.');
     const filterValue = rest.join('.'); // support both filterName.value and filterName.value.with.dot
@@ -597,7 +598,7 @@ class SearchAndSortQuery extends React.Component {
     }
 
     return filtersString
-      .split(',')
+      .split(FILTER_DELIMITER)
       .reduce((resultFilters, currentFilter) => {
         const [filterName, filterValue] = currentFilter.split('.');
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-329

Use filter delimiter (currently set to `\t`) from stripes-components (https://github.com/folio-org/stripes-components/pull/1238) instead of comma in order to correctly split filters.