### PR TITLE
STSMACOM-365: Use search term when filter is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `entityTagsPath` to `Tags` to set custom entity tags path. Refs STSMACOM-385.
 * Increase record limit for loan policy lookups in `<ChangeDueDateDialog>`. Fixes UIU-1731.
 * Remove horizontal scrollbar from `ChangeDueDateDialog`. Refs STSMACOM-402.
+* Use search term when filter is applied via `<SearchAndSort>`. Fixes STSMACOM-365.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ControlledVocab/tests/actuators-refdata-test.js
+++ b/lib/ControlledVocab/tests/actuators-refdata-test.js
@@ -20,7 +20,11 @@ describe('ControlledVocab', () => {
         },
         preCreateHook: (rec) => rec,
         preUpdateHook: (rec) => rec,
-      }
+      },
+      hideConfirmDialog: () => {},
+      showDeletionSuccessCallout: () => {},
+      deleteItemResolve: () => {},
+      deleteItemReject: () => {},
     };
 
     const actuators = makeRefdataActuatorsBoundTo(mock);

--- a/lib/Notes/NoteViewPage/tests/NoteViewPage-test.js
+++ b/lib/Notes/NoteViewPage/tests/NoteViewPage-test.js
@@ -52,7 +52,7 @@ describe('NoteViewPage', () => {
 
   describe('rendering NoteView component', () => {
     beforeEach(async () => {
-      await renderComponent();
+      renderComponent();
       await noteViewPage.whenLoaded();
 
       navigateBackSpy.resetHistory();
@@ -116,7 +116,7 @@ describe('NoteViewPage', () => {
 
   describe('when a note was never updated', () => {
     beforeEach(async () => {
-      await renderComponent({
+      renderComponent({
         noteId: 'neverUpdatedNote',
       });
 
@@ -131,7 +131,7 @@ describe('NoteViewPage', () => {
 
   describe('when a note was updated', () => {
     beforeEach(async () => {
-      await renderComponent({
+      renderComponent({
         noteId: 'updatedNote',
       });
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -377,10 +377,15 @@ class SearchAndSort extends React.Component {
 
   onFilterChangeHandler = (filter) => {
     const {
-      parentMutator: { resultCount, resultOffset },
+      parentMutator: {
+        resultCount,
+        resultOffset,
+        query,
+      },
       initialResultCount,
       onFilterChange,
     } = this.props;
+    const { locallyChangedSearchTerm } = this.state;
 
     resultCount.replace(initialResultCount);
 
@@ -388,7 +393,10 @@ class SearchAndSort extends React.Component {
       resultOffset.replace(0);
     }
 
-    onFilterChange(filter);
+    query.update({ query: locallyChangedSearchTerm });
+
+    // use next tick in order to wait for the resource query to update
+    defer(() => onFilterChange(filter));
   };
 
   onChangeSearch = (e) => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -54,18 +54,42 @@ export const parseMessageFromJsx = (values, translation) => {
 };
 
 export const wait = (ms = 1000) => new Promise(resolve => { setTimeout(resolve, ms); });
+
 const warn = console.warn;
-const blacklist = [
+const warnBlocklist = [
   /componentWillReceiveProps has been renamed/,
   /componentWillUpdate has been renamed/,
   /componentWillMount has been renamed/,
+  /Formatter possibly needed for column/,
+];
+
+const error = console.error;
+const errorBlocklist = [
+  /React Intl/,
+  /Cannot update a component from inside the function body of a different component/,
+  /Can't perform a React state update on an unmounted component./,
+  /Invalid prop `component` supplied to.*Field/,
+  /Each child in a list/,
+  /Failed prop type/,
+  /component is changing an uncontrolled/,
+  /validateDOMNesting/,
+  /Invalid ARIA attribute/,
+  /Unknown event handler property/,
+  /React does not recognize the/,
 ];
 
 export function turnOffWarnings() {
   console.warn = function (...args) {
-    if (blacklist.some(rx => rx.test(args[0]))) {
+    if (warnBlocklist.some(rx => rx.test(args[0]))) {
       return;
     }
     warn.apply(console, args);
+  };
+
+  console.error = function (...args) {
+    if (errorBlocklist.some(rx => rx.test(args[0]))) {
+      return;
+    }
+    error.apply(console, args);
   };
 }


### PR DESCRIPTION
Use search term when filter is applied via `SearchAndSort`. 

This approach is using a resource query in order to keep track of the current search term. 

https://issues.folio.org/browse/STSMACOM-365

![search](https://user-images.githubusercontent.com/63545/87617740-2001fb80-c6e6-11ea-8c1f-2264cf734523.gif)
