### PR TITLE
[STSMACOM-419] NotesList: Fix 'Show more' button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Show correct number of characters in NoteList details. Refs STSMACOM-411.
 * Handle `react-router-dom` deprecation warnings. Refs STSMACOM-421.
 * Handle 'Aged to lost' items in `<ChangeDueDateDialog>`. Refs UIU-1495.
+* Fixed `Show more` button in `<NotesList>` expanding every note. Refs STSMACOM-419.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -53,7 +53,7 @@ class NotesList extends React.Component {
 
   state = { isDetailsExpanded: {} };
 
-  handleShowMoreClick = ({ id, e }) => {
+  handleShowMoreClick = id => e => {
     e.stopPropagation();
 
     this.setState(({ isDetailsExpanded }) => ({
@@ -77,7 +77,7 @@ class NotesList extends React.Component {
       <button
         type="button"
         className={classnames([css.NoteDetailsButton, css.NoteDetailsShowMoreButton])}
-        onClick={e => this.handleShowMoreClick({ id, e })}
+        onClick={this.handleShowMoreClick(id)}
         data-test-note-show-more-button
       >
         {isDetailsExpanded[id]

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -59,7 +59,7 @@ class NotesList extends React.Component {
     this.setState(({ isDetailsExpanded }) => ({
       isDetailsExpanded: {
         ...isDetailsExpanded,
-        [id]: !isDetailsExpanded[id]
+        [id]: !isDetailsExpanded[id],
       },
     }));
   }

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -51,13 +51,16 @@ class NotesList extends React.Component {
     },
   }
 
-  state = { isDetailsExpanded: false };
+  state = { isDetailsExpanded: {} };
 
-  handleShowMoreClick = (e) => {
+  handleShowMoreClick = ({ id, e }) => {
     e.stopPropagation();
 
     this.setState(({ isDetailsExpanded }) => ({
-      isDetailsExpanded: !isDetailsExpanded,
+      isDetailsExpanded: {
+        ...isDetailsExpanded,
+        [id]: !isDetailsExpanded[id]
+      },
     }));
   }
 
@@ -67,17 +70,17 @@ class NotesList extends React.Component {
     this.props.onNoteEditClick(e, note);
   }
 
-  renderShowMoreButton() {
+  renderShowMoreButton(id) {
     const { isDetailsExpanded } = this.state;
 
     return (
       <button
         type="button"
         className={classnames([css.NoteDetailsButton, css.NoteDetailsShowMoreButton])}
-        onClick={this.handleShowMoreClick}
+        onClick={e => this.handleShowMoreClick({ id, e })}
         data-test-note-show-more-button
       >
-        {isDetailsExpanded
+        {isDetailsExpanded[id]
           ? <FormattedMessage id="stripes-smart-components.notes.showLessDetails" />
           : <FormattedMessage id="stripes-smart-components.notes.showMoreDetails" />
         }
@@ -118,7 +121,7 @@ class NotesList extends React.Component {
           </div>
         );
 
-        const htmlString = isDetailsExpanded
+        const htmlString = isDetailsExpanded[id]
           ? content
           : getHTMLSubstring(content, DETAILS_CUTOFF_LENGTH);
 
@@ -147,7 +150,7 @@ class NotesList extends React.Component {
               {titleContent}
               {detailsContent}
               <div>
-                {getStringLength(content) > DETAILS_CUTOFF_LENGTH && this.renderShowMoreButton()}
+                {getStringLength(content) > DETAILS_CUTOFF_LENGTH && this.renderShowMoreButton(id)}
                 {this.renderEditButton(note)}
               </div>
             </div>


### PR DESCRIPTION
[[STSMACOM-419]](https://issues.folio.org/browse/STSMACOM-419) NotesList: Fix 'Show more' button

## Purpose 
While clicking on `Show more` button in Note list, every note that was collapsed  did expand. This PR is fixing the wrong behavior of `Show more` button, so now it works as expected and expand/collapse only corresponding note.