### PR TITLE
STSMACOM-454 allow escaping to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Do not execute search automatically when query index changes. Fixes STSMACOM-350.
 * `<CollapseFilterPaneButton>` must pass a string to `<ToolTip>`. Refs STSMACOM-447.
 * Correctly retrieve related requests when changing a loan's due date. Refs STSMACOM-452.
+* Allow configurable escaping in `makeQueryFunction`. Refs STSMACOM-454.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -23,7 +23,8 @@ import { removeNsKeys } from './nsQueryFunctions';
 //      2: fail if both query and filters and empty.
 //     For compatibility, false and true may be used for 0 and 1 respectively.
 // @nsParams object|string: namespace keys
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams) {
+// @escape boolean whether to escape quote and backslash values in the query (default: true)
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, escape = true) {
   return (queryParams, pathComponents, resourceValues, logger) => {
     const resourceQuery = removeNsKeys(resourceValues.query, nsParams);
     const nsQueryParams = removeNsKeys(queryParams, nsParams);
@@ -39,16 +40,18 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       return null;
     }
 
+    const escapeFx = escape ? escapeCqlValue : (s) => (s);
+
     let cql;
     if (query && qindex) {
       const t = qindex.split('/', 2);
       if (t.length === 1) {
-        cql = `${qindex}="${escapeCqlValue(query)}*"`;
+        cql = `${qindex}="${escapeFx(query)}*"`;
       } else {
-        cql = `${t[0]} =/${t[1]} "${escapeCqlValue(query)}*"`;
+        cql = `${t[0]} =/${t[1]} "${escapeFx(query)}*"`;
       }
     } else if (query) {
-      const escapedQuery = { ...resourceQuery, ...{ query: escapeCqlValue(get(resourceQuery, 'query', '')) } };
+      const escapedQuery = { ...resourceQuery, ...{ query: escapeFx(get(resourceQuery, 'query', '')) } };
       cql = (typeof queryTemplate === 'function')
         ? queryTemplate(nsQueryParams, pathComponents, { query: escapedQuery })
         : compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: escapedQuery });
@@ -58,6 +61,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
         return null;
       }
     }
+
 
     const filterCql = filters2cql(filterConfig, filters);
     if (filterCql) {


### PR DESCRIPTION
`makeQueryFunction` now accepts another argument, `escape` (default:
`true`) to allow callers to turn off escaping of quote and backslash
values in CQL queries. This is necessary for features like
ui-inventory's "Query search" search-type that submits a fully-formed
CQL query.

Refs [STSMACOM-454](https://issues.folio.org/browse/STSMACOM-454), [UIIN-1319](https://issues.folio.org/browse/UIIN-1319).