### PR TITLE
STSMACOM-432: Fix bug in ChangeDueDateDialog saving unwanted actionComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Handle `react-router-dom` deprecation warnings. Refs STSMACOM-421.
 * Handle 'Aged to lost' items in `<ChangeDueDateDialog>`. Refs UIU-1495.
 * Fixed `Show more` button in `<NotesList>` expanding every note. Refs STSMACOM-419.
+* Fix bug in `<ChangeDueDateDialog>` that saved an unwanted actionComment. Fixes STSMACOM-432.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -154,6 +154,7 @@ class ChangeDueDate extends React.Component {
         ...loan,
         dueDate: datetime,
         action: 'dueDateChanged',
+        actionComment: '',
       }));
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-432

This fixes a bug wherein changing the due date of an item would add an entry to the action history with the comment of the _previous_ action, not the due date change. Turns out that the _previous action_ is saved as part of the loan record, and this code was somewhat blindly copying and modifying the existing record to change the due date, perpetuating the old action comment.