### PR TITLE
STSMACOM-350: Do not execute search automatically when query index changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.1.0 IN PROGRESS
 
+* Do not execute search automatically when query index changes. Fixes STSMACOM-350.
+
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)
 

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/DeleteCustomFieldsOptions-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/DeleteCustomFieldsOptions-test.js
@@ -32,6 +32,12 @@ const getMultiSelectCustomFieldData = options => ({
   }
 });
 
+const axeConfig = {
+  rules: {
+    'aria-hidden-focus': { enabled: false },
+  },
+};
+
 const renderComponent = (props = {}) => {
   setupApplication({
     component: <EditCustomFieldsSettings
@@ -92,12 +98,16 @@ describe('delete custom fields options functionality', () => {
 
       renderComponent();
       await editCustomFields.whenLoaded();
-
-      a11yResults = await axe.run();
     });
 
-    it('should not have any a11y issues', () => {
-      expect(a11yResults.violations).to.be.empty;
+    describe('a11y', () => {
+      beforeEach(async () => {
+        a11yResults = await axe.run(document, axeConfig);
+      });
+
+      it('should not have any a11y issues', () => {
+        expect(a11yResults.violations).to.be.empty;
+      });
     });
 
     it('should not display the option delete buttons since there are only 2 options', () => {
@@ -109,7 +119,7 @@ describe('delete custom fields options functionality', () => {
       beforeEach(async () => {
         await editCustomFields.customFields(0).addOption();
         await editCustomFields.customFields(0).options(2).fillOptionName('nice option');
-        a11yResults = await axe.run();
+        a11yResults = await axe.run(document, axeConfig);
       });
 
       it('should not have any a11y issues', () => {

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -238,6 +238,7 @@ class SearchAndSort extends React.Component {
       selectedItem: this.initiallySelectedRecord,
       filterPaneIsVisible: true,
       locallyChangedSearchTerm: '',
+      locallyChangedQueryIndex: '',
     };
 
     this.handleFilterChange = handleFilterChange.bind(this);
@@ -270,20 +271,24 @@ class SearchAndSort extends React.Component {
     } = this.props;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
+    const {
+      location: {
+        search,
+      },
+    } = nextProps;
+    const { qindex } = queryString.parse(search);
 
-    {
-      // If the nominated mutation has finished, select the newly created record
-      const oldStateForFinalSource = makeConnectedSource(this.props, logger, finishedResourceName);
-      const newStateForFinalSource = makeConnectedSource(nextProps, logger, finishedResourceName);
+    // If the nominated mutation has finished, select the newly created record
+    const oldStateForFinalSource = makeConnectedSource(this.props, logger, finishedResourceName);
+    const newStateForFinalSource = makeConnectedSource(nextProps, logger, finishedResourceName);
 
-      if (oldStateForFinalSource.records()) {
-        const finishedResourceNextSM = newStateForFinalSource.successfulMutations();
+    if (oldStateForFinalSource.records()) {
+      const finishedResourceNextSM = newStateForFinalSource.successfulMutations();
 
-        if (finishedResourceNextSM.length > oldStateForFinalSource.successfulMutations().length) {
-          const sm = newState.successfulMutations();
+      if (finishedResourceNextSM.length > oldStateForFinalSource.successfulMutations().length) {
+        const sm = newState.successfulMutations();
 
-          if (sm[0]) this.onSelectRow(undefined, { id: sm[0].record.id });
-        }
+        if (sm[0]) this.onSelectRow(undefined, { id: sm[0].record.id });
       }
     }
 
@@ -306,6 +311,12 @@ class SearchAndSort extends React.Component {
 
     if (newState.totalCount() !== null) {
       this.lastNonNullReaultCount = newState.totalCount();
+    }
+
+    // Reset local qindex if the qindex is not present in the url.
+    // This happens when the search segment changes.
+    if (this.state.locallyChangedQueryIndex && !qindex) {
+      this.setState({ locallyChangedQueryIndex: '' });
     }
   }
 
@@ -413,11 +424,27 @@ class SearchAndSort extends React.Component {
     }
   };
 
+  onChangeIndex = (e) => {
+    this.setState({ locallyChangedQueryIndex: e.target.value });
+
+    if (this.props.onChangeIndex) {
+      this.props.onChangeIndex(e);
+    }
+  }
+
   onSubmitSearch = (e) => {
     e.preventDefault();
     e.stopPropagation();
 
-    this.performSearch(this.state.locallyChangedSearchTerm);
+    const {
+      locallyChangedSearchTerm,
+      locallyChangedQueryIndex,
+    } = this.state;
+
+    this.performSearch({
+      query: locallyChangedSearchTerm,
+      qindex: locallyChangedQueryIndex,
+    });
   };
 
   onChangeFilter = (e) => {
@@ -444,9 +471,17 @@ class SearchAndSort extends React.Component {
     this.props.filterChangeCallback(newFilters);
   };
 
+  resetLocallyChangedQuery = () => {
+    this.setState({
+      locallyChangedSearchTerm: '',
+      locallyChangedQueryIndex: '',
+    });
+  }
+
   onClearSearch = () => {
     this.log('action', 'cleared search');
-    this.setState({ locallyChangedSearchTerm: '' });
+
+    this.resetLocallyChangedQuery();
     this.transitionToParams({
       query: '',
       qindex: '',
@@ -460,7 +495,7 @@ class SearchAndSort extends React.Component {
   onClearSearchAndFilters = () => {
     this.log('action', 'cleared search and filters');
 
-    this.setState({ locallyChangedSearchTerm: '' });
+    this.resetLocallyChangedQuery();
     this.transitionToParams({
       filters: this.initialFilters || '',
       sort: this.initialSort || '',
@@ -680,20 +715,20 @@ class SearchAndSort extends React.Component {
   }
 
   // eslint-disable-next-line react/sort-comp
-  performSearch = debounce((query) => {
+  performSearch = debounce((queryParams) => {
     const {
       parentMutator: { resultCount, resultOffset },
       initialResultCount,
     } = this.props;
 
-    this.log('action', `searched for '${query}'`);
+    this.log('action', `searched for '${queryParams.query}'`);
     resultCount.replace(initialResultCount);
 
     if (resultOffset) {
       resultOffset.replace(0);
     }
 
-    this.transitionToParams({ query });
+    this.transitionToParams(queryParams);
   }, 350);
 
   queryParam(name) {
@@ -949,17 +984,20 @@ class SearchAndSort extends React.Component {
       renderFilters,
       renderNavigation,
       disableFilters,
-      onChangeIndex,
       searchableIndexes,
       selectedIndex,
     } = this.props;
-    const { locallyChangedSearchTerm } = this.state;
+    const {
+      locallyChangedSearchTerm,
+      locallyChangedQueryIndex,
+    } = this.state;
 
     const filters = filterState(this.queryParam('filters'));
     const query = this.queryParam('query') || '';
     const searchTerm = (locallyChangedSearchTerm !== undefined)
       ? locallyChangedSearchTerm
       : query;
+    const queryIndex = locallyChangedQueryIndex || selectedIndex;
 
     return (
       <form onSubmit={this.onSubmitSearch}>
@@ -975,11 +1013,11 @@ class SearchAndSort extends React.Component {
               ariaLabel={ariaLabel}
               className={css.searchField}
               searchableIndexes={searchableIndexes}
-              selectedIndex={selectedIndex}
+              selectedIndex={queryIndex}
               value={searchTerm}
               loading={source.pending()}
               marginBottom0
-              onChangeIndex={onChangeIndex}
+              onChangeIndex={this.onChangeIndex}
               onChange={this.onChangeSearch}
               onClear={this.onClearSearchQuery}
             />

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -20,8 +20,13 @@ describe('SearchAndSort', () => {
         resultCountIncrement={0}
         viewRecordPerms="test"
         objectName="user"
+        searchableIndexes={[
+          { label: 'all', value: 'all' },
+          { label: 'contributors', value: 'contributors' },
+        ]}
         parentResources={{
           records: {
+            isPending: false,
             totalCount: () => 99999,
           }
         }}
@@ -63,6 +68,16 @@ describe('SearchAndSort', () => {
       it('should render an expand button', () => {
         expect(searchAndSort.expandFilterPaneButton.isPresent).to.be.true;
       });
+    });
+  });
+
+  describe('Select query index', () => {
+    beforeEach(async () => {
+      await searchAndSort.selectQueryIndex('contributors');
+    });
+
+    it('search is not performed', function () {
+      expect(this.location.search).to.equal('');
     });
   });
 });

--- a/lib/SearchAndSort/tests/interactor.js
+++ b/lib/SearchAndSort/tests/interactor.js
@@ -3,6 +3,7 @@ import {
   Interactor,
   isPresent,
   text,
+  selectable,
 } from '@bigtest/interactor';
 import ExpandFilterPaneButtonInteractor from '../components/ExpandFilterPaneButton/tests/interactor';
 
@@ -15,4 +16,5 @@ export default interactor(class SearchAndSortInteractor {
   resultsSubtitle = text('#paneHeaderpane-results-subtitle');
   noResultsMessageIsPresent = isPresent('[class^=mclEmptyMessage]');
   noResultsMessage = text('[class^=mclEmptyMessage]');
+  selectQueryIndex = selectable('#input-user-search-qindex');
 });


### PR DESCRIPTION
### Purpose
Given a search type (e.g. Keyword search in Inventory) is selected AND a search for search string "XYZ" has been conducted
When the search type is changed (e.g. from Keyword to Contributors in Inventory) Then:
* The search term "XYZ" should be retained
* The Contributor search for "XYZ" would not be automatically executed (user would need to click "Search" button or hit enter to execute new search or change the filters (once we've fixed this bug: STSMACOM-365))

https://issues.folio.org/browse/STSMACOM-350

This is not a breaking change but the modules which still use `SearchAndSort` will need to remove or adjust `onChangeIndex` if they want to follow the functionality described  STSMACOM-365 for example:

https://github.com/folio-org/ui-inventory/pull/1200/files

Another approach here would be to remove `onChangeIndex` prop from `SearchAndSort` completely. It looks like all of them look exactly the same:

https://github.com/folio-org/ui-finc-config/blob/a820871efed0590839359461df0de3fd2c7150d5/src/routes/SourcesRoute.js#L124-L126

 https://github.com/search?q=org%3Afolio-org+onChangeIndex&type=code


