### PR TITLE
STCOM-782: Return promise from createRecord in SearchAndSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Allow configurable escaping in `makeQueryFunction`. Refs STSMACOM-454.
 * Show `callout` in `EntryManager` component. Refs STSMACOM-456.
 * Increase record limit for tags query in `<Tags>`. Fixes STSMACOM-457.
+* Return promise from `createRecord` to make `submitting` work correctly. Fixes STCOM-782.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Allow configurable escaping in `makeQueryFunction`. Refs STSMACOM-454.
 * Show `callout` in `EntryManager` component. Refs STSMACOM-456.
 * Increase record limit for tags query in `<Tags>`. Fixes STSMACOM-457.
-* Return promise from `createRecord` to make `submitting` work correctly. Fixes STCOM-782.
+* Return promise from `createRecord` to make `submitting` works correctly. Fixes STCOM-782.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -711,7 +711,8 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     massageNewRecord(record);
-    onCreate(record);
+
+    return onCreate(record);
   }
 
   // eslint-disable-next-line react/sort-comp


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-782

It looks like ui-inventory is doing a correct thing already while submitting a form by checking the `submitting` flag:

https://github.com/folio-org/ui-inventory/blob/24a9d2cc4ad1a5156e9f9c0c21472008a98be053/src/edit/InstanceForm.js#L231

https://final-form.org/docs/final-form/types/FormState#submitting

The problem is that the `submitting` is always set to `false` because the submission handler doesn't currently receive a promise. 

This is causing "double submission" problems with instance form in ui-inventory:

https://issues.folio.org/browse/UIIN-1339
https://issues.folio.org/browse/UIIN-1340

There is some additional work which was also required to address it in ui-inventory

https://github.com/folio-org/ui-inventory/pull/1219

This PR takes care of the creation promise configured via `SearchAndSort`.
