### PR TITLE
STSMACOM-335: Extend Note title character limit to 255 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Use search term when filter is applied via `<SearchAndSort>`. Fixes STSMACOM-365.
 * Remove Note details length limit. Refs STSMACOM-383.
 * Fix reset the sort terms when clicking the 'Reset all' button. Fixes STSMACOM-194.
+* Extended Note title max length to 255. Refs STSMACOM-335.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/Notes/constants.js
+++ b/lib/Notes/constants.js
@@ -1,4 +1,4 @@
-export const MAX_TITLE_LENGTH = 75;
+export const MAX_TITLE_LENGTH = 255;
 export const NOTES_PATH = 'notes';
 
 export const notesStatuses = {


### PR DESCRIPTION
## Purpose
- Extend Note title character limit to 255 characters