### PR TITLE
STSMACOM-447 correctly pass props.text to ToolTip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.1.0 IN PROGRESS
 
+* `<CollapseFilterPaneButton>` must pass a string to `<ToolTip>`. Refs STSMACOM-447.
+
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)
 

--- a/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
+++ b/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
@@ -4,32 +4,32 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { PaneHeaderIconButton, Tooltip } from '@folio/stripes-components';
 import css from './CollapseFilterPaneButton.css';
 
-const CollapseFilterPaneButton = ({ onClick }) => (
-  <FormattedMessage id="stripes-smart-components.hideSearchPane">
-    {hideSearchPaneMessage => (
-      <Tooltip
-        text={hideSearchPaneMessage}
-        id="collapse-filter-pane-button-tooltip"
-      >
-        {({ ref, ariaIds }) => (
-          <PaneHeaderIconButton
-            ref={ref}
-            aria-labelledby={ariaIds.text}
-            icon="caret-left"
-            iconSize="medium"
-            onClick={onClick}
-            className={css.button}
-            data-test-collapse-filter-pane-button
-          />
-        )}
-      </Tooltip>
-    )}
-  </FormattedMessage>
-);
+const CollapseFilterPaneButton = ({ onClick }) => {
+  const intl = useIntl();
+
+  return (
+    <Tooltip
+      text={intl.formatMessage({ id: 'stripes-smart-components.hideSearchPane' })}
+      id="collapse-filter-pane-button-tooltip"
+    >
+      {({ ref, ariaIds }) => (
+        <PaneHeaderIconButton
+          ref={ref}
+          aria-labelledby={ariaIds.text}
+          icon="caret-left"
+          iconSize="medium"
+          onClick={onClick}
+          className={css.button}
+          data-test-collapse-filter-pane-button
+        />
+      )}
+    </Tooltip>
+  );
+};
 
 CollapseFilterPaneButton.propTypes = {
   onClick: PropTypes.func,


### PR DESCRIPTION
`<CollapseFilterPaneButton>` used `<FormattedMessage>` with renderprops
to derive the value to pass to `<ToolTip>`, but as of `react-intl` `v5`
that results in an array instead of a string, which sucks, and which
generates this console warning:
```
Warning: Failed prop type: Invalid prop `text` supplied to `Tooltip`.
```
Refs [STSMACOM-447](https://issues.folio.org/browse/STSMACOM-447)