### PR TITLE
UIEH-963: Fix invalid ARIA attribute order in EditableList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fix bug in `<ChangeDueDateDialog>` that did not allow data to be updated. Fixes STSMACOM-441.
 * Move inter-stripes deps to peers. Refs STSMACOM-442.
 * Move `moment` to `peerDependencies`. Ref STSMACOM-443.
+* Fix invalid ARIA attribute order in `<EditableList>`. Fixes UIEH-963.
 
 ## [4.2.0] (IN PROGRESS)
 

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -74,7 +74,7 @@ const ItemEdit = ({
   });
 
   return (
-    <div className={classnames(css.editListRow, css.baselineListRow)} role="row" aria-rowindex={rowIndex + 2}>
+    <div className={classnames(css.editListRow, css.baselineListRow)} aria-rowindex={rowIndex + 2}>
       {fields}
     </div>
   );

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import css from './EditableList.css';
 
 const ItemView = ({ cells, rowIndex }) => (
-  <div className={css.editListRow} role="row" aria-rowindex={rowIndex + 2}>
+  <div className={css.editListRow} aria-rowindex={rowIndex + 2}>
     {cells}
   </div>
 );

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -505,7 +505,7 @@ export default class NotesAssigningModal extends React.Component {
                   id="noteTypes"
                   closedByDefault={false}
                   label={
-                    <Headline size="large" tag="h3">
+                    <Headline size="large" tag="h3" id="noteTypeSelect-label">
                       <FormattedMessage id="stripes-smart-components.noteType" />
                     </Headline>
                   }
@@ -525,6 +525,7 @@ export default class NotesAssigningModal extends React.Component {
                         onChange={this.onNoteTypeFiltersChange}
                         disabled={this.props.notes.loading}
                         aria-label={ariaLabel}
+                        aria-labelledby="noteTypeSelect-label"
                       />
                     )}
                   </FormattedMessage>


### PR DESCRIPTION
## Description
1. Remove unneeded `role="row"` attribute in `<EditableList>` item wrappers. It is unnecessary to add this attribute in `<EditableList>`, because `<MultiColumnList>` already adds `role="row"` to a wrapper element of each row
2. Add id to note type select header to be referenced as a label