### PR TITLE
STSMACOM-370: Settings > Users > Custom Fields: Only 10 custom fields display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Edit/View Custom Fields UI updates. Refs STSMACOM-355.
 * Allow a user to not select any option in a single select custom field Refs UIU-1673.
 * Removing aria-labelledby attribute from primary address radio button.  Fixes UIU-1641
+* Allow loading more than 10 Custom Fields. Refs STSMACOM-370.
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)

--- a/lib/CustomFields/utils/useCustomFieldsFetch.js
+++ b/lib/CustomFields/utils/useCustomFieldsFetch.js
@@ -14,7 +14,7 @@ const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
 
   useEffect(() => {
     const fetchCustomFields = async () => {
-      const response = await makeOkapiRequest('custom-fields')({
+      const response = await makeOkapiRequest('custom-fields?limit=2147483647')({
         method: 'GET',
       });
 

--- a/lib/CustomFields/utils/useCustomFieldsFetch.js
+++ b/lib/CustomFields/utils/useCustomFieldsFetch.js
@@ -2,6 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 
 import makeRequest from './makeRequest';
 
+// max signed int value, specified in mod-customfields API documentation
+const MAX_RECORDS = 2147483647;
+
 const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
   const [customFieldsLoaded, setCustomFieldsLoaded] = useState(false);
   const [customFields, setCustomFields] = useState(null);
@@ -14,7 +17,7 @@ const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
 
   useEffect(() => {
     const fetchCustomFields = async () => {
-      const response = await makeOkapiRequest('custom-fields?limit=2147483647')({
+      const response = await makeOkapiRequest(`custom-fields?limit=${MAX_RECORDS}`)({
         method: 'GET',
       });
 


### PR DESCRIPTION
## Purpose
- Apply limit to `/custom-fields` request to allow loading more than 10 Custom Fields