### PR TITLE
STSMACOM-439: added headerProps property to NotesSmartAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Increase PasswordValidationField test coverage to 80%. Refs STSMACOM-424.
 * Fix `ClipCopy` success message
 * `NotesList` - Suppress Edit link when user lacks edit permissions. Refs STSMACOM-430.
+* Added `headerProps` property to `NotesSmartAccordion` and `NotesAccordion`. Refs STSMACOM-439.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -47,6 +47,7 @@ class NotesSmartAccordion extends Component {
     entityId: PropTypes.string.isRequired,
     entityName: PropTypes.string.isRequired,
     entityType: PropTypes.string.isRequired,
+    headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -348,6 +349,7 @@ class NotesSmartAccordion extends Component {
       id,
       hideAssignButton,
       label,
+      headerProps,
     } = this.props;
 
     const { sortedColumn } = this.state;
@@ -377,6 +379,7 @@ class NotesSmartAccordion extends Component {
           onHeaderClick={this.onHeaderClick}
           sortedColumn={sortedColumn.column}
           sortDirection={sortedColumn.isDesc ? 'descending' : 'ascending'}
+          headerProps={headerProps}
         />
       </IfPermission>
     );

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -142,7 +142,7 @@ export default class NotesAccordion extends Component {
       onHeaderClick,
       sortedColumn,
       sortDirection,
-      headerProps
+      headerProps,
     } = this.props;
 
     const {

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -21,6 +21,7 @@ import styles from './NotesAccordion.css';
 
 export default class NotesAccordion extends Component {
   static propTypes = {
+    headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -141,6 +142,7 @@ export default class NotesAccordion extends Component {
       onHeaderClick,
       sortedColumn,
       sortDirection,
+      headerProps
     } = this.props;
 
     const {
@@ -156,6 +158,7 @@ export default class NotesAccordion extends Component {
           displayWhenClosed={this.renderQuantityIndicator()}
           displayWhenOpen={this.renderHeaderButtons()}
           onToggle={onToggle}
+          headerProps={headerProps}
         >
           <NotesList
             notes={assignedNotes}


### PR DESCRIPTION
## Purpose
Related to [UIEH-923](https://issues.folio.org/browse/UIEH-923)
Added `headerProps` property to `NotesSmartAccordion` and `NotesAccordion` in order to pass it down to `Accordion`