### PR TITLE
STSMACOM-404: Increase record limit for open request lookups in <ChangeDueDateDialog>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Extended Note title max length to 255. Refs STSMACOM-335.
 * Show Note details in Notes Accordion. Refs STSMACOM-353.
 * Set record limit for libraries in `<LocationLookup>`. Fixes UIOR-591.
+* Increase record limit for open request lookups in `<ChangeDueDateDialog>`. Fixes STSMACOM-404.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -58,7 +58,9 @@ class ChangeDueDateDialog extends React.Component {
       path: 'circulation/requests',
       records: 'requests',
       accumulate: true,
-
+      params: {
+        limit: '10000',
+      },
     },
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-404

This fixes a bug in the ChangeDueDateDialog loan list, wherein an item with an open request on it would not be identified as such.