### PR TITLE
STSMACOM-402: Remove horizontal scrollbar from ChangeDueDateDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Prevent PUT request for accordion title during drag'n'drop custom field. STSMACOM-382.
 * Fix incorrect `Last updated source` in Note View metadata when record was never updated. Fixes STSMACOM-386.
 * Add `entityTagsPath` to `Tags` to set custom entity tags path. Refs STSMACOM-385.
+* Remove horizontal scrollbar from `ChangeDueDateDialog`. Refs STSMACOM-402.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/LoanList.js
+++ b/lib/ChangeDueDateDialog/LoanList.js
@@ -107,6 +107,11 @@ const LoanList = (props) => {
       }}
       columnWidths={{
         alertDetails: 120,
+        currentDueDate: 150,
+        effectiveCallNumber: 120,
+        loanPolicy: 120,
+        requests: 100,
+        title: 170,
         selected: 40,
       }}
     />


### PR DESCRIPTION
# Description
 Adjust column widths for `ChangeDueDateDialog` to remove horizontal scrollbar.
# Issue
https://issues.folio.org/browse/STSMACOM-402
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/87543710-da294100-c6ad-11ea-8865-4cb566bfee49.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/87543653-c5e54400-c6ad-11ea-8f2a-b5a114f1e3c4.png)
