### PR TITLE
STSMACOM-194: Fix reset the sort terms when clicking 'Reset all'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Remove horizontal scrollbar from `ChangeDueDateDialog`. Refs STSMACOM-402.
 * Use search term when filter is applied via `<SearchAndSort>`. Fixes STSMACOM-365.
 * Remove Note details length limit. Refs STSMACOM-383.
+* Fix reset the sort terms when clicking the 'Reset all' button. Fixes STSMACOM-194.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -250,6 +250,7 @@ class SearchAndSort extends React.Component {
     this.lastNonNullReaultCount = undefined;
     this.initialQuery = queryString.parse(this.initialSearch);
     this.initialFilters = this.initialQuery.filters;
+    this.initialSort = this.initialQuery.sort;
 
     const logger = stripes.logger;
 
@@ -460,6 +461,7 @@ class SearchAndSort extends React.Component {
     this.setState({ locallyChangedSearchTerm: '' });
     this.transitionToParams({
       filters: this.initialFilters || '',
+      sort: this.initialSort || '',
       query: '',
       qindex: '',
     });


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-194

### Purpose
Achieve that when clicking the "Reset all" button the search terms are cleared and the sort terms returned to default.