### PR TITLE
Fix `ClipCopy` success message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Increment `react-intl` to `v5`. Refs STSMACOM-433.
 * Refactor PasswordValidationField to use `final-form` instead of `redux-form`. Refs STSMACOM-389.
 * Increase PasswordValidationField test coverage to 80%. Refs STSMACOM-424.
+* Fix `ClipCopy` success message
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ClipCopy/ClipCopy.js
+++ b/lib/ClipCopy/ClipCopy.js
@@ -22,7 +22,7 @@ const ClipCopy = ({ text }) => {
       type: 'success',
       message: (
         <FormattedMessage
-          id="stripes-smart-components.successfullyCopiedMessage"
+          id="stripes-smart-components.clipCopy.success"
           values={{ text }}
         />)
     });
@@ -33,9 +33,9 @@ const ClipCopy = ({ text }) => {
       text={text}
       onCopy={handleCopy}
     >
-      <div data-test-copy-icon>
+      <span data-test-copy-icon>
         <IconButton icon="clipboard" />
-      </div>
+      </span>
     </CopyToClipboard>
   );
 };


### PR DESCRIPTION
component was introduced in https://github.com/folio-org/stripes-smart-components/pull/858 but with wrong message id :)