### PR TITLE
UIREQ-467: Add changeable content to assigned accordion to Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
 * Add alphabetical sorting of Custom Field options. Refs STSMACOM-379.
+* Add changeable content to assigned accordion to NotesView and NotesForm components. Part of UIREQ-467.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/Notes/NoteCreatePage/NoteCreatePage.js
+++ b/lib/Notes/NoteCreatePage/NoteCreatePage.js
@@ -29,6 +29,7 @@ class NoteCreatePage extends Component {
     paneHeaderAppIcon: PropTypes.string.isRequired,
     paneTitle: PropTypes.node,
     referredEntityData: referredEntityDataShape.isRequired,
+    renderReferredRecord: PropTypes.func,
     resources: PropTypes.shape({
       noteTypesData: PropTypes.shape({
         records: PropTypes.arrayOf(noteTypesCollectionShape).isRequired,
@@ -121,6 +122,7 @@ class NoteCreatePage extends Component {
 
   render() {
     const {
+      renderReferredRecord,
       referredEntityData,
       entityTypeTranslationKeys,
       paneHeaderAppIcon,
@@ -147,6 +149,7 @@ class NoteCreatePage extends Component {
           {pageTitle => (
             <TitleManager record={pageTitle}>
               <NoteForm
+                renderReferredRecord={renderReferredRecord}
                 noteTypes={this.getNoteTypesSelectOptions()}
                 referredEntityData={referredEntityData}
                 entityTypeTranslationKeys={entityTypeTranslationKeys}

--- a/lib/Notes/NoteEditPage/NoteEditPage.js
+++ b/lib/Notes/NoteEditPage/NoteEditPage.js
@@ -36,6 +36,7 @@ class NoteEditPage extends Component {
       referredEntityDataShape,
       PropTypes.bool
     ]),
+    renderReferredRecord: PropTypes.func,
     resources: PropTypes.shape({
       note: PropTypes.object,
       noteTypesData: PropTypes.shape({
@@ -139,6 +140,7 @@ class NoteEditPage extends Component {
 
   renderNoteForm() {
     const {
+      renderReferredRecord,
       referredEntityData,
       entityTypeTranslationKeys,
       entityTypePluralizedTranslationKeys,
@@ -165,6 +167,7 @@ class NoteEditPage extends Component {
               referredEntityData={referredEntityData}
               entityTypeTranslationKeys={entityTypeTranslationKeys}
               entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+              renderReferredRecord={renderReferredRecord}
               submitIsPending={submitIsPending}
               submitSucceeded={submitSucceeded}
               paneHeaderAppIcon={paneHeaderAppIcon}

--- a/lib/Notes/NoteViewPage/NoteViewPage.js
+++ b/lib/Notes/NoteViewPage/NoteViewPage.js
@@ -39,6 +39,7 @@ class NoteViewPage extends Component {
       referredEntityDataShape,
       PropTypes.bool
     ]),
+    renderReferredRecord: PropTypes.func,
     resources: PropTypes.shape({
       note: PropTypes.shape({
         records: PropTypes.arrayOf(noteShape),
@@ -209,6 +210,7 @@ class NoteViewPage extends Component {
 
   renderViewPage = () => {
     const {
+      renderReferredRecord,
       referredEntityData,
       entityTypeTranslationKeys,
       entityTypePluralizedTranslationKeys,
@@ -234,6 +236,7 @@ class NoteViewPage extends Component {
         {pageTitle => (
           <TitleManager record={pageTitle}>
             <NoteView
+              renderReferredRecord={renderReferredRecord}
               referredEntityData={referredEntityData}
               entityTypeTranslationKeys={entityTypeTranslationKeys}
               entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -53,6 +53,7 @@ export default class NoteView extends Component {
       referredEntityDataShape,
       PropTypes.bool
     ]),
+    renderReferredRecord: PropTypes.func,
   };
 
   state = {
@@ -103,18 +104,22 @@ export default class NoteView extends Component {
     );
   }
 
-  renderReferredRecord() {
+  renderReferredRecordElement() {
     const {
+      renderReferredRecord,
       referredEntityData,
       entityTypeTranslationKeys,
+      noteData,
     } = this.props;
 
-    return (
-      <ReferredRecord
-        referredEntityData={referredEntityData}
-        entityTypeTranslationKeys={entityTypeTranslationKeys}
-      />
-    );
+    return renderReferredRecord
+      ? renderReferredRecord(noteData)
+      : (
+        <ReferredRecord
+          referredEntityData={referredEntityData}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+        />
+      );
   }
 
   renderFirstMenu = () => {
@@ -219,6 +224,7 @@ export default class NoteView extends Component {
     return (
       <Paneset>
         <Pane
+          data-test-note-view
           paneTitle={paneTitle}
           appIcon={paneTitleAppIcon}
           actionMenu={this.getActionMenu}
@@ -282,7 +288,7 @@ export default class NoteView extends Component {
                 closedByDefault
                 onToggle={this.handleSectionToggle}
               >
-                {referredEntityData && this.renderReferredRecord()}
+                {referredEntityData && this.renderReferredRecordElement()}
                 <AssignmentsList
                   links={noteData.links}
                   entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
@@ -1,0 +1,16 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
+import ReferredRecordInteractor from '../../../../components/ReferredRecord/tests/interactor';
+
+export default interactor(class NoteViewInteractor {
+  static defaultScope = '[data-test-note-view]';
+
+  assignedAccordion = new AccordionInteractor('#assigned');
+  defaultReferredRecord = new ReferredRecordInteractor();
+  insertedReferredRecord = scoped('[data-test-inserted-referred-record]');
+});

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import NoteView from '../NoteView';
+import NoteViewInteractor from './interactor';
+import {
+  mount,
+  setupApplication,
+} from '../../../../../../tests/helpers';
+
+const referredEntityData = {
+  name: 'Test Name',
+  type: 'Type',
+  id: '1',
+};
+const entityTypeTranslationKeys = { [referredEntityData.type]: 'Test' };
+const entityTypePluralizedTranslationKeys = { request: 'Request' };
+const noteData = {
+  content: undefined,
+  links: [{
+    id: '8460928a-0cc9-482f-b68a-1f0db7624439',
+    type: 'request',
+  }],
+  title: 'Local information',
+  type: 'General note',
+};
+
+describe('NoteView', () => {
+  const noteView = new NoteViewInteractor();
+
+  describe('rendering NoteView component', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(
+        <NoteView
+          noteData={noteData}
+          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+          referredEntityData={referredEntityData}
+        />
+      );
+    });
+
+    it('should display NoteView component', () => {
+      expect(noteView.isPresent).to.be.true;
+    });
+
+    it('assigned accordion should be closed', () => {
+      expect(noteView.assignedAccordion.isOpen).to.be.false;
+    });
+
+    it('should display default Referred Record element', () => {
+      expect(noteView.defaultReferredRecord.isPresent).to.be.true;
+    });
+  });
+
+  describe('rendering NoteView component with inserted Referred Record element', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(
+        <NoteView
+          noteData={noteData}
+          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+          referredEntityData={referredEntityData}
+          renderReferredRecord={() => <div data-test-inserted-referred-record>Test</div>}
+        />
+      );
+    });
+
+    it('should display inserted Reffered Record element', () => {
+      expect(noteView.insertedReferredRecord.isPresent).to.be.true;
+    });
+  });
+});

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -47,6 +47,7 @@ class NotesSmartAccordion extends Component {
     open: PropTypes.bool,
     pathToNoteCreate: PropTypes.string.isRequired,
     pathToNoteDetails: PropTypes.string.isRequired,
+    referredRecordData: PropTypes.object,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
     }).isRequired,
@@ -55,6 +56,7 @@ class NotesSmartAccordion extends Component {
   static defaultProps = {
     hideAssignButton: false,
     label: <FormattedMessage id="stripes-smart-components.notes" />,
+    referredRecordData: {},
   };
 
   static manifest = Object.freeze({
@@ -241,6 +243,7 @@ class NotesSmartAccordion extends Component {
       entityType,
       entityId,
       history,
+      referredRecordData,
     } = this.props;
 
     history.push({
@@ -249,6 +252,7 @@ class NotesSmartAccordion extends Component {
         entityName,
         entityType,
         entityId,
+        referredRecordData,
       },
     });
   }
@@ -260,6 +264,7 @@ class NotesSmartAccordion extends Component {
       entityName,
       entityType,
       entityId,
+      referredRecordData,
     } = this.props;
 
     history.push({
@@ -268,6 +273,7 @@ class NotesSmartAccordion extends Component {
         entityName,
         entityType,
         entityId,
+        referredRecordData,
       },
     });
   }

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -58,6 +58,7 @@ export default class NoteForm extends Component {
       referredEntityDataShape,
       PropTypes.bool
     ]),
+    renderReferredRecord: PropTypes.func,
     submitIsPending: PropTypes.bool.isRequired,
     submitSucceeded: PropTypes.bool.isRequired,
   };
@@ -193,18 +194,21 @@ export default class NoteForm extends Component {
     );
   }
 
-  renderReferredRecord() {
+  renderReferredRecordElement() {
     const {
+      renderReferredRecord,
       referredEntityData,
       entityTypeTranslationKeys,
     } = this.props;
 
-    return (
-      <ReferredRecord
-        referredEntityData={referredEntityData}
-        entityTypeTranslationKeys={entityTypeTranslationKeys}
-      />
-    );
+    return renderReferredRecord
+      ? renderReferredRecord()
+      : (
+        <ReferredRecord
+          referredEntityData={referredEntityData}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+        />
+      );
   }
 
   isEditForm = () => {
@@ -327,7 +331,7 @@ export default class NoteForm extends Component {
                         closedByDefault
                         onToggle={this.handleSectionToggle}
                       >
-                        {referredEntityData && this.renderReferredRecord()}
+                        {referredEntityData && this.renderReferredRecordElement()}
                         <AssignmentsList
                           links={links}
                           entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}

--- a/lib/Notes/components/NoteForm/tests/interactor.js
+++ b/lib/Notes/components/NoteForm/tests/interactor.js
@@ -1,0 +1,16 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
+import ReferredRecordInteractor from '../../ReferredRecord/tests/interactor';
+
+export default interactor(class NoteFormInteractor {
+  static defaultScope = '#notes-form';
+
+  assignedAccordion = new AccordionInteractor('#assigned');
+  defaultReferredRecord = new ReferredRecordInteractor();
+  insertedReferredRecord = scoped('[data-test-inserted-referred-record]');
+});

--- a/lib/Notes/components/NoteForm/tests/note-form-test.js
+++ b/lib/Notes/components/NoteForm/tests/note-form-test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import NoteForm from '../NoteForm';
+import NoteFormInteractor from './interactor';
+import {
+  mount,
+  setupApplication,
+} from '../../../../../tests/helpers';
+import translation from '../../../../../translations/stripes-smart-components/en';
+
+const referredEntityData = {
+  name: 'Test Name',
+  type: 'Type',
+  id: '1',
+};
+const entityTypeTranslationKeys = { [referredEntityData.type]: 'Test' };
+const entityTypePluralizedTranslationKeys = { request: 'Request' };
+const noteData = {
+  content: undefined,
+  links: [{
+    id: '8460928a-0cc9-482f-b68a-1f0db7624439',
+    type: 'request',
+  }],
+  title: 'Local information',
+  type: 'General note',
+};
+const noteTypes = [{
+  label: 'General note',
+  value: '7d33b190-586a-41fa-b649-924c2d69c14c',
+}];
+
+const props = {
+  createFormTitle: translation['notes.newNote'],
+  entityTypePluralizedTranslationKeys,
+  entityTypeTranslationKeys,
+  navigateBack: () => {},
+  noteData,
+  noteTypes,
+  onSubmit: () => {},
+  paneHeaderAppIcon: 'requests',
+  referredEntityData,
+  submitIsPending: false,
+  submitSucceeded: false,
+};
+
+describe('NoteForm', () => {
+  const noteForm = new NoteFormInteractor();
+
+  describe('rendering NoteForm component', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(<NoteForm {...props} />);
+    });
+
+    it('should display NoteForm component', () => {
+      expect(noteForm.isPresent).to.be.true;
+    });
+
+    it('assigned accordion should be closed', () => {
+      expect(noteForm.assignedAccordion.isOpen).to.be.false;
+    });
+
+    it('should display default Referred Record element', () => {
+      expect(noteForm.defaultReferredRecord.isPresent).to.be.true;
+    });
+  });
+
+  describe('rendering NoteForm component with inserted Referred Record element', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(
+        <NoteForm
+          {...props}
+          renderReferredRecord={() => <div data-test-inserted-referred-record>Test</div>}
+        />
+      );
+    });
+
+    it('should display inserted Reffered Record element', () => {
+      expect(noteForm.insertedReferredRecord.isPresent).to.be.true;
+    });
+  });
+});

--- a/lib/Notes/components/ReferredRecord/tests/interactor.js
+++ b/lib/Notes/components/ReferredRecord/tests/interactor.js
@@ -1,0 +1,11 @@
+import {
+  interactor,
+  text,
+} from '@bigtest/interactor';
+
+export default interactor(class ReferredRecordInteractor {
+  static defaultScope = '[class*=kvRoot---]';
+
+  referredEntityType = text('[data-test-referred-entity-type]');
+  referredEntityName = text('[data-test-referred-entity-name]');
+});

--- a/lib/Notes/components/ReferredRecord/tests/referred-record-test.js
+++ b/lib/Notes/components/ReferredRecord/tests/referred-record-test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import ReferredRecord from '../ReferredRecord';
+import ReferredRecordInteractor from './interactor';
+import {
+  mount,
+  setupApplication,
+} from '../../../../../tests/helpers';
+
+
+describe('ReferredRecord', () => {
+  const referredRecord = new ReferredRecordInteractor();
+  const referredEntityData = {
+    name: 'Test Name',
+    type: 'Type',
+    id: '1',
+  };
+  const entityTypeTranslationKeys = { [referredEntityData.type]: 'Test' };
+
+  setupApplication();
+
+  describe('rendering referredRecord component', () => {
+    beforeEach(() => {
+      mount(
+        <ReferredRecord
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+          referredEntityData={referredEntityData}
+        />
+      );
+    });
+
+    it('should display referredRecord component', () => {
+      expect(referredRecord.isPresent).to.be.true;
+    });
+
+    it('should display correct title', () => {
+      expect(referredRecord.referredEntityType).to.equal(entityTypeTranslationKeys[referredEntityData.type]);
+    });
+
+    it('should display correct name', () => {
+      expect(referredRecord.referredEntityName).to.equal(referredEntityData.name);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add changeable content to NotesView and NotesForm components to show it in Assigned accordion. Part of [UIREQ-467](https://issues.folio.org/browse/UIREQ-467)

## Screenshot

![image](https://user-images.githubusercontent.com/55701515/86175649-683ced80-bb2c-11ea-904a-d4c7e784d3f2.png)
