### PR TITLE
STSMACOM-334: Notes list: Refreshing Detail record causes the Note type value to be cut off

### DIFF
--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -12,14 +12,17 @@ const defaultColumnsConfig = [
   {
     name: 'date',
     title: <FormattedMessage id="stripes-smart-components.date" />,
+    width: '10%',
   },
   {
     name: 'title',
     title: <FormattedMessage id="stripes-smart-components.title" />,
+    width: '50%',
   },
   {
     name: 'type',
     title: <FormattedMessage id="stripes-smart-components.type" />,
+    width: '40%',
   },
 ];
 


### PR DESCRIPTION
## Purpose
- Fix note type values in `<NotesList>` component being cut off by providing default column widths to MCL component

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/81176697-2e2cf080-8fae-11ea-983b-a9f75e1794eb.png)
