### PR TITLE
bug fix: use tilde deps on stripes-* libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@folio/stripes-components": "~6.2.0",
     "@folio/stripes-connect": "~5.6.0",
     "@folio/stripes-core": "~4.2.0",
-    "@folio/stripes-final-form": "^2.2.0",
+    "@folio/stripes-final-form": "~2.2.0",
     "@folio/stripes-form": "~3.2.0",
     "@folio/stripes-logger": "~1.0.0",
     "@folio/stripes-util": "~2.1.0",


### PR DESCRIPTION
Within the `@folio/stripes` namespace, packages must depend on each
other with `~` instead of `^`. Some details at STRIPES-588 and
STRIPES-612. This loose dependency was inadvertently introduced in #740.