### PR TITLE
STSMACOM-410: Fix same IDs of CustomFields drag-and-drop tooltip

### DIFF
--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -109,7 +109,6 @@ const FieldAccordion = (props) => {
               {(message) => (
                 <Tooltip
                   text={message}
-                  id="custom-field-drag-drop-button-tooltip"
                 >
                   {({ ref, ariaIds }) => (
                     <Icon


### PR DESCRIPTION
## Purpose
- Remove repeated IDs of Custom Fields drag-and-drop tooltips