### PR TITLE
STSMACOM-452 correctly retrieve related requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for stripes-smart-components
 
 ## 5.1.0 IN PROGRESS
-* Increase returnted Note Types per response limit. Refs STSMACOM-449.
 
+* Increase returned Note Types per response limit. Refs STSMACOM-449.
 * Do not execute search automatically when query index changes. Fixes STSMACOM-350.
 * `<CollapseFilterPaneButton>` must pass a string to `<ToolTip>`. Refs STSMACOM-447.
+* Correctly retrieve related requests when changing a loan's due date. Refs STSMACOM-452.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -22,46 +22,66 @@ import getErrorMessage from './utils';
 import css from './ChangeDueDateDialog.css';
 
 class ChangeDueDateDialog extends React.Component {
-  static getOpenRequestsQuery(props) {
-    const userLoans = get(props, 'resources.loans.records', []);
-    const loanIds = props.loanIds.map(loan => loan.id);
+  /**
+   * getOpenRequestQuery
+   * Generate a CQL query to retrieve open requests for items the user has
+   * on loaned.
+   *
+   * @arg loans[] { id } currently selected loans
+   * @arg userLoans[] user's open loans
+   *
+   * return string CQL query for open requests related to current loans; null if there are none
+   */
+  static getOpenRequestsQuery(loans, userLoans) {
+    let queryClause = null;
+    const loanIds = loans.map(loan => loan.id);
     const selectedLoans = userLoans.filter(loan => loanIds.includes(loan.id));
+    if (selectedLoans.length) {
+      const itemsIds = selectedLoans.map(loan => `itemId==${loan.itemId}`).join(' or ');
+      const statuses = '"Open - Awaiting pickup" or "Open - Not yet filled"';
+      queryClause = `(${itemsIds}) and status==(${statuses}) sortby requestDate desc`;
+    }
 
-    if (!selectedLoans.length) return null;
-
-    const itemsIds = selectedLoans.map(loan => `itemId==${loan.itemId}`).join(' or ');
-    const statuses = '"Open - Awaiting pickup" or "Open - Not yet filled"';
-    const query = `(${itemsIds}) and status==(${statuses}) sortby requestDate desc`;
-
-    return { query };
+    return queryClause;
   }
 
+  /**
+   * fetchData
+   * retrieve open loans for this user; if there are any, use that list to
+   * retrieve open requests for those items.
+   *
+   * return void
+   */
   static fetchData(props) {
     props.mutator.loans.reset();
-    props.mutator.loans.GET();
-    props.mutator.openRequests.reset();
-    props.mutator.openRequests.GET(ChangeDueDateDialog.getOpenRequestsQuery(props));
+    props.mutator.loans.GET()
+      .then(res => {
+        const openRequestsQuery = ChangeDueDateDialog.getOpenRequestsQuery(props.loanIds, res);
+        if (openRequestsQuery) {
+          props.mutator.openRequests.reset();
+          props.mutator.openRequests.GET({ params: { query: openRequestsQuery, limit: '1000' } });
+        }
+      });
   }
 
   static manifest = Object.freeze({
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=100000',
+      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1000',
       throwErrors: false,
       accumulate: true,
       PUT: {
         path: 'circulation/loans/%{loanId}',
       },
     },
+    // do not fetch open-requests by default
     openRequests: {
       type: 'okapi',
       path: 'circulation/requests',
       records: 'requests',
+      fetch: false,
       accumulate: true,
-      params: {
-        limit: '10000',
-      },
     },
   });
 


### PR DESCRIPTION
Previously, open requests were incorrectly retrieved without
qualification, rather than related only to items currently on loan. The
current approach (see #572, #575) based on manually inspecting state and
manually firing requests in `getDerivedStateFromProps` differs from how
connected components typically fetch data. That's fine; commentary in
PR #575 indicates this was deliberate due to the peculiarities of how
state is managed in the modal.

Here are the changes now in place:

* the `openRequests` query does not run automatically (by setting
`fetch: false` in the manifest)
* the results of the `loans` query, returned in a promise, are fed
directly to `getOpenRequestsQuery()` because, although they will also be
provided in `props.resources.loans`, `getOpenRequestsQuery()` is not
triggered based on a lifecycle method and therefore needs direct access
to the result from the promise.

I think the bug crept in because a manifest's `params` prop can be
implemented as a function that returns either a query string or,
importantly, `null` to indicate that required props are missing and the
fetch should not fire. In the previous implementation here,
`getOpenRequestsQuery` would return `null` under some circumstances and
a CQL query in others, but as this was not part of a `params` function,
returning `null` did not prevent the fetch from firing; it merely
prevented it from including the correct CQL query in the fetch URL.

In addition to running the unrestricted fetch, the correctly qualified
fetch would never run because `fetchData` would be called from `gDSFP`
only once (because state, rather than a change in props, is used as the
trigger), meaning the result of the `loans` query (which provides the
query for the `openRequests` query) was never used.

Whew.

Refs [STSMACOM-452](https://issues.folio.org/browse/STSMACOM-452)