### PR TITLE
Pull record name from nameKey

### DIFF
--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -273,7 +273,7 @@ class EntrySelector extends React.Component {
             <SafeHTMLMessage
               id="stripes-core.label.confirmDeleteEntry"
               values={{
-                name: item.name || <FormattedMessage id="stripes-core.untitled" />,
+                name: item[nameKey] || <FormattedMessage id="stripes-core.untitled" />,
               }}
             />
           )}

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -215,6 +215,7 @@ class EntrySelector extends React.Component {
       parentResources,
       enableDetailsActionMenu,
       prohibitItemDelete,
+      nameKey
     } = this.props;
 
     const {


### PR DESCRIPTION
When using the normal Edit button, the `nameKey` prop is used to render the delete confirmation modal. However, when using the actions dropdown, it just always uses `.name`.