### PR TITLE
STSMACOM-457: Increase record limit for tags query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly retrieve related requests when changing a loan's due date. Refs STSMACOM-452.
 * Allow configurable escaping in `makeQueryFunction`. Refs STSMACOM-454.
 * Show `callout` in `EntryManager` component. Refs STSMACOM-456.
+* Increase record limit for tags query in `<Tags>`. Fixes STSMACOM-457.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -12,7 +12,7 @@ class Tags extends React.Component {
   static manifest = Object.freeze({
     tags: {
       type: 'okapi',
-      path: 'tags?limit=100',
+      path: 'tags?limit=10000',
       records: 'tags',
       clear: false,
       throwErrors: false,


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-457

The 100 limit started causing some issues in `bugfest-honeysuckle` were there are currently over 100 added tags.

The problem happens when only first 100 tags are fetched. When the new tag is being added which already exists in the db but it's not prefetched the frontend will treat it as a brand `new` tag and the POST request will be issued in order to create it. 

