### PR TITLE
pass correct aria props to Button

### DIFF
--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -232,7 +232,7 @@ class EntrySelector extends React.Component {
               <Button
                 onClick={() => this.props.onEdit(item)}
                 id="clickable-edit-item"
-                ariaLabel={ariaLabel}
+                aria-label={ariaLabel}
                 buttonStyle="primary"
                 marginBottom0
               >


### PR DESCRIPTION
A `<Button>` can have an `aria-label` but not an `ariaLabel`.