### PR TITLE
UIU-1700, UIU-1690, STSMACOM-368: fix custom fields issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Edit/View Custom Fields UI updates. Refs STSMACOM-355.
 * Allow a user to not select any option in a single select custom field Refs UIU-1673.
 * Removing aria-labelledby attribute from primary address radio button.  Fixes UIU-1641
+* Remove asterisk from radio button custom field label. Fixes UIU-1700
+* Apply correct styling to the save button on the edit custom fields page. Fixes STSMACOM-368
+* Make checkbox custom field correctly reflect form state. Fixes UIU-1690
+
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)

--- a/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
+++ b/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
@@ -152,6 +152,7 @@ const CustomFieldsForm = ({
       <Button
         marginBottom0
         type="submit"
+        buttonStyle="primary"
         disabled={buttonsDisabled}
         data-test-custom-fields-save-button
       >

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -276,6 +276,8 @@ const EditCustomFieldsRecord = ({
           label: customField.selectField.options.values.find(_option => _option.id === option)?.value || option,
         })),
       });
+    } else if (customField.type === fieldTypes.CHECKBOX) {
+      return createCustomFieldRenderFunction(customField)({ type: 'checkbox' });
     } else {
       return createCustomFieldRenderFunction(customField)();
     }

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -261,7 +261,7 @@ const EditCustomFieldsRecord = ({
       return createCustomFieldRenderFunction(customField)({
         children: getRadioButtonSetChildren(customField),
         label: (
-          <Label required>
+          <Label>
             {renderCustomFieldLabel(customField)}
           </Label>
         ),

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -115,7 +115,7 @@ const ViewCustomFieldsRecord = ({
 
     const customFieldValue = customFieldsValues[refId];
 
-    if (customFieldValue) {
+    if (refId in customFieldsValues && customFieldValue !== '') {
       if (type === MULTISELECT && customFieldValue.length) {
         return getMultiselectOptionLabels(customField);
       }


### PR DESCRIPTION
The purpose of this pr is to fix a couple of minor CF-related issues: 
* Remove asterisk from radio button custom field label (UIU-1700)
* Apply correct styling to the save button on the edit custom fields page (STSMACOM-368)
* Make checkbox custom field correctly reflect the form state when saving a record for the first time (UIU-1690)
