### PR TITLE
STSMACOM-456: Show callout in EntryManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `<CollapseFilterPaneButton>` must pass a string to `<ToolTip>`. Refs STSMACOM-447.
 * Correctly retrieve related requests when changing a loan's due date. Refs STSMACOM-452.
 * Allow configurable escaping in `makeQueryFunction`. Refs STSMACOM-454.
+* Show `callout` in `EntryManager` component. Refs STSMACOM-456.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -119,6 +119,7 @@ export default class EntryWrapper extends React.Component {
 
     this.props.parentMutator[rk][action](normalizedEntry)
       .then(data => this.goTo(data))
+      .then(() => this.showCalloutMessage(entry[this.props.nameKey], action))
       .catch(this.handleSaveError);
   }
 
@@ -157,13 +158,27 @@ export default class EntryWrapper extends React.Component {
     history.push(`${location.pathname}?layer=${layer}`);
   }
 
-  showCalloutMessage(name) {
+  showCalloutMessage(name, action) {
+    let actionValue;
+
+    switch (action) {
+      case 'POST':
+        actionValue = 'created';
+        break;
+      case 'PUT':
+        actionValue = 'updated';
+        break;
+      default:
+        actionValue = 'deleted';
+    }
+
     const message = (
       <SafeHTMLMessage
-        id="stripes-core.successfullyDeleted"
+        id="stripes-smart-components.success.message"
         values={{
           entry: this.props.entryLabel,
           name: name || '',
+          action: actionValue
         }}
       />
     );

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -256,6 +256,7 @@
   "settings.common.duplicate": "Duplicate",
   "settings.common.edit": "Edit",
   "settings.common.delete": "Delete",
+  "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
 
   "clipCopy.success": "Successfully copied \"{text}\" to clipboard."
 }


### PR DESCRIPTION
# Description
`Callout` does not show up any more on pages where `EntryManager` is used (circulation forms). 
# Issue
https://issues.folio.org/browse/STSMACOM-456