### PR TITLE
STSMACOM-332 getEntity and getEntityTags props for Tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 3.1.1 (IN PROGRESS)
+
+* Support custom `getEntity` and `getEntityTags` methods in `Tags` component. Fixes UIDATIMP-461.
+
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)
 

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -28,28 +28,30 @@ class Tags extends React.Component {
 
   static propTypes = {
     children: PropTypes.func,
+    getEntity: PropTypes.func,
+    getEntityTags: PropTypes.func,
     link: PropTypes.string.isRequired,
     mutator: PropTypes.shape({
-      entities: PropTypes.shape({
-        PUT: PropTypes.func.isRequired,
-      }),
-      tags: PropTypes.shape({
-        POST: PropTypes.func.isRequired,
-      }),
+      entities: PropTypes.shape({ PUT: PropTypes.func.isRequired }),
+      tags: PropTypes.shape({ POST: PropTypes.func.isRequired }),
     }),
     onToggle: PropTypes.func,
     refreshRemote: PropTypes.func.isRequired,
     resources: PropTypes.shape({
-      entities: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-      tags: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
+      entities: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
+      tags: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
     }).isRequired,
   };
 
-  static defaultProps = { onToggle: noop };
+  static defaultProps = {
+    onToggle: noop,
+    getEntity: props => get(props, ['resources', 'entities', 'records', 0], {}),
+    getEntityTags: props => {
+      const entity = props.getEntity(props);
+
+      return get(entity, ['tags', 'tagList'], []);
+    },
+  };
 
   componentDidUpdate(prevProps) {
     // TODO: remove the explicit `refreshRemote` call when https://issues.folio.org/browse/STCON-81 is done.
@@ -69,17 +71,28 @@ class Tags extends React.Component {
   };
 
   onRemove = tag => {
-    const entity = this.getEntity();
-    const tags = this.getEntityTags();
+    const {
+      getEntity,
+      getEntityTags,
+    } = this.props;
+    const entity = getEntity(this.props);
+    const tags = getEntityTags(this.props);
     const tagList = tags.filter(t => t !== tag);
+
     entity.tags = { tagList };
+
     this.props.mutator.entities.PUT(entity);
   };
 
   // add tag to the list of entity tags
   saveEntityTags(tags) {
-    const entity = this.getEntity();
-    const tagList = this.getEntityTags();
+    const {
+      getEntity,
+      getEntityTags,
+    } = this.props;
+    const entity = getEntity(this.props);
+    const tagList = getEntityTags(this.props);
+
     entity.tags = { tagList: sortBy(uniq([...tags, ...tagList])) };
     this.props.mutator.entities.PUT(entity);
   }
@@ -98,18 +111,9 @@ class Tags extends React.Component {
 
     if (this.calloutRef.current) {
       const message = <FormattedMessage id="stripes-smart-components.newTagCreated" />;
+
       this.calloutRef.current.sendCallout({ message });
     }
-  }
-
-  getEntity() {
-    return get(this.props, ['resources', 'entities', 'records', 0], {});
-  }
-
-  getEntityTags() {
-    const entity = this.getEntity();
-
-    return get(entity, ['tags', 'tagList'], []);
   }
 
   getTags() {
@@ -117,8 +121,12 @@ class Tags extends React.Component {
   }
 
   render() {
-    const { children, onToggle } = this.props;
-    const entityTags = this.getEntityTags();
+    const {
+      children,
+      onToggle,
+      getEntityTags,
+    } = this.props;
+    const entityTags = getEntityTags(this.props);
     const tags = this.getTags();
 
     const tagsForm = (


### PR DESCRIPTION
Provide default props `getEntity` and `getEntityTags` to `<Tags>` to allow implementors
to set other paths to the tags resource.

Refs [STSMACOM-332](https://issues.folio.org/browse/STSMACOM-332) (formerly [UIDATIMP-461](https://issues.folio.org/browse/UIDATIMP-461))