### PR TITLE
STSMACOM-334: Increased space for notes date column

### DIFF
--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -12,17 +12,17 @@ const defaultColumnsConfig = [
   {
     name: 'date',
     title: <FormattedMessage id="stripes-smart-components.date" />,
-    width: '10%',
+    width: '20%',
   },
   {
     name: 'title',
     title: <FormattedMessage id="stripes-smart-components.title" />,
-    width: '50%',
+    width: '45%',
   },
   {
     name: 'type',
     title: <FormattedMessage id="stripes-smart-components.type" />,
-    width: '40%',
+    width: '35%',
   },
 ];
 


### PR DESCRIPTION
## Purpose
- Increase space for `date` column to fit all digits in one row

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/82032949-b2fdc580-96a4-11ea-8ca3-a90a6c69d6b9.png)
