### PR TITLE
do not use translations from ui repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0 (IN PROGRESS)
 
 * Increment `react-intl` to `v4.5`. Refs STRIPES-672.
+* Do not use translations from `ui-circulation`; that module may not be present. 
 
 ## [3.2.0](IN PROGRESS)
 

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -147,7 +147,7 @@ class EntrySelector extends React.Component {
               }}
             >
               <Icon icon="duplicate">
-                <FormattedMessage id="ui-circulation.settings.common.duplicate" />
+                <FormattedMessage id="stripes-smart-components.settings.common.duplicate" />
               </Icon>
             </Button>
           </IfPermission>
@@ -162,7 +162,7 @@ class EntrySelector extends React.Component {
             }}
           >
             <Icon icon="edit">
-              <FormattedMessage id="ui-circulation.settings.common.edit" />
+              <FormattedMessage id="stripes-smart-components.settings.common.edit" />
             </Icon>
           </Button>
         </IfPermission>
@@ -180,7 +180,7 @@ class EntrySelector extends React.Component {
             }}
           >
             <Icon icon="trash">
-              <FormattedMessage id="ui-circulation.settings.common.delete" />
+              <FormattedMessage id="stripes-smart-components.settings.common.delete" />
             </Icon>
           </Button>
         </IfPermission>

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -237,5 +237,9 @@
   "customFields.characters.limit": "{limit} has been exceeded.",
   "customFields.options.left": "You can add {count, number} more {count, plural, one {option} other {options}}.",
   "customFields.options.maxNumberReached": "You have added the maximum number of options.",
-  "customFields.options.default": "Default"
+  "customFields.options.default": "Default",
+
+  "settings.common.duplicate": "Duplicate",
+  "settings.common.edit": "Edit",
+  "settings.common.delete": "Delete"
 }


### PR DESCRIPTION
Do not use translation keys from `ui-circulation`. Only repositories
below this one in the stripes hierarchy may be used because only those
are guaranteed to be present.