### PR TITLE
STSMACOM-421: Handle react-router-dom deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix Custom Fields Edit page has multiple elements with the same ID. Fixes STSMACOM-410.
 * Add `listFormLabel` prop to `ControlledVocab` to set header of `EditableList`. Refs STSMACOM-408.
 * Show correct number of characters in NoteList details. Refs STSMACOM-411.
+* Handle `react-router-dom` deprecation warnings. Refs STSMACOM-421.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import Switch from 'react-router-dom/Switch';
-import Route from 'react-router-dom/Route';
+import {
+  Switch,
+  Route,
+} from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -4,8 +4,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import Route from 'react-router-dom/Route';
+import {
+  Link,
+  Route,
+} from 'react-router-dom';
 import { withRouter } from 'react-router';
 import { FormattedMessage } from 'react-intl';
 import queryString from 'query-string';

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Switch from 'react-router-dom/Switch';
-import Route from 'react-router-dom/Route';
+import {
+  Switch,
+  Route,
+} from 'react-router-dom';
 
 import { withStripes } from '@folio/stripes-core';
 import NavListItem from '@folio/stripes-components/lib/NavListItem';


### PR DESCRIPTION
## Purpose

Handle react-router-dom deprecation warnings

```
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Route` instead of `require("react-router-dom/Route")`. Support for the latter will be removed in the next major release.'
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Link` instead of `require("react-router-dom/Link")`. Support for the latter will be removed in the next major release.'
Chrome 84.0.4147 (Mac OS X 10.15.6) ERROR: 'Warning: Please use `require("react-router-dom").Switch` instead of `require("react-router-dom/Switch")`. Support for the latter will be removed in the next major release.'
```
