### PR TITLE
UIU-1495: Handle Aged to lost items in ChangeDueDateDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add `listFormLabel` prop to `ControlledVocab` to set header of `EditableList`. Refs STSMACOM-408.
 * Show correct number of characters in NoteList details. Refs STSMACOM-411.
 * Handle `react-router-dom` deprecation warnings. Refs STSMACOM-421.
+* Handle 'Aged to lost' items in `<ChangeDueDateDialog>`. Refs UIU-1495.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -249,7 +249,7 @@ class ChangeDueDate extends React.Component {
           { loans.length > 1 ?
             <SafeHTMLMessage
               id="stripes-smart-components.cddd.itemsSelected"
-              values={{ count: loans.length }}
+              values={{ count: Object.values(loanSelection).filter(Boolean).length }}
             /> : null
           }
           {warnings.map((warning, i) => (

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -10,8 +10,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import DueDatePicker from './DueDatePicker';
 import LoanList from './LoanList';
 import css from './ChangeDueDateDialog.css';
-
-const DueDateUnchangeableItemStatuses = ['Declared lost', 'Claimed returned', 'Aged to lost'];
+import { DueDateUnchangeableItemStatuses } from './constants';
 
 class ChangeDueDate extends React.Component {
   static checkForWarnings(props, state) {
@@ -244,13 +243,15 @@ class ChangeDueDate extends React.Component {
       // ... or the checked loans are all associated with items declared lost or claimed returned
       this.onlyDueDateUnchangeableItems(loanSelection);
 
+    const numSelectedLoans = Object.values(loanSelection).filter(Boolean).length;
+
     return (
       <div>
         <p role="alert">
           { loans.length > 1 ?
             <SafeHTMLMessage
               id="stripes-smart-components.cddd.itemsSelected"
-              values={{ count: Object.values(loanSelection).filter(Boolean).length }}
+              values={{ count: numSelectedLoans }}
             /> : null
           }
           {warnings.map((warning, i) => (

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -11,7 +11,7 @@ import DueDatePicker from './DueDatePicker';
 import LoanList from './LoanList';
 import css from './ChangeDueDateDialog.css';
 
-const DueDateUnchangeableItemStatuses = ['Declared lost', 'Claimed returned'];
+const DueDateUnchangeableItemStatuses = ['Declared lost', 'Claimed returned', 'Aged to lost'];
 
 class ChangeDueDate extends React.Component {
   static checkForWarnings(props, state) {
@@ -203,7 +203,8 @@ class ChangeDueDate extends React.Component {
     });
   }
 
-  // Return true if the item associated with the given loan ID has status 'Declared lost' or 'Claimed returned'
+  // Return true if the item associated with the given loan ID has status 'Declared lost',
+  // 'Claimed returned', or 'Aged to lost'
   isItemDueDateUnchangeable = loanId => {
     const matchedLoan = this.props.loans.find(loan => loanId === loan.id);
     return DueDateUnchangeableItemStatuses.includes(matchedLoan?.item?.status?.name);

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -183,6 +183,14 @@ class ChangeDueDateDialog extends React.Component {
             'stripes-smart-components.cddd.itemClaimedReturnedWarning'
           );
         }
+        if (loan.item?.status?.name === 'Aged to lost') {
+          newAlerts[loan.id] = this.renderAlert(
+            css.warn,
+            'exclamation-circle',
+            'warn',
+            'stripes-smart-components.cddd.itemAgedToLostWarning'
+          );
+        }
       });
     }
 

--- a/lib/ChangeDueDateDialog/constants.js
+++ b/lib/ChangeDueDateDialog/constants.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
+// An array of item statuses for which loan due date cannot
+// be changed
+export const DueDateUnchangeableItemStatuses = [
+  'Declared lost',
+  'Claimed returned',
+  'Aged to lost'
+];

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -13,6 +13,7 @@
   "cddd.itemDeclaredLostWarning": "Item is Declared lost",
   "cddd.itemClaimedReturned": "Due date change failed: item is Claimed returned",
   "cddd.itemClaimedReturnedWarning": "Item is Claimed returned",
+  "cddd.itemAgedToLostWarning": "Item is Aged to lost",
   "cddd.itemHasRequestQueue": "Item has a request queue",
   "cddd.itemsHaveWarnings": "<b>{count}</b> items have <b>warnings.</b>",
   "cddd.header.alertDetails": "Alert details",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1495

This adds support for Aged to lost items in <ChangeDueDateDialog>. It also addresses a bug I encountered, wherein the "x items selected" text at the top of the dialog box would not change when items were selected or deselected.

<img width="1644" alt="Screen Shot 2020-08-26 at 5 16 18 PM" src="https://user-images.githubusercontent.com/1322242/91446192-220ebc80-e845-11ea-9487-f3d3cd44b55a.png">
