### PR TITLE
UIU-1641: New/Edit User Record: Primary address toggle uses invalid ARIA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.2.0] (IN PROGRESS)
 
 * Edit/View Custom Fields UI updates. Refs STSMACOM-355.
+* Removing aria-labelledby attribute from primary address radio button.  Fixes UIU-1641
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -136,12 +136,6 @@ class EmbeddedAddressForm extends React.Component {
           id={props.id}
           onChange={() => { this.singlePrimary(fieldKey); }}
           name="primary"
-          aria-labelledby={
-            intl.formatMessage(
-              { id: 'stripes-smart-components.addressEdit.useAddressAsPrimaryAddress' },
-              { index: fieldKey + 1 }
-            )
-          }
         />
         <FormattedMessage id="stripes-smart-components.addressEdit.useAsPrimaryAddress" />
       </label>


### PR DESCRIPTION
After looking up how the aria-labelledby attribute is supposed to be used,
I decided to remove this attribute entirely from the radio button. This
attribute is supposed to tell assistive technologies what label is associated
with this form control.  But the label in question already wraps around the
control, making it clear from context what form control it's associated with.
The label/control shouldn't need any attribute to associate the two.

Refs: https://issues.folio.org/browse/UIU-1641