### PR TITLE
STSMACOM-378: Add ability to customize path used after search is performed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix cannot select a radio button when multiple Custom Field radio button sets are created. Refs STSMACOM-373.
 * Display custom fields accordion with a spinner while custom fields data is being loaded.
 * Add `label` prop to `<NotesSmartAccordion>` and `createFormTitle` for `<NoteForm>`. Part of UIREQ-457.
+* Introduce `basePath` prop to add ability to control the path after search is performed. Part of STSMACOM-378.
 
 ## [4.1.1](https://github.com/folio-org/stripes-smart-components/tree/v4.1.1) (2020-07-12)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.0...v4.1.1)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -77,6 +77,7 @@ class SearchAndSort extends React.Component {
     actionMenu: PropTypes.func, // parameter properties provided by caller
     apolloQuery: PropTypes.object, // machine-readable
     apolloResource: PropTypes.string,
+    basePath: PropTypes.string,
     browseOnly: PropTypes.bool,
     columnMapping: PropTypes.object,
     columnWidths: PropTypes.object,
@@ -488,11 +489,12 @@ class SearchAndSort extends React.Component {
       history,
       nsParams,
       browseOnly,
+      basePath,
       parentMutator: { query },
     } = this.props;
 
     const nsValues = mapNsKeys(values, nsParams);
-    const url = buildUrl(location, nsValues);
+    const url = buildUrl(location, nsValues, basePath);
 
     // react-router doesn't work well with our 'plugin' setup
     // so unfortunately we still have to rely on query resource

--- a/lib/SearchAndSort/buildUrl.js
+++ b/lib/SearchAndSort/buildUrl.js
@@ -19,9 +19,9 @@ function removeEmpty(obj) {
   return cleanObj;
 }
 
-export default function buildUrl(location, values) {
+export default function buildUrl(location, values, basePath) {
   const locationQuery = getLocationQuery(location);
-  let url = values._path || location.pathname;
+  let url = values._path || basePath || location.pathname;
   const params = removeEmpty(Object.assign(locationQuery, values));
 
   unset(params, '_path');

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -58,6 +58,7 @@ getHelperResourcePath | func | An optional function which can be used to return 
 getHelperComponent | func | An optional function which can be used to return connected helper component implementation.
 title | string/element | An optional property to specify title of results pane. By default module display name is used.
 hasNewButton | boolean | An optional property to specify appearance Of `New` button of results pane. By default pane displays with `New` button.
+basePath | string | An optional string to customize the path which should be used after performing search.
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mocha": "^5.2.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-intl": "^4.5.3",
+    "react-intl": "^4.7.2",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.0.0",


### PR DESCRIPTION
This PR adds a new prop to `SearchAndSort` called `basePath` which can be used to control which path should be used after search is performed.

https://issues.folio.org/browse/STSMACOM-378

This should help with addressing issue described in https://issues.folio.org/browse/UIIN-1074