### PR TITLE
STSMACOM-385: Add `entityTagsPath` to `Tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
+* Add `entityTagsPath` to `Tags` to set custom entity tags path. Part of UIDATIMP-499.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { get, uniq, sortBy, difference, noop, isFunction } from 'lodash';
+import { get, set, uniq, sortBy, difference, noop, isFunction } from 'lodash';
 
 import { Callout, Pane } from '@folio/stripes-components';
 import { stripesConnect } from '@folio/stripes-core';
@@ -28,6 +28,7 @@ class Tags extends React.Component {
 
   static propTypes = {
     children: PropTypes.func,
+    entityTagsPath: PropTypes.string,
     getEntity: PropTypes.func,
     getEntityTags: PropTypes.func,
     link: PropTypes.string.isRequired,
@@ -44,6 +45,7 @@ class Tags extends React.Component {
   };
 
   static defaultProps = {
+    entityTagsPath: 'tags',
     onToggle: noop,
     getEntity: props => get(props, ['resources', 'entities', 'records', 0], {}),
     getEntityTags: props => {
@@ -74,13 +76,13 @@ class Tags extends React.Component {
     const {
       getEntity,
       getEntityTags,
+      entityTagsPath,
     } = this.props;
     const entity = getEntity(this.props);
     const tags = getEntityTags(this.props);
     const tagList = tags.filter(t => t !== tag);
 
-    entity.tags = { tagList };
-
+    set(entity, entityTagsPath, { tagList });
     this.props.mutator.entities.PUT(entity);
   };
 
@@ -89,11 +91,13 @@ class Tags extends React.Component {
     const {
       getEntity,
       getEntityTags,
+      entityTagsPath,
     } = this.props;
     const entity = getEntity(this.props);
     const tagList = getEntityTags(this.props);
+    const tagsToSave = { tagList: sortBy(uniq([...tags, ...tagList])) };
 
-    entity.tags = { tagList: sortBy(uniq([...tags, ...tagList])) };
+    set(entity, entityTagsPath, tagsToSave);
     this.props.mutator.entities.PUT(entity);
   }
 

--- a/lib/Tags/TagsAccordion.js
+++ b/lib/Tags/TagsAccordion.js
@@ -12,8 +12,8 @@ import {
 
 import Tags from './Tags';
 
-const TagsAccordion = React.memo(({ link, getEntity, getEntityTags }) => (
-  <Tags link={link} getEntity={getEntity} getEntityTags={getEntityTags}>
+const TagsAccordion = React.memo(({ link, getEntity, getEntityTags, entityTagsPath }) => (
+  <Tags link={link} getEntity={getEntity} getEntityTags={getEntityTags} entityTagsPath={entityTagsPath}>
     {({
       entityTags,
       tagsForm,
@@ -40,6 +40,7 @@ const TagsAccordion = React.memo(({ link, getEntity, getEntityTags }) => (
 ));
 
 TagsAccordion.propTypes = {
+  entityTagsPath: PropTypes.string,
   getEntity: PropTypes.func,
   getEntityTags: PropTypes.func,
   link: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description
Provide `entityTagsPath` prop to `<Tags>` to allow implementors to set custom entity tags path. (See the usage of it [here](https://github.com/folio-org/ui-data-import/blob/UIDATIMP-499/src/settings/JobProfiles/ViewJobProfile.js#L421))

## Approach
Add `entityTagsPath` prop to `<Tags>`
Set tags to an entity by the provided path.
Set `entityTagsPath` = "tags" by default

## Refs
[STSMACOM-385](https://issues.folio.org/browse/STSMACOM-385)
[UIDATIMP-499](https://issues.folio.org/browse/UIDATIMP-499)