### PR TITLE
STSMACOM-333: Check if the component exists for given customField.type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add optional prop `hasNewButton` to `SearchAndSort` component. Refs UIREQ-415.
 * Modify change due date dialog behavior to report successes and failures. Refs UIU-1516.
 * Support custom `getEntity` and `getEntityTags` methods in `Tags` component (UIDATIMP-461)
+* Check if the component exists for `customField.type` before rendering. Fixes STSMACOM-333.
 
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -80,30 +80,32 @@ const EditCustomFieldsRecord = ({
   const columnWidth = rowShapes / columnCount;
 
   const renderCustomField = customField => (
-    <Col
-      data-test-record-edit-custom-field
-      key={customField.refId}
-      md={columnWidth}
-      xs={rowShapes}
-    >
-      <Field
-        component={fieldComponents[customField.type]}
-        name={`customFields.${customField.refId}`}
-        required={customField.required}
-        label={
-          <>
-            {customField.name}
-            {customField.helpText && (
-              <InfoPopover
-                content={customField.helpText}
-                iconSize="small"
-              />
-            )}
-          </>
-        }
-        validate={validateCustomFields(customField)}
-      />
-    </Col>
+    fieldComponents[customField.type] ?
+      <Col
+        data-test-record-edit-custom-field
+        key={customField.refId}
+        md={columnWidth}
+        xs={rowShapes}
+      >
+        <Field
+          component={fieldComponents[customField.type]}
+          name={`customFields.${customField.refId}`}
+          required={customField.required}
+          label={
+            <>
+              {customField.name}
+              {customField.helpText && (
+                <InfoPopover
+                  content={customField.helpText}
+                  iconSize="small"
+                />
+              )}
+            </>
+          }
+          validate={validateCustomFields(customField)}
+        />
+      </Col> :
+      null
   );
 
   return (


### PR DESCRIPTION
It looks like we ran into a case where the type defined on the server (`SINGLE_SELECT_DROPDOWN`) was not defined in: 

https://github.com/folio-org/stripes-smart-components/blob/master/lib/CustomFields/constants.js

which caused the ui-users to explode.

This PR adds an extra check to make sure there is a corresponding component for the given type. 

I think there should be another story created to actually register `SINGLE_SELECT_DROPDOWN` as a valid type.

### Link
https://issues.folio.org/browse/STSMACOM-333