### PR TITLE
STSMACOM-380: Settings > Edit Custom Fields > change Save button label to Save & close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
 * Add alphabetical sorting of Custom Field options. Refs STSMACOM-379.
 * Add changeable content to assigned accordion to NotesView and NotesForm components. Part of UIREQ-467.
+* Settings > Edit Custom Fields > change Save button label to Save & close. STSMACOM-380.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
+++ b/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
@@ -156,7 +156,7 @@ const CustomFieldsForm = ({
         disabled={buttonsDisabled}
         data-test-custom-fields-save-button
       >
-        <FormattedMessage id="stripes-smart-components.customFields.save" />
+        <FormattedMessage id="stripes-smart-components.customFields.save&Close" />
       </Button>
     );
 

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -212,7 +212,7 @@
   "customFields.hidden": "Hidden",
   "customFields.defaultValue": "Default value",
   "customFields.cancel": "Cancel",
-  "customFields.save": "Save",
+  "customFields.save&Close": "Save & close",
   "customFields.delete.modalTitle": "Delete field data",
   "customFields.delete.confirm": "Save & lose data",
   "customFields.delete.cancel": "Cancel & keep editing",


### PR DESCRIPTION
## Description
Change `Save` button label to `Save & close`

## Issue
[STSMACOM-380](https://issues.folio.org/browse/STSMACOM-380)

## Screenshot
![image](https://user-images.githubusercontent.com/55701515/86541553-7b79ff80-bf16-11ea-984d-299779a6f2c5.png)
