### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Prevent `ProxyManager` form submission from propagating to outer forms. Fixes UIREQ-449, UIREQ-454.
 * Marked Note Title field as required. Fixes STSMACOM-323.
 * Added `PersistedPaneset` component.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.2",
     "lodash": "^4.17.4",
-    "moment": "^2.22.1",
+    "moment": "~2.24.0",
     "moment-timezone": "^0.5.17",
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
     "react-intl": "^2.4.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)