### PR TITLE
UIREQ-459: Extend NotesSmartAccordion interactor

### DIFF
--- a/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
+++ b/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
@@ -6,6 +6,7 @@ import {
   text,
   isVisible,
 } from '@bigtest/interactor';
+import { isEmpty } from 'lodash';
 
 @interactor class Button {
   isDisplayed = isVisible();
@@ -18,6 +19,7 @@ import {
   newButtonDisplayed = isPresent('[data-test-notes-accordion-new-button]');
   clickAssignButton = clickable('[data-test-notes-accordion-assign-button]');
   clickNewButton = clickable('[data-test-notes-accordion-new-button]');
+  clickCloseButton = clickable('[data-test-leave-note-view]');
 
   newButton = new Button('[data-test-notes-accordion-new-button]');
   assignButton = new Button('[data-test-notes-accordion-assign-button]');
@@ -27,6 +29,10 @@ import {
     click: clickable(),
     title: text('[class^="mclCell":last-child]'),
   });
+
+  whenNotesLoaded() {
+    return this.when(() => !isEmpty(this.notes));
+  }
 }
 
 export default NotesAccordion;


### PR DESCRIPTION
## Purpose
- Extend `<NotesSmartAccordion>` interactor to support testing navigating back