### PR TITLE
STSMACOM-384: Remove the 'no data' message displayed when saving a record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Set record limit for libraries in `<LocationLookup>`. Fixes UIOR-591.
 * Increase record limit for open request lookups in `<ChangeDueDateDialog>`. Fixes STSMACOM-404.
 * Use search term when filter is applied via `<SearchAndSortQuery>`. Fixes STSMACOM-407.
+* Remove 'no data' message displayed when saving the item. Fixes STSMACOM-384.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -4,7 +4,7 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { isEqual, uniqueId, pickBy } from 'lodash';
 
-import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row } from '@folio/stripes-components';
+import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row, Loading } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
@@ -111,6 +111,7 @@ class ControlledVocab extends React.Component {
       ]),
       updaters: PropTypes.object,
       values: PropTypes.shape({
+        isPending: PropTypes.bool,
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }).isRequired,
@@ -385,7 +386,9 @@ class ControlledVocab extends React.Component {
   }
 
   render() {
-    if (!this.props.resources.values) return <div />;
+    const { values } = this.props.resources;
+
+    if (!values) return <div />;
 
     const type = this.props.labelSingular;
     const term = this.state.selectedItem[this.state.primaryField];
@@ -398,7 +401,7 @@ class ControlledVocab extends React.Component {
     );
 
     const rows = this.parseRows(
-      this.filteredRows(this.props.resources.values.records || [])
+      this.filteredRows(values.records || [])
     );
 
     const hideList = this.props.listSuppressor && this.props.listSuppressor();
@@ -456,10 +459,12 @@ class ControlledVocab extends React.Component {
               onCreate={this.actuators.onCreate}
               onDelete={this.showConfirmDialog}
               isEmptyMessage={
-                <FormattedMessage
-                  id="stripes-smart-components.cv.noExistingTerms"
-                  values={{ terms: this.props.label }}
-                />
+                values.isPending
+                  ? <Loading />
+                  : <FormattedMessage
+                    id="stripes-smart-components.cv.noExistingTerms"
+                    values={{ terms: this.props.label }}
+                  />
               }
               validate={this.validate}
             />

--- a/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
+++ b/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
@@ -3,15 +3,13 @@ import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mount, setupApplication } from '../../../../../tests/helpers';
+import { setupApplication } from '../../../../../tests/helpers';
 
 import CustomFieldsForm from '../CustomFieldsForm';
 import CustomFieldsFormInteractor from './interactor';
 import fetchUsageStatistics from './helpers/fetchUsageStatistics';
 
 describe('CustomFieldsForm', () => {
-  setupApplication();
-
   const customFieldsForm = new CustomFieldsFormInteractor();
   const onCancelDelete = sinon.spy();
   const onConfirmDelete = sinon.spy();
@@ -21,8 +19,8 @@ describe('CustomFieldsForm', () => {
   const handleSubmit = sinon.spy();
 
   const renderComponent = (props) => {
-    return mount(
-      <CustomFieldsForm
+    setupApplication({
+      component: <CustomFieldsForm
         deleteModalIsDisplayed={false}
         entityType="user"
         fetchUsageStatistics={fetchUsageStatistics}
@@ -63,12 +61,12 @@ describe('CustomFieldsForm', () => {
         fieldOptionsStats={{}}
         {...props}
       />
-    );
+    });
   };
 
-  beforeEach(async () => {
-    await renderComponent();
+  renderComponent();
 
+  beforeEach(async () => {
     onCancelDelete.resetHistory();
     onConfirmDelete.resetHistory();
     onDeleteClick.resetHistory();
@@ -104,43 +102,43 @@ describe('CustomFieldsForm', () => {
   describe('when custom fields accordions are reordered', () => {
     const saveCustomFieldsHandler = sinon.spy();
 
+    renderComponent({
+      saveCustomFields: saveCustomFieldsHandler,
+      initialValues: {
+        customFields: [
+          {
+            id: 'field_1',
+            values: {
+              entityType: 'user',
+              helpText: '',
+              hidden: false,
+              name: 'Facebook ID',
+              order: 1,
+              required: false,
+              type: 'TEXTBOX_SHORT',
+              visible: true,
+            },
+          },
+          {
+            id: 'field_2',
+            values: {
+              entityType: 'user',
+              helpText: '',
+              hidden: false,
+              name: 'Facebook ID 2',
+              order: 2,
+              required: false,
+              type: 'TEXTBOX_SHORT',
+              visible: true,
+            },
+          },
+        ],
+        sectionTitle: 'Custom fields',
+      }
+    });
+
     beforeEach(async () => {
       saveCustomFieldsHandler.resetHistory();
-
-      await renderComponent({
-        saveCustomFields: saveCustomFieldsHandler,
-        initialValues: {
-          customFields: [
-            {
-              id: 'field_1',
-              values: {
-                entityType: 'user',
-                helpText: '',
-                hidden: false,
-                name: 'Facebook ID',
-                order: 1,
-                required: false,
-                type: 'TEXTBOX_SHORT',
-                visible: true,
-              },
-            },
-            {
-              id: 'field_2',
-              values: {
-                entityType: 'user',
-                helpText: '',
-                hidden: false,
-                name: 'Facebook ID 2',
-                order: 2,
-                required: false,
-                type: 'TEXTBOX_SHORT',
-                visible: true,
-              },
-            },
-          ],
-          sectionTitle: 'Custom fields',
-        }
-      });
 
       await customFieldsForm.moveAccordionDown();
     });
@@ -270,33 +268,33 @@ describe('CustomFieldsForm', () => {
   });
 
   describe('when deleting a custom field', () => {
-    beforeEach(async () => {
-      await renderComponent({
-        fieldsToDelete: [
-          {
-            index: 0,
-            data: {
-              id: '0',
-              values: {
-                entityType: 'user',
-                helpText: '',
-                hidden: false,
-                name: 'Facebook ID',
-                order: 1,
-                required: false,
-                type: 'TEXTBOX_SHORT',
-                visible: true,
-              },
+    renderComponent({
+      fieldsToDelete: [
+        {
+          index: 0,
+          data: {
+            id: '0',
+            values: {
+              entityType: 'user',
+              helpText: '',
+              hidden: false,
+              name: 'Facebook ID',
+              order: 1,
+              required: false,
+              type: 'TEXTBOX_SHORT',
+              visible: true,
             },
           },
-        ],
-        initialValues: {
-          customFields: [],
-          sectionTitle: 'Some title',
         },
-        deleteModalIsDisplayed: true,
-      });
+      ],
+      initialValues: {
+        customFields: [],
+        sectionTitle: 'Some title',
+      },
+      deleteModalIsDisplayed: true,
+    });
 
+    beforeEach(async () => {
       await customFieldsForm.deleteModal.whenLoaded();
     });
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -4,14 +4,12 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { Form, Field } from 'react-final-form';
 
-import { mount, setupApplication } from '../../../../../tests/helpers';
+import { setupApplication } from '../../../../../tests/helpers';
 
 import EditCustomFieldsRecord from '../EditCustomFieldsRecord';
 import EditCustomFieldsRecordInteractor from './interactor';
 
 describe('EditCustomFieldsRecord', () => {
-  setupApplication();
-
   const editCustomFields = new EditCustomFieldsRecordInteractor();
 
   const changeFinalFormField = sinon.spy();
@@ -39,26 +37,26 @@ describe('EditCustomFieldsRecord', () => {
       </Form>
     );
 
-    return mount(
-      <FormComponent />
-    );
+    setupApplication({
+      component: <FormComponent />
+    });
   };
 
-  beforeEach(async () => {
-    await renderComponent();
+  renderComponent();
 
+  beforeEach(async () => {
     changeFinalFormField.resetHistory();
     changeReduxFormField.resetHistory();
     onToggle.resetHistory();
   });
 
   describe('when there are no custom fields', () => {
+    renderComponent();
     beforeEach(async function () {
       this.server.get('/custom-fields', {
         'customFields': [],
       });
 
-      await renderComponent();
       await editCustomFields.whenCustomFieldsLoaded();
     });
 

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/DeleteCustomFieldsOptions-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/DeleteCustomFieldsOptions-test.js
@@ -9,7 +9,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
-  mount,
   setupApplication,
 } from '../../../../../tests/helpers';
 
@@ -33,8 +32,8 @@ const getMultiSelectCustomFieldData = options => ({
 });
 
 const renderComponent = (props = {}) => {
-  return mount(
-    <EditCustomFieldsSettings
+  setupApplication({
+    component: <EditCustomFieldsSettings
       backendModuleName="users-test"
       entityType="user"
       permissions={{
@@ -45,11 +44,11 @@ const renderComponent = (props = {}) => {
       viewRoute="/custom-fields-view"
       {...props}
     />
-  );
+  });
 };
 
 describe('delete custom fields options functionality', () => {
-  setupApplication();
+  renderComponent();
   const updateCustomFieldsHandler = sinon.spy();
   const editCustomFields = new EditCustomFieldsSettingsInteractor();
 
@@ -88,7 +87,7 @@ describe('delete custom fields options functionality', () => {
         };
       });
 
-      await renderComponent();
+      renderComponent();
     });
 
     it('should not display the option delete buttons since there are only 2 options', () => {
@@ -244,7 +243,7 @@ describe('delete custom fields options functionality', () => {
         };
       });
 
-      await renderComponent();
+      renderComponent();
     });
 
     it('should hide the option delete buttons', () => {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-384

### Purpose
Remove the 'no data' message displayed when saving a record.

**Before**

![before](https://user-images.githubusercontent.com/49517355/87563001-66942d80-c6c7-11ea-8ad8-25643bb74b63.gif)

**Approach**

Added display of `Loader` while the records are not loaded yet.

![approach_2](https://user-images.githubusercontent.com/49517355/87563455-e8845680-c6c7-11ea-841f-bf57860355de.gif)

### Additional challenge
Problems with passing tests in the `CustomFields` component have also been fixed. Achieved by mounting the component directly when using `setupApplication` instead of `mount` later on.
