### PR TITLE
UIU-1514: add radio button set view and edit functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Custom fields: Multi-select dropdown. Refs STSMACOM-326.
 * Custom fields: Radio button set. Refs STSMACOM-292.
 * Entry Manager: hide Edit button when actions menu is enabled. Refs UICIRC-437.
+* Custom fields: support redux-form and final-form.
 
 ## [3.1.0](https://github.com/folio-org/stripes-smart-components/tree/v3.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.0.0...v3.1.0)

--- a/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
+++ b/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
@@ -207,7 +207,7 @@ const CustomFieldsForm = ({
 
           const selectField = form.getState().values.customFields[index].values.selectField;
 
-          if (fieldType === fieldTypes.RADIO_BUTTON_SET || fieldType === fieldTypes.SELECT) {
+          if (fieldType === fieldTypes.RADIO_BUTTON_GROUP || fieldType === fieldTypes.SELECT) {
             accordionProps.defaultOptions = selectField.defaults;
           }
 

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -18,7 +18,7 @@ const editFieldsByType = {
   [fieldTypes.TEXTFIELD]: editFields.TextboxFields,
   [fieldTypes.TEXTAREA]: editFields.TextboxFields,
   [fieldTypes.CHECKBOX]: editFields.CheckboxFields,
-  [fieldTypes.RADIO_BUTTON_SET]: editFields.RadioButtonSetFields,
+  [fieldTypes.RADIO_BUTTON_GROUP]: editFields.RadioButtonSetFields,
   [fieldTypes.SELECT]: editFields.SelectDropdownFields,
   [fieldTypes.MULTISELECT]: editFields.SelectDropdownFields,
 };
@@ -27,7 +27,7 @@ const viewSectionsByType = {
   [fieldTypes.TEXTFIELD]: viewSections.TextboxViewSection,
   [fieldTypes.TEXTAREA]: viewSections.TextboxViewSection,
   [fieldTypes.CHECKBOX]: viewSections.CheckboxViewSection,
-  [fieldTypes.RADIO_BUTTON_SET]: viewSections.RadioButtonSetSection,
+  [fieldTypes.RADIO_BUTTON_GROUP]: viewSections.RadioButtonSetSection,
   [fieldTypes.SELECT]: viewSections.SelectDropdownSection,
   [fieldTypes.MULTISELECT]: viewSections.SelectDropdownSection,
 };

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/OptionsField.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/OptionsField.js
@@ -116,8 +116,8 @@ const OptionsField = ({
   };
 
   const labelForDefaultColumn = isMultiSelect
-    ? <FormattedMessage id="stripes-smart-components.customFields.options.default" />
-    : <FormattedMessage id="stripes-smart-components.customFields.options.defaults" />;
+    ? <FormattedMessage id="stripes-smart-components.customFields.options.defaults" />
+    : <FormattedMessage id="stripes-smart-components.customFields.options.default" />;
 
   return (
     <Col xs>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/Options.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/Options.js
@@ -35,8 +35,8 @@ const Options = ({ selectField, isMultiSelect }) => {
   });
 
   const labelForDefaultColumn = isMultiSelect
-    ? <FormattedMessage id="stripes-smart-components.customFields.options.default" />
-    : <FormattedMessage id="stripes-smart-components.customFields.options.defaults" />;
+    ? <FormattedMessage id="stripes-smart-components.customFields.options.defaults" />
+    : <FormattedMessage id="stripes-smart-components.customFields.options.default" />;
 
   return (
     <Col xs>

--- a/lib/CustomFields/constants.js
+++ b/lib/CustomFields/constants.js
@@ -14,7 +14,7 @@ export const fieldTypes = {
   CHECKBOX: 'SINGLE_CHECKBOX',
   SELECT: 'SINGLE_SELECT_DROPDOWN',
   MULTISELECT: 'MULTI_SELECT_DROPDOWN',
-  RADIO_BUTTON_SET: 'RADIO_BUTTON',
+  RADIO_BUTTON_GROUP: 'RADIO_BUTTON',
 };
 
 export const fieldTypesLabels = {
@@ -23,7 +23,7 @@ export const fieldTypesLabels = {
   [fieldTypes.CHECKBOX]: <FormattedMessage id="stripes-smart-components.customFields.fieldTypes.CHECKBOX" />,
   [fieldTypes.SELECT]: <FormattedMessage id="stripes-smart-components.customFields.fieldTypes.SELECT" />,
   [fieldTypes.MULTISELECT]: <FormattedMessage id="stripes-smart-components.customFields.fieldTypes.MULTISELECT" />,
-  [fieldTypes.RADIO_BUTTON_SET]: <FormattedMessage id="stripes-smart-components.customFields.fieldTypes.RADIO_BUTTON" />,
+  [fieldTypes.RADIO_BUTTON_GROUP]: <FormattedMessage id="stripes-smart-components.customFields.fieldTypes.RADIO_BUTTON" />,
 };
 export const NO_DEFAULT_OPTIONS_VALUE = 'no-default';
 
@@ -66,11 +66,11 @@ export const defaultFieldConfigs = {
       }
     },
   },
-  [fieldTypes.RADIO_BUTTON_SET]: {
+  [fieldTypes.RADIO_BUTTON_GROUP]: {
     name: '',
     visible: true,
     helpText: '',
-    type: fieldTypes.RADIO_BUTTON_SET,
+    type: fieldTypes.RADIO_BUTTON_GROUP,
     selectField: {
       multiSelect: false,
       defaults: NO_DEFAULT_OPTIONS_VALUE,
@@ -100,7 +100,7 @@ export const fieldComponents = {
   [fieldTypes.TEXTAREA]: TextArea,
   [fieldTypes.CHECKBOX]: Checkbox,
   [fieldTypes.SELECT]: Select,
-  [fieldTypes.RADIO_BUTTON_SET]: RadioButtonGroup,
+  [fieldTypes.RADIO_BUTTON_GROUP]: RadioButtonGroup,
 };
 
 export const rowShapes = 12;

--- a/lib/CustomFields/constants.js
+++ b/lib/CustomFields/constants.js
@@ -8,11 +8,6 @@ import {
   RadioButtonGroup,
 } from '@folio/stripes-components';
 
-export const formTypes = {
-  FINAL_FORM: 'finalForm',
-  REDUX_FORM: 'reduxForm'
-};
-
 export const fieldTypes = {
   TEXTFIELD: 'TEXTBOX_SHORT',
   TEXTAREA: 'TEXTBOX_LONG',

--- a/lib/CustomFields/constants.js
+++ b/lib/CustomFields/constants.js
@@ -5,7 +5,13 @@ import {
   TextField,
   TextArea,
   Select,
+  RadioButtonGroup,
 } from '@folio/stripes-components';
+
+export const formTypes = {
+  FINAL_FORM: 'finalForm',
+  REDUX_FORM: 'reduxForm'
+};
 
 export const fieldTypes = {
   TEXTFIELD: 'TEXTBOX_SHORT',
@@ -99,6 +105,7 @@ export const fieldComponents = {
   [fieldTypes.TEXTAREA]: TextArea,
   [fieldTypes.CHECKBOX]: Checkbox,
   [fieldTypes.SELECT]: Select,
+  [fieldTypes.RADIO_BUTTON_SET]: RadioButtonGroup,
 };
 
 export const rowShapes = 12;

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
@@ -1,0 +1,12 @@
+.fieldLabel {
+  position: relative;
+}
+
+.fieldLabel legend {
+  margin-bottom: 0;
+}
+
+.infoPopover {
+  position: absolute;
+  right: -2rem;
+}

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -41,6 +41,8 @@ import {
   validateCustomFields,
 } from '../../utils';
 
+import css from './EditCustomFieldsRecord.css';
+
 const propTypes = {
   accordionId: PropTypes.string.isRequired,
   backendModuleId: PropTypes.string,
@@ -157,15 +159,17 @@ const EditCustomFieldsRecord = ({
   ]);
 
   const renderCustomFieldLabel = customField => (
-    <>
+    <span className={css.fieldLabel}>
       {customField.name}
       {customField.helpText && (
-        <InfoPopover
-          content={customField.helpText}
-          iconSize="small"
-        />
+        <span className={css.infoPopover}>
+          <InfoPopover
+            content={customField.helpText}
+            iconSize="small"
+          />
+        </span>
       )}
-    </>
+    </span>
   );
 
   const createCustomFieldRenderFunction = customField => (props = {}) => (

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -18,7 +18,7 @@ import {
 } from '@folio/stripes-components';
 
 import {
-  change as changeReduxFormField,
+  change,
   getFormValues,
 } from 'redux-form';
 
@@ -47,8 +47,8 @@ const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
   changeFinalFormField: PropTypes.func,
+  changeReduxFormField: PropTypes.func,
   columnCount: PropTypes.number,
-  dispatch: PropTypes.func.isRequired,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
   fieldComponent: PropTypes.func.isRequired,
@@ -78,10 +78,10 @@ const EditCustomFieldsRecord = ({
   backendModuleName,
   entityType,
   columnCount,
-  dispatch,
   isReduxForm,
   formName,
   changeFinalFormField,
+  changeReduxFormField,
   fieldComponent: Field,
   reduxFormCustomFieldsValues,
   finalFormCustomFieldsValues,
@@ -127,7 +127,7 @@ const EditCustomFieldsRecord = ({
           if (fieldHasOptions && fieldIsEmpty) {
             const valueToSet = cf.selectField.defaults[0];
 
-            dispatch(changeReduxFormField(formName, `customFields.${cf.refId}`, valueToSet));
+            changeReduxFormField(`customFields.${cf.refId}`, valueToSet);
           }
         } else {
           const fieldIsEmpty = !hasIn(finalFormCustomFieldsValues, cf.refId);
@@ -148,8 +148,8 @@ const EditCustomFieldsRecord = ({
     customFieldsLoaded,
     sectionTitleLoaded,
     changeFinalFormField,
+    changeReduxFormField,
     customFields,
-    dispatch,
     formName,
     isReduxForm,
     reduxFormCustomFieldsValues,
@@ -215,7 +215,6 @@ const EditCustomFieldsRecord = ({
             {renderCustomFieldLabel(customField)}
           </Label>
         ),
-        required: true,
       });
     } else {
       return createCustomFieldRenderFunction(customField)();
@@ -253,5 +252,14 @@ export default connect(
     backendModuleId: selectModuleId(state, ownProps.backendModuleName),
     okapi: selectOkapiData(state),
     reduxFormCustomFieldsValues: get(getFormValues(ownProps.formName)(state), 'customFields'),
-  })
+  }),
+  (dispatch, { formName, isReduxForm }) => {
+    const props = {};
+
+    if (isReduxForm) {
+      props.changeReduxFormField = (fieldName, value) => dispatch(change(formName, fieldName, value));
+    }
+
+    return props;
+  }
 )(EditCustomFieldsRecord);

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -118,7 +118,7 @@ const EditCustomFieldsRecord = ({
       customFields.forEach(cf => {
         const fieldHasOptions = (
           cf.type === fieldTypes.SELECT ||
-          cf.type === fieldTypes.RADIO_BUTTON_SET
+          cf.type === fieldTypes.RADIO_BUTTON_GROUP
         );
 
         const customFieldsFormValues = isReduxForm
@@ -205,7 +205,7 @@ const EditCustomFieldsRecord = ({
       return createCustomFieldRenderFunction(customField)({
         dataOptions: collectDataOptionsForSelect(customField),
       });
-    } else if (customField.type === fieldTypes.RADIO_BUTTON_SET) {
+    } else if (customField.type === fieldTypes.RADIO_BUTTON_GROUP) {
       return createCustomFieldRenderFunction(customField)({
         children: getRadioButtonSetChildren(customField),
         label: (

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -18,7 +18,7 @@ import {
 } from '@folio/stripes-components';
 
 import {
-  change as reduxFormChange,
+  change as changeReduxFormField,
   getFormValues,
 } from 'redux-form';
 
@@ -26,7 +26,6 @@ import {
   fieldComponents,
   rowShapes,
   fieldTypes,
-  formTypes,
 } from '../../constants';
 
 import {
@@ -47,7 +46,7 @@ const propTypes = {
   accordionId: PropTypes.string.isRequired,
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
-  changeFormValue: PropTypes.func,
+  changeFinalFormField: PropTypes.func,
   columnCount: PropTypes.number,
   dispatch: PropTypes.func.isRequired,
   entityType: PropTypes.string.isRequired,
@@ -55,20 +54,19 @@ const propTypes = {
   fieldComponent: PropTypes.func.isRequired,
   finalFormCustomFieldsValues: PropTypes.objectOf(PropTypes.string),
   formName: PropTypes.string,
-  formType: PropTypes.oneOf(Object.values(formTypes)),
+  isReduxForm: PropTypes.bool,
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     token: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
   onToggle: PropTypes.func.isRequired,
-  reduxFormCustomFieldsValues: PropTypes.shape({
-    customFields: PropTypes.objectOf(PropTypes.string),
-  }),
+  reduxFormCustomFieldsValues: PropTypes.objectOf(PropTypes.string),
 };
 
 const defaultProps = {
   columnCount: 4,
+  isReduxForm: false,
 };
 
 const EditCustomFieldsRecord = ({
@@ -81,9 +79,9 @@ const EditCustomFieldsRecord = ({
   entityType,
   columnCount,
   dispatch,
-  formType,
+  isReduxForm,
   formName,
-  changeFormValue,
+  changeFinalFormField,
   fieldComponent: Field,
   reduxFormCustomFieldsValues,
   finalFormCustomFieldsValues,
@@ -123,13 +121,13 @@ const EditCustomFieldsRecord = ({
           cf.type === fieldTypes.RADIO_BUTTON_SET
         );
 
-        if (formType === formTypes.REDUX_FORM) {
+        if (isReduxForm) {
           const fieldIsEmpty = !hasIn(reduxFormCustomFieldsValues, cf.refId);
 
           if (fieldHasOptions && fieldIsEmpty) {
             const valueToSet = cf.selectField.defaults[0];
 
-            dispatch(reduxFormChange(formName, `customFields.${cf.refId}`, valueToSet));
+            dispatch(changeReduxFormField(formName, `customFields.${cf.refId}`, valueToSet));
           }
         } else {
           const fieldIsEmpty = !hasIn(finalFormCustomFieldsValues, cf.refId);
@@ -137,7 +135,7 @@ const EditCustomFieldsRecord = ({
           if (fieldHasOptions && fieldIsEmpty) {
             const valueToSet = cf.selectField.defaults[0];
 
-            changeFormValue(`customFields.${cf.refId}`, valueToSet);
+            changeFinalFormField(`customFields.${cf.refId}`, valueToSet);
           }
         }
       });
@@ -149,11 +147,11 @@ const EditCustomFieldsRecord = ({
   }, [
     customFieldsLoaded,
     sectionTitleLoaded,
-    changeFormValue,
+    changeFinalFormField,
     customFields,
     dispatch,
     formName,
-    formType,
+    isReduxForm,
     reduxFormCustomFieldsValues,
     finalFormCustomFieldsValues,
   ]);

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
-import { chunk } from 'lodash';
+import {
+  chunk,
+  hasIn,
+  get,
+} from 'lodash';
 
 import {
   Accordion,
@@ -9,12 +13,20 @@ import {
   Col,
   Row,
   InfoPopover,
+  RadioButton,
+  Label,
 } from '@folio/stripes-components';
+
+import {
+  change as reduxFormChange,
+  getFormValues,
+} from 'redux-form';
 
 import {
   fieldComponents,
   rowShapes,
   fieldTypes,
+  formTypes,
 } from '../../constants';
 
 import {
@@ -33,16 +45,24 @@ const propTypes = {
   accordionId: PropTypes.string.isRequired,
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
+  changeFormValue: PropTypes.func,
   columnCount: PropTypes.number,
+  dispatch: PropTypes.func.isRequired,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
-  fieldComponent: PropTypes.node.isRequired,
+  fieldComponent: PropTypes.func.isRequired,
+  finalFormCustomFieldsValues: PropTypes.objectOf(PropTypes.string),
+  formName: PropTypes.string,
+  formType: PropTypes.oneOf(Object.values(formTypes)),
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     token: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
   onToggle: PropTypes.func.isRequired,
+  reduxFormCustomFieldsValues: PropTypes.shape({
+    customFields: PropTypes.objectOf(PropTypes.string),
+  }),
 };
 
 const defaultProps = {
@@ -57,8 +77,14 @@ const EditCustomFieldsRecord = ({
   backendModuleId,
   backendModuleName,
   entityType,
-  fieldComponent,
   columnCount,
+  dispatch,
+  formType,
+  formName,
+  changeFormValue,
+  fieldComponent: Field,
+  reduxFormCustomFieldsValues,
+  finalFormCustomFieldsValues,
 }) => {
   const {
     customFields,
@@ -76,9 +102,8 @@ const EditCustomFieldsRecord = ({
   const dataIsLoaded = sectionTitleLoaded && customFieldsLoaded;
   const customFieldsIsVisible = customFields?.length && customFields?.some(customField => customField.visible);
   const accordionIsVisible = dataIsLoaded && customFieldsIsVisible;
-  const Field = fieldComponent;
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
-  const formatedCustomFields = chunk(visibleCustomFields, columnCount);
+  const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const columnWidth = rowShapes / columnCount;
 
   const collectDataOptionsForSelect = (customField) => {
@@ -88,8 +113,63 @@ const EditCustomFieldsRecord = ({
     }));
   };
 
+  useEffect(() => {
+    const initializeFields = () => {
+      customFields.forEach(cf => {
+        const fieldHasOptions = (
+          cf.type === fieldTypes.SELECT ||
+          cf.type === fieldTypes.RADIO_BUTTON_SET
+        );
+
+        if (formType === formTypes.REDUX_FORM) {
+          const fieldIsEmpty = !hasIn(reduxFormCustomFieldsValues, cf.refId);
+
+          if (fieldHasOptions && fieldIsEmpty) {
+            const valueToSet = cf.selectField.defaults[0];
+
+            dispatch(reduxFormChange(formName, `customFields.${cf.refId}`, valueToSet));
+          }
+        } else {
+          const fieldIsEmpty = !hasIn(finalFormCustomFieldsValues, cf.refId);
+
+          if (fieldHasOptions && fieldIsEmpty) {
+            const valueToSet = cf.selectField.defaults[0];
+
+            changeFormValue(`customFields.${cf.refId}`, valueToSet);
+          }
+        }
+      });
+    };
+
+    if (customFieldsLoaded && sectionTitleLoaded) {
+      initializeFields();
+    }
+  }, [
+    customFieldsLoaded,
+    sectionTitleLoaded,
+    changeFormValue,
+    customFields,
+    dispatch,
+    formName,
+    formType,
+    reduxFormCustomFieldsValues,
+    finalFormCustomFieldsValues,
+  ]);
+
+  const renderCustomFieldLabel = customField => (
+    <>
+      {customField.name}
+      {customField.helpText && (
+        <InfoPopover
+          content={customField.helpText}
+          iconSize="small"
+        />
+      )}
+    </>
+  );
+
   const createCustomFieldRenderFunction = customField => (props = {}) => (
-    fieldComponents[customField.type] ?
+    fieldComponents[customField.type] && (
       <Col
         data-test-record-edit-custom-field
         key={customField.refId}
@@ -100,28 +180,40 @@ const EditCustomFieldsRecord = ({
           component={fieldComponents[customField.type]}
           name={`customFields.${customField.refId}`}
           required={customField.required}
-          label={
-            <>
-              {customField.name}
-              {customField.helpText && (
-                <InfoPopover
-                  content={customField.helpText}
-                  iconSize="small"
-                />
-              )}
-            </>
-          }
+          label={renderCustomFieldLabel(customField)}
           validate={validateCustomFields(customField)}
           {...props}
         />
-      </Col> :
-      null
+      </Col>
+    )
   );
 
-  const renderCustomField = (customField) => {
+  const getRadioButtonSetChildren = customField => {
+    return customField.selectField.options.values.map(option => (
+      <RadioButton
+        checked
+        value={option}
+        id={option}
+        label={option}
+        type="radio"
+      />
+    ));
+  };
+
+  const renderCustomField = customField => {
     if (customField.type === fieldTypes.SELECT) {
       return createCustomFieldRenderFunction(customField)({
         dataOptions: collectDataOptionsForSelect(customField),
+      });
+    } else if (customField.type === fieldTypes.RADIO_BUTTON_SET) {
+      return createCustomFieldRenderFunction(customField)({
+        children: getRadioButtonSetChildren(customField),
+        label: (
+          <Label required>
+            {renderCustomFieldLabel(customField)}
+          </Label>
+        ),
+        required: true,
       });
     } else {
       return createCustomFieldRenderFunction(customField)();
@@ -138,7 +230,7 @@ const EditCustomFieldsRecord = ({
           label={sectionTitle.value}
         >
           {
-            formatedCustomFields.map((row, i) => (
+            formattedCustomFields.map((row, i) => (
               <Row key={i}>
                 {row.map(renderCustomField)}
               </Row>
@@ -158,5 +250,6 @@ export default connect(
   (state, ownProps) => ({
     backendModuleId: selectModuleId(state, ownProps.backendModuleName),
     okapi: selectOkapiData(state),
+    reduxFormCustomFieldsValues: get(getFormValues(ownProps.formName)(state), 'customFields'),
   })
 )(EditCustomFieldsRecord);

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -121,20 +121,18 @@ const EditCustomFieldsRecord = ({
           cf.type === fieldTypes.RADIO_BUTTON_SET
         );
 
-        if (isReduxForm) {
-          const fieldIsEmpty = !hasIn(reduxFormCustomFieldsValues, cf.refId);
+        const customFieldsFormValues = isReduxForm
+          ? reduxFormCustomFieldsValues
+          : finalFormCustomFieldsValues;
 
-          if (fieldHasOptions && fieldIsEmpty) {
-            const valueToSet = cf.selectField.defaults[0];
+        const fieldIsEmpty = !hasIn(customFieldsFormValues, cf.refId);
 
+        if (fieldHasOptions && fieldIsEmpty) {
+          const valueToSet = cf.selectField.defaults[0];
+
+          if (isReduxForm) {
             changeReduxFormField(`customFields.${cf.refId}`, valueToSet);
-          }
-        } else {
-          const fieldIsEmpty = !hasIn(finalFormCustomFieldsValues, cf.refId);
-
-          if (fieldHasOptions && fieldIsEmpty) {
-            const valueToSet = cf.selectField.defaults[0];
-
+          } else {
             changeFinalFormField(`customFields.${cf.refId}`, valueToSet);
           }
         }

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -114,7 +114,7 @@ const EditCustomFieldsSettings = ({
       } = cf;
 
       const fieldHasOptions =
-        formData.type === fieldTypes.RADIO_BUTTON_SET ||
+        formData.type === fieldTypes.RADIO_BUTTON_GROUP ||
         formData.type === fieldTypes.SELECT;
 
       if (fieldHasOptions) {
@@ -181,7 +181,7 @@ const EditCustomFieldsSettings = ({
   const formatCustomFieldsForBackend = customFieldsFormData => {
     return customFieldsFormData.customFields.map(({ values: { hidden, ...customFieldData } }) => {
       const fieldHasOptions =
-        customFieldData.type === fieldTypes.RADIO_BUTTON_SET ||
+        customFieldData.type === fieldTypes.RADIO_BUTTON_GROUP ||
         customFieldData.type === fieldTypes.SELECT;
 
       if (fieldHasOptions) {

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -1,9 +1,7 @@
-Currently, custom fields feature provides two components (pages) which can be utilized to edit and view custom fields configuration for a module.
-
-## ViewCustomFieldsSettings
+# ViewCustomFieldsSettings
 `ViewCustomFieldsSettings`'s responsibilities are basically fetching custom fields configuration data for the provided entity type and displaying them inside accordions.
 
-### Usage example
+## Usage example
 ```js
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -34,17 +32,17 @@ class CustomFieldsSettings extends Component {
 export default CustomFieldsSettings;
 ```
 
-### Props
+## Props
 Name | type | description | required
 --- | --- | --- | ---
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
 `entityType` | string | used to filter custom files by particular entity type |true
 `redirectToEdit` | func | function that redirect to route which renders `<EditCustomFieldsSettings />` |true
 
-## EditCustomFieldsSettings
+# EditCustomFieldsSettings
 `EditCustomFieldsSettings` provides the functionality to create, edit and delete custom fields for the provided entity type.
 
-### Usage example
+## Usage example
 ```js
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -76,7 +74,7 @@ class EditCustomFields extends Component {
 export default EditCustomFields;
 ```
 
-### Props
+## Props
 Name | type | description | required
 --- | --- | --- | ---
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
@@ -84,10 +82,10 @@ Name | type | description | required
 `redirectToView` | func | function that redirect to route which renders `<ViewCustomFieldsSettings />` |true
 
 
-## ViewCustomFieldsRecord
+# ViewCustomFieldsRecord
 `ViewCustomFieldsRecord`'s responsibilities are basically fetching custom fields configuration data for displaying accordions with them.
 
-### Usage example
+## Usage example
 ```js
 import { ViewCustomFieldsRecord } from '@folio/stripes/smart-components';
 
@@ -106,7 +104,7 @@ import { ViewCustomFieldsRecord } from '@folio/stripes/smart-components';
 />
 ```
 
-### Props
+## Props
 Name | type | description | required | default
 --- | --- | --- | --- | ---
 `accordionId` | string | used to set accordion id | true |
@@ -119,10 +117,14 @@ Name | type | description | required | default
 
 
 
-## EditCustomFieldsRecord
-`EditCustomFieldsSettings` provides the functionality to create, edit and delete custom fields values for the choosing record.
+# EditCustomFieldsRecord
+`EditCustomFieldsSettings` provides the functionality of changing custom fields values of a particular record.
 
-### Usage example
+## Usage example
+The components supports both `redux-form` and `final-form` and requires specific props for each of them.
+
+### redux-form example
+
 ```js
 import { Field } from 'redux-form';
 import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
@@ -130,22 +132,68 @@ import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
 ---
 
 <EditCustomFieldsRecord
-  accordionId="customFields"
-  backendModuleName="users"
+  isReduxForm
+  formName="userForm"
   entityType="user"
-  expanded={this.state.sections.customFields}
+  backendModuleName="users"
+  accordionId="customFields"
+  onToggle={this.toggleSection}
+  expanded={sections.customFields}
   fieldComponent={Field}
-  onToggle={this.handleSectionToggle}
 />
 ```
 
-### Props
+### final-form example
+
+```js
+import {
+  Field,
+  Form
+} from 'react-final-form';
+
+import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
+
+---
+
+<Form {...formProps}>
+  ({ form: { change, getState } }) => (
+    <EditCustomFieldsRecord
+      changeFinalFormField={change}
+      finalFormCustomFieldsValues={getState().values.customFields}
+      entityType="user"
+      backendModuleName="users"
+      accordionId="customFields"
+      onToggle={this.toggleSection}
+      expanded={sections.customFields}
+      fieldComponent={Field}
+    />
+ </Form>
+```
+
+
+## Props
+
+### General props
 Name | type | description | required | default
 --- | --- | --- | --- | ---
 `accordionId` | string | used to set accordion id | true |
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
-`columnCount` | number | grid display in the same menner as other accordions in current page | false | 4
+`columnCount` | number | grid display in the same manner as other accordions in current page | false | 4
 `entityType` | string | used to filter custom files by particular entity type |true
-`expanded` | boolean | accordion open or closed | true |
-`fieldComponent` | node | Field component | true |
+`expanded` | boolean | indicates if the accordion is open | true |
+`fieldComponent` | func | Field component | true |
 `onToggle` | func | callback for toggling the accordion open/closed | true |
+
+
+### redux-form specific props
+Name | type | description | required | default
+--- | --- | --- | --- | ---
+`isReduxForm` | boolean | indicates that custom fields are used with redux-form | required when redux-form is used | false
+`formName` | string | the name of the redux-form that contains custom field | required when redux-form is used | 
+
+
+### final-form specific props
+Name | type | description | required | default
+--- | --- | --- | --- | ---
+`changeFinalFormField` | func | a function used to change `final-form` field value | required when final-form is used |
+`finalFormCustomFieldsValues` | object | custom fields values stored in final-form state. Can be retrieved using `<Form>` render props: `{form.getState().values.customFields}` | required when final-form is used

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -229,8 +229,6 @@
   "customFields.errorOccurred": "Unable to update due to a module error. Please try again. If problem persists please contact your system administrator.",
   "customFields.dropdown.label": "Label",
   "customFields.dropdown.code": "Code",
-  "customFields.dropdown.default": "Default",
-  "customFields.dropdown.defaults": "Default(s)",
   "customFields.options": "Options",
   "customFields.addOption": "Add option",
   "customFields.option.required": "Option label is required.",
@@ -239,6 +237,7 @@
   "customFields.options.left": "You can add {count, number} more {count, plural, one {option} other {options}}.",
   "customFields.options.maxNumberReached": "You have added the maximum number of options.",
   "customFields.options.default": "Default",
+  "customFields.options.defaults": "Default(s)",
 
   "settings.common.duplicate": "Duplicate",
   "settings.common.edit": "Edit",

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -195,7 +195,7 @@
   "customFields.fieldTypes.TEXTFIELD": "Text field",
   "customFields.fieldTypes.TEXTAREA": "Text area",
   "customFields.fieldTypes.CHECKBOX": "Checkbox",
-  "customFields.fieldTypes.RADIO_BUTTON": "Radio button set",
+  "customFields.fieldTypes.RADIO_BUTTON_GROUP ": "Radio button set",
   "customFields.fieldTypes.SELECT": "Single select",
   "customFields.fieldTypes.MULTISELECT": "Multi-select",
   "customFields.fieldLabel": "Field label",


### PR DESCRIPTION
Requires https://github.com/folio-org/ui-users/pull/1295
## Purpose
To be able to edit and see values of custom fields of type "Radio button set" on entity records

## Approach
### Populating custom fields with their default values
 Some custom fields can have default values (like select and radio button set). It's not possible to pass these default values to a form, since `<Form initialValues={...} />` doesn't live in `stripes-smart-components`. That's why, in order to populate fields with default values, I imperatively change their values after there are rendered.
### Supporting final-form and redux-form
To imperatively change the value of a field it's necessary to know if its a part of `final-form` or `redux-form`. For this purpose, a couple of props were added:
### redux-form props
* `isReduxForm` - used to tell custom fields if they are being rendered inside `redux-form`. If `isReduxForm` is `true`, then custom fields will dispatch `redux-form`'s `change` action to populate fields with default values
* `formName` - when dispatching the `change` action, we need to know the name of the form whose value will be changed

### final-form props
If `isReduxForm` is `false`, then the following props should be passed:
* `changeFormValue` - a function used to change `final-form` field value. We can simply pass `form.change` function passed with `Form` render props
* `finalFormCustomFieldsValues` - custom fields values stored in final-form state. Can be retrieved using `Form` render props:  {form.getState().values.customFields}. 


## Example of using with final-form
```js
<Form ...>
  {({form: { change, getState } }) => (
    <EditCustomFieldsRecord
      changeFormValue={change}
      finalFormCustomFieldsValues={getState().values.customFields}
      accordionId="customFields"
      onToggle={this.toggleSection}
      expanded
      backendModuleName="mod-kb-ebsco-java"
      entityType="package"
      fieldComponent={Field}
    />
  )}
</Form>

```

## Example of using with redux-form
```js
<EditCustomFieldsRecord
  isReduxForm
  formName="userForm"
  accordionId="customFields"
  onToggle={this.handleSectionToggle}
  expanded={sections.customFields}
  backendModuleName="users"
  entityType="user"
  fieldComponent={Field}
/>
```

## Screenshot
![image](https://user-images.githubusercontent.com/43514877/81291884-503c7680-9073-11ea-852e-a05e27d65909.png)
