### PR TITLE
UIU-1731: Increase record limit in ChangeDueDate loan policy lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Prevent PUT request for accordion title during drag'n'drop custom field. STSMACOM-382.
 * Fix incorrect `Last updated source` in Note View metadata when record was never updated. Fixes STSMACOM-386.
 * Add `entityTagsPath` to `Tags` to set custom entity tags path. Refs STSMACOM-385.
+* Increase record limit for loan policy lookups in ChangeDueDateDialog. Fixes UIU-1731.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Prevent PUT request for accordion title during drag'n'drop custom field. STSMACOM-382.
 * Fix incorrect `Last updated source` in Note View metadata when record was never updated. Fixes STSMACOM-386.
 * Add `entityTagsPath` to `Tags` to set custom entity tags path. Refs STSMACOM-385.
-* Increase record limit for loan policy lookups in ChangeDueDateDialog. Fixes UIU-1731.
+* Increase record limit for loan policy lookups in `<ChangeDueDateDialog>`. Fixes UIU-1731.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/LoanList.js
+++ b/lib/ChangeDueDateDialog/LoanList.js
@@ -38,6 +38,9 @@ const manifest = Object.freeze({
   loanPolicies: {
     type: 'okapi',
     path: 'loan-policy-storage/loan-policies',
+    params: {
+      limit: '1000',
+    },
   },
 });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1731

This fixes a bug in the ChangeDueDateDialog loan list, wherein the loan policy name was not appearing. Thanks to @mkuklis  for pointing out the problem!