### PR TITLE
UIU-1702: make custom fields accordion visible while data is being loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make checkbox custom field correctly reflect form state. Fixes UIU-1690
 * Allow loading more than 10 Custom Fields. Refs STSMACOM-370.
 * Fix cannot select a radio button when multiple Custom Field radio button sets are created. Refs STSMACOM-373.
+* Display custom fields accordion with a spinner while custom fields data is being loaded.
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)
@@ -35,7 +36,7 @@
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v3.1.0...v4.0.0)
 
 * Increment `react-intl` to `v4.5`. Refs STRIPES-672.
-* Do not use translations from `ui-circulation`; that module may not be present. 
+* Do not use translations from `ui-circulation`; that module may not be present.
 * Test clean-up etc related to the babel-7 upgrade. Refs STCOR-381.
 
 ## 3.2.0 (UNRELEASED)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -20,6 +20,7 @@ import {
   InfoPopover,
   RadioButton,
   Label,
+  Icon,
 } from '@folio/stripes-components';
 
 import {
@@ -106,9 +107,7 @@ const EditCustomFieldsRecord = ({
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
-  const dataIsLoaded = sectionTitleLoaded && customFieldsLoaded;
-  const customFieldsIsVisible = customFields?.length && customFields?.some(customField => customField.visible);
-  const accordionIsVisible = dataIsLoaded && customFieldsIsVisible;
+  const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const columnWidth = rowShapes / columnCount;
@@ -286,15 +285,18 @@ const EditCustomFieldsRecord = ({
 
   return (
     <>
-      {accordionIsVisible && (
+      {(!customFieldsLoaded || customFieldsIsVisible) && (
         <Accordion
           open={expanded}
           id={accordionId}
           onToggle={onToggle}
-          label={sectionTitle.value}
+          label={sectionTitleLoaded
+            ? sectionTitle.value
+            : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
+          }
         >
           {
-            formattedCustomFields.map((row, i) => (
+            customFieldsLoaded && formattedCustomFields.map((row, i) => (
               <Row key={i}>
                 {row.map(renderCustomField)}
               </Row>

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -20,7 +20,7 @@ describe('EditCustomFieldsRecord', () => {
 
   const renderComponent = (props = {}) => {
     const FormComponent = () => (
-      <Form onSubmit={() => {}}>
+      <Form onSubmit={() => { }}>
         {({ form: { getState } }) => (
           <EditCustomFieldsRecord
             accordionId="test-accordion-id"
@@ -52,13 +52,14 @@ describe('EditCustomFieldsRecord', () => {
     onToggle.resetHistory();
   });
 
-  describe('when custom fields are not loaded', () => {
+  describe('when there are no custom fields', () => {
     beforeEach(async function () {
       this.server.get('/custom-fields', {
         'customFields': [],
       });
 
       await renderComponent();
+      await editCustomFields.whenCustomFieldsLoaded();
     });
 
     it('should not show custom fields accordion', () => {

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -20,7 +20,7 @@ describe('EditCustomFieldsRecord', () => {
 
   const renderComponent = (props = {}) => {
     const FormComponent = () => (
-      <Form onSubmit={() => { }}>
+      <Form onSubmit={() => {}}>
         {({ form: { getState } }) => (
           <EditCustomFieldsRecord
             accordionId="test-accordion-id"

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/interactor.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/interactor.js
@@ -11,4 +11,9 @@ export default interactor(class EditCustomFieldsRecord {
   accordionIsPresent = isPresent('#test-accordion-id');
 
   customFields = collection('[data-test-record-edit-custom-field]');
+  loadingIconIsPresent = isPresent('[data-test-custom-fields-loading-icon]');
+
+  whenCustomFieldsLoaded() {
+    return this.when(() => !this.loadingIconIsPresent);
+  }
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -11,6 +11,7 @@ import {
   Row,
   Col,
   Checkbox,
+  Icon,
 } from '@folio/stripes-components';
 
 import {
@@ -82,9 +83,7 @@ const ViewCustomFieldsRecord = ({
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
-  const dataIsLoaded = sectionTitleLoaded && customFieldsLoaded;
-  const customFieldsIsVisible = customFields?.length && customFields?.some(customField => customField.visible);
-  const accordionIsVisible = dataIsLoaded && customFieldsIsVisible;
+  const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);
   const columnWidth = rowShapes / columnCount;
 
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
@@ -143,33 +142,35 @@ const ViewCustomFieldsRecord = ({
 
   return (
     <>
-      {accordionIsVisible && (
+      {(!customFieldsLoaded || customFieldsIsVisible) && (
         <Accordion
           open={expanded}
           id={accordionId}
           onToggle={onToggle}
-          label={sectionTitle.value}
+          label={sectionTitleLoaded
+            ? sectionTitle.value
+            : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
+          }
         >
-          {
-            formattedCustomFields.map((row, i) => (
-              <Row key={i}>
-                {
-                  row.map(customField => (
-                    <Col
-                      key={customField.refId}
-                      md={columnWidth}
-                      xs={rowShapes}
-                      data-test-col-custom-field
-                    >
-                      <KeyValue
-                        label={customField.name}
-                        value={formatValue(customField)}
-                      />
-                    </Col>
-                  ))
-                }
-              </Row>
-            ))
+          {customFieldsLoaded && formattedCustomFields.map((row, i) => (
+            <Row key={i}>
+              {
+                row.map(customField => (
+                  <Col
+                    key={customField.refId}
+                    md={columnWidth}
+                    xs={rowShapes}
+                    data-test-col-custom-field
+                  >
+                    <KeyValue
+                      label={customField.name}
+                      value={formatValue(customField)}
+                    />
+                  </Col>
+                ))
+              }
+            </Row>
+          ))
           }
         </Accordion>
       )}


### PR DESCRIPTION
## Purpose 
To show custom fields accordion with the loading icon until the data is loaded.
![Users - FOLIO - Google Chrome 2020-06-22 11-11-49](https://user-images.githubusercontent.com/43514877/85264943-29e36680-b47a-11ea-9dd1-ee3ad4784f0f.gif)

