### PR TITLE
STSMACOM-441: Fix bug in ChangeDueDateDialog that did not allow data …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Added `headerProps` property to `NotesSmartAccordion` and `NotesAccordion`. Refs STSMACOM-439.
 * Execute `<ChangeDueDateDialog>` PUT requests in sequence. Refs UIU-1789.
 * Add accessibility tests for Custom Fields. Refs STSMACOM-435.
+* Fix bug in `<ChangeDueDateDialog>` that did not allow data to be updated. Fixes STSMACOM-441.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -122,7 +122,7 @@ class ChangeDueDateDialog extends React.Component {
     this.state = {
       succeeded: false,
       alerts: {},
-      open: false, // eslint-disable-line react/no-unused-state
+      shouldDataUpdate: true, // eslint-disable-line react/no-unused-state
       loanIds: [], // eslint-disable-line react/no-unused-state
       isProcessing: false,  // indicates whether a change due date operation is running
     };
@@ -136,9 +136,9 @@ class ChangeDueDateDialog extends React.Component {
 
   static getDerivedStateFromProps(props, state) {
     const newState = {};
-    if (!state.open && props.open) {
+    if (state.shouldDataUpdate && props.open) {
       ChangeDueDateDialog.fetchData(props);
-      newState.open = true;
+      newState.shouldDataUpdate = false;
     }
 
     const loanIds = props.loanIds.map(l => l.id);
@@ -204,7 +204,7 @@ class ChangeDueDateDialog extends React.Component {
     this.setState({
       alerts: {},
       succeeded: false,
-      open: false,
+      shouldDataUpdate: true,
     });
 
     this.props.onClose();

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -203,7 +203,8 @@ class ChangeDueDateDialog extends React.Component {
   handleCancel() {
     this.setState({
       alerts: {},
-      succeeded: false
+      succeeded: false,
+      open: false,
     });
 
     this.props.onClose();
@@ -323,7 +324,7 @@ class ChangeDueDateDialog extends React.Component {
       succeeded,
       resultCounts,
     } = this.state;
-    const { user, open, onClose, stripes } = this.props;
+    const { user, open, stripes } = this.props;
 
     const BodyComponent = succeeded ? ChangeDueDateSuccess : this.connectedChangeDueDate;
     const modalLabel = succeeded ?
@@ -340,7 +341,7 @@ class ChangeDueDateDialog extends React.Component {
         dismissible
         closeOnBackgroundClick
         enforceFocus={false} // Needed to allow Calendar in Datepicker to get focus
-        onClose={onClose}
+        onClose={this.handleCancel}
         open={open}
         label={modalLabel}
       >


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-441

### Purpose
The issue described in the ticket occurs after calling the `ChangeDueDate` modal again within one session.
It turned out that in the `getDerivedStateFromProps` method the data update occurs if the `ChangeDueDate` modal becomes open (the `props.open` property is responsible for this) and **the `state.open` value is set to `false`**. After updating the data, the `state.open` value is explicitly set to `true` (to avoid an infinite loop). And this value remains until the end of the session.
Consequently, the next calling of the `ChangeDueDateDialog` component (for example, after renewal loan) doesn't update the data (including the current loan).

### Approach
This PR addresses this by explicitly setting `state.open` to `false` when closing the modal.