### PR TITLE
STSMACOM-382: Prevent PUT request for accordion title during drag'n'drop custom field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
+* Prevent PUT request for accordion title during drag'n'drop custom field. STSMACOM-382.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
+++ b/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
@@ -200,7 +200,7 @@ const CustomFieldsForm = ({
     form.mutators.moveCustomFieldToIndex(source.index, destination.index, draggableId);
     if (pristine) {
       const data = form.getState().values;
-      saveCustomFields(data, false);
+      saveCustomFields(data, false, false);
       // TODO: save without redirect
     }
   };

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -173,13 +173,16 @@ const EditCustomFieldsSettings = ({
     }));
   };
 
-  const saveCustomFields = async (data, redirectToView = true) => {
+  const saveCustomFields = async (data, redirectToView = true, titleShouldUpdate = true) => {
     setSubmitting(true);
 
-    Promise.all([
-      updateCustomFields(formatCustomFieldsForBackend(data)),
-      updateTitle(data.sectionTitle),
-    ]).then(responses => {
+    const requests = [updateCustomFields(formatCustomFieldsForBackend(data))];
+
+    if (titleShouldUpdate) {
+      requests.push(updateTitle(data.sectionTitle));
+    }
+
+    Promise.all(requests).then(responses => {
       if (responses.every(({ ok }) => !!ok)) {
         if (redirectToView) {
           history.push(viewRoute);


### PR DESCRIPTION
## Description
After drop custom field on new place EditCustomFieldSettings sends request to set Accordion title. It must be prevent because drag'n'drop doesn't change accordion title.

## Issue
[STSMACOM-382](https://issues.folio.org/browse/STSMACOM-382)

## Screenshot
![OGG8vDud1B](https://user-images.githubusercontent.com/55701515/86266867-865b2a00-bbce-11ea-94f9-b19c811b259e.gif)
