### PR TITLE
STSMACOM-379: Settings > Custom Fields > Saved Options display in alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
+* Add alphabetical sorting of Custom Field options. Refs STSMACOM-379.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/CustomFields/components/CustomFieldsForm/components/AddButton/tests/interactor.js
+++ b/lib/CustomFields/components/CustomFieldsForm/components/AddButton/tests/interactor.js
@@ -17,6 +17,6 @@ export default interactor(class AddButtonInteractor {
   };
 
   selectCustomFieldType = function (index) {
-    return this.addCustomFieldButtons(index).click();
+    return this.click().addCustomFieldButtons(index).click();
   };
 });

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/components/AddOptionButton/AddOptionButton.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/components/AddOptionButton/AddOptionButton.js
@@ -34,6 +34,7 @@ const AddOptionButton = ({
     <Button
       buttonClass={css.addOptionButton}
       onClick={onClick}
+      data-test-custom-fields-add-option-button
     >
       <FormattedMessage id="stripes-smart-components.customFields.addOption" />
     </Button>

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/HelpTextField/HelpTextField.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/HelpTextField/HelpTextField.js
@@ -36,6 +36,7 @@ const HelpTextField = ({ fieldNamePrefix }) => (
         </>
       }
       validate={validate}
+      data-test-custom-fields-help-text-input
     />
   </Col>
 );

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/HiddenField/HiddenField.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/HiddenField/HiddenField.js
@@ -20,6 +20,7 @@ const HiddenField = ({ fieldNamePrefix }) => (
       name={`${fieldNamePrefix}.hidden`}
       label={<FormattedMessage id="stripes-smart-components.customFields.hidden" />}
       vertical
+      data-test-custom-fields-hidden-checkbox
     />
   </Col>
 );

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/NameField/NameField.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/NameField/NameField.js
@@ -31,6 +31,7 @@ const NameField = ({ fieldNamePrefix }) => (
       label={<FormattedMessage id="stripes-smart-components.customFields.fieldLabel" />}
       required
       validate={validate}
+      data-test-custom-fields-name-input
     />
   </Col>
 );

--- a/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/RequiredField/RequiredField.js
+++ b/lib/CustomFields/components/FieldAccordion/edit-fields/shared-fields/RequiredField/RequiredField.js
@@ -20,6 +20,7 @@ const RequiredField = ({ fieldNamePrefix }) => (
       name={`${fieldNamePrefix}.required`}
       label={<FormattedMessage id="stripes-smart-components.customFields.required" />}
       vertical
+      data-test-custom-fields-required-checkbox
     />
   </Col>
 );

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -6,6 +6,7 @@ import {
   injectIntl,
 } from 'react-intl';
 import ReactRouterPropTypes from 'react-router-prop-types';
+import { cloneDeep } from 'lodash';
 
 import {
   Icon,
@@ -25,6 +26,7 @@ import {
   useSectionTitleFetch,
 } from '../../utils';
 import { permissionsShape } from '../../shapes';
+import { fieldTypes } from '../../constants';
 
 const propTypes = {
   backendModuleId: PropTypes.string,
@@ -158,9 +160,18 @@ const EditCustomFieldsSettings = ({
 
   const formatCustomFieldsForBackend = customFieldsFormData => {
     return customFieldsFormData.customFields.map(({ values: { hidden, ...customFieldData }, id }) => {
+      const customFieldDataWithSortedOptions = cloneDeep(customFieldData);
+      const fieldTypesWithOptions = [fieldTypes.SELECT, fieldTypes.MULTISELECT, fieldTypes.RADIO_BUTTON_GROUP];
+
+      if (fieldTypesWithOptions.includes(customFieldData.type)) {
+        const options = customFieldDataWithSortedOptions.selectField.options.values;
+        customFieldDataWithSortedOptions.selectField.options.values = options
+          .sort((a, b) => a.value.localeCompare(b.value));
+      }
+
       return ({
         id : id.startsWith('unsaved_') ? null : id,
-        ...customFieldData,
+        ...customFieldDataWithSortedOptions,
         visible: !hidden,
       });
     });

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { mount, setupApplication } from '../../../../../tests/helpers';
 
@@ -11,6 +12,7 @@ describe('EditCustomFieldsSettings', () => {
   setupApplication();
 
   const editCustomFields = new EditCustomFieldsSettingsInteractor();
+  const updateCustomFieldsHandler = sinon.spy();
 
   const renderComponent = (props = {}) => {
     return mount(
@@ -29,11 +31,13 @@ describe('EditCustomFieldsSettings', () => {
   };
 
   beforeEach(async function () {
-    this.server.put('/custom-fields', () => {});
+    this.server.put('/custom-fields', updateCustomFieldsHandler);
 
     this.server.put('/configurations/entries/tested-custom-field-label', () => ({}));
 
     await renderComponent();
+
+    updateCustomFieldsHandler.resetHistory();
   });
 
   it('should show correct section title', () => {
@@ -135,6 +139,46 @@ describe('EditCustomFieldsSettings', () => {
         it('should remove this custom field', () => {
           expect(editCustomFields.customFields().length).to.equal(4);
         });
+      });
+    });
+  });
+
+  describe('when creating a custom field with options', () => {
+    beforeEach(async () => {
+      await editCustomFields.addFieldButton.selectCustomFieldType(1);
+      await editCustomFields.customFields(5).fillName('Test field');
+      await editCustomFields.customFields(5).options(0).fillOptionName('beta');
+      await editCustomFields.customFields(5).options(1).fillOptionName('alpha');
+      await editCustomFields.save();
+    });
+
+    it('should send correct new custom field data', () => {
+      const body = JSON.parse(updateCustomFieldsHandler.args[0][1].requestBody);
+
+      const {
+        name,
+        selectField,
+      } = body.customFields[5];
+
+      expect({ name, selectField }).to.deep.equal({
+        name: 'Test field',
+        selectField: {
+          multiSelect: true,
+          options: {
+            values: [
+              {
+                default: false,
+                id: 'opt_1',
+                value: 'alpha',
+              },
+              {
+                default: false,
+                id: 'opt_0',
+                value: 'beta',
+              },
+            ],
+          },
+        },
       });
     });
   });

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/interactor.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/interactor.js
@@ -29,6 +29,14 @@ export default interactor(class EditCustomFieldsSettings {
 
   customFields = collection('[data-test-accordion-section]', {
     delete: clickable('[data-test-custom-field-delete-button]'),
+    fillName: fillable('[data-test-custom-fields-name-input]'),
+    fillHelpText: fillable('[data-test-custom-fields-help-text-input]'),
+    checkHidden: clickable('[data-test-custom-fields-hidden-checkbox]'),
+    checkRequired: clickable('[data-test-custom-fields-required-checkbox]'),
+    options: collection('[class^="mclRow--"]', {
+      fillOptionName: fillable('input[type="text"]'),
+    }),
+    addOption: clickable('[data-test-custom-fields-add-option-button]')
   });
 
   addFieldButton = new AddButtonInteractor();


### PR DESCRIPTION
## Purpose
* Add alphabetical sorting of Custom Fields options when saving Custom Fields

## Issue
[STSMACOM-379](https://issues.folio.org/browse/STSMACOM-379)