### PR TITLE
UIREQ-457: Add 'label' prop to '<NotesSmartAccordion>'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Allow loading more than 10 Custom Fields. Refs STSMACOM-370.
 * Fix cannot select a radio button when multiple Custom Field radio button sets are created. Refs STSMACOM-373.
 * Display custom fields accordion with a spinner while custom fields data is being loaded.
+* Add `label` prop to `<NotesSmartAccordion>` and `createFormTitle` for `<NoteForm>`. Part of UIREQ-457.
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)

--- a/lib/Notes/NoteCreatePage/NoteCreatePage.js
+++ b/lib/Notes/NoteCreatePage/NoteCreatePage.js
@@ -27,6 +27,7 @@ class NoteCreatePage extends Component {
     }).isRequired,
     navigateBack: PropTypes.func.isRequired,
     paneHeaderAppIcon: PropTypes.string.isRequired,
+    paneTitle: PropTypes.node,
     referredEntityData: referredEntityDataShape.isRequired,
     resources: PropTypes.shape({
       noteTypesData: PropTypes.shape({
@@ -37,6 +38,10 @@ class NoteCreatePage extends Component {
       hasPerm: PropTypes.func.isRequired,
     }),
   }
+
+  static defaultProps = {
+    paneTitle: <FormattedMessage id="stripes-smart-components.notes.newNote" />,
+  };
 
   static manifest = Object.freeze({
     noteTypesData: {
@@ -119,6 +124,7 @@ class NoteCreatePage extends Component {
       referredEntityData,
       entityTypeTranslationKeys,
       paneHeaderAppIcon,
+      paneTitle,
       navigateBack,
       stripes,
     } = this.props;
@@ -147,6 +153,7 @@ class NoteCreatePage extends Component {
                 submitIsPending={submitIsPending}
                 submitSucceeded={submitSucceeded}
                 paneHeaderAppIcon={paneHeaderAppIcon}
+                createFormTitle={paneTitle}
                 onSubmit={this.onSubmit}
                 navigateBack={navigateBack}
               />

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -5,6 +5,7 @@ import {
   pick,
 } from 'lodash';
 import { withRouter } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
 
 import {
   stripesConnect,
@@ -40,6 +41,7 @@ class NotesSmartAccordion extends Component {
     hideAssignButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     mutator: PropTypes.object.isRequired,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -52,6 +54,7 @@ class NotesSmartAccordion extends Component {
 
   static defaultProps = {
     hideAssignButton: false,
+    label: <FormattedMessage id="stripes-smart-components.notes" />,
   };
 
   static manifest = Object.freeze({
@@ -287,6 +290,7 @@ class NotesSmartAccordion extends Component {
       open,
       id,
       hideAssignButton,
+      label,
     } = this.props;
 
     return (
@@ -309,6 +313,7 @@ class NotesSmartAccordion extends Component {
           open={open}
           hideAssignButton={hideAssignButton}
           onToggle={onToggle}
+          label={label}
         />
       </IfPermission>
     );

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -40,6 +40,7 @@ import styles from './NoteForm.css';
 
 export default class NoteForm extends Component {
   static propTypes = {
+    createFormTitle: PropTypes.node.isRequired,
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
     entityTypeTranslationKeys: PropTypes.objectOf(PropTypes.string).isRequired,
     navigateBack: PropTypes.func.isRequired,
@@ -249,6 +250,7 @@ export default class NoteForm extends Component {
 
   render() {
     const {
+      createFormTitle,
       onSubmit,
       referredEntityData,
       noteData,
@@ -272,7 +274,7 @@ export default class NoteForm extends Component {
           values={{ noteTitle: noteData.title }}
         />
       )
-      : <FormattedMessage id="stripes-smart-components.notes.newNote" />;
+      : createFormTitle;
 
     const paneTitleAppIcon = <AppIcon app={paneHeaderAppIcon} size="small" />;
     const noteTypeInitialValue = isEditForm

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -21,6 +21,7 @@ export default class NotesAccordion extends Component {
   static propTypes = {
     hideAssignButton: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     onAssignedNoteClick: PropTypes.func.isRequired,
     onNoteCreateButtonClick: PropTypes.func.isRequired,
     onResetSearchResults: PropTypes.func.isRequired,
@@ -50,7 +51,7 @@ export default class NotesAccordion extends Component {
   renderHeader = () => {
     return (
       <Headline size="large" tag="h3">
-        <FormattedMessage id="stripes-smart-components.notes" />
+        {this.props.label}
       </Headline>
     );
   };


### PR DESCRIPTION
## Description

Add possibility to change Notes accordion label. In scope of [UIREQ-457](https://issues.folio.org/browse/UIREQ-457) we need to show `Staff notes` instead of `Notes` accordion name

## Screenshot

<img width="960" alt="2_RequestNoNotesOpenAccordion" src="https://user-images.githubusercontent.com/55701515/84875607-dc888300-b08e-11ea-8d4d-093bdfc89e48.png">
