### PR TITLE
STSMACOM-459: Improve Tags loading experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Show `callout` in `EntryManager` component. Refs STSMACOM-456.
 * Increase record limit for tags query in `<Tags>`. Fixes STSMACOM-457.
 * Return promise from `createRecord` to make `submitting` works correctly. Fixes STCOM-782.
+* Improve tags loading experience. Fixes STSMACOM-459.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { get, set, uniq, sortBy, difference, noop, isFunction } from 'lodash';
 
-import { Callout, Pane } from '@folio/stripes-components';
+import {
+  Callout,
+  Pane,
+  Loading,
+} from '@folio/stripes-components';
 import { stripesConnect } from '@folio/stripes-core';
 
 import TagsForm from './TagsForm';
@@ -24,6 +28,8 @@ class Tags extends React.Component {
       throwErrors: false,
       type: 'okapi',
       path: '!{link}',
+      // make sure the previously loaded entity is cleaned up
+      resourceShouldRefresh: true,
     },
   });
 
@@ -136,6 +142,10 @@ class Tags extends React.Component {
     }
   }
 
+  isLoading() {
+    return this.props.resources?.entities?.isPending;
+  }
+
   render() {
     const {
       children,
@@ -144,6 +154,7 @@ class Tags extends React.Component {
     } = this.props;
     const entityTags = getEntityTags(this.props);
     const tags = this.getTags();
+    const isLoading = this.isLoading();
 
     const tagsForm = (
       <>
@@ -180,6 +191,7 @@ class Tags extends React.Component {
         onClose={onToggle}
       >
         {tagsForm}
+        {isLoading && <Loading />}
       </Pane>
     );
   }

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -28,7 +28,7 @@ class Tags extends React.Component {
       throwErrors: false,
       type: 'okapi',
       path: '!{link}',
-      // make sure the previously loaded entity is cleaned up
+      // make sure previously loaded entity is cleaned up
       resourceShouldRefresh: true,
     },
   });

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -20,6 +20,14 @@ class TagsForm extends React.Component {
     tags: [],
   };
 
+  constructor() {
+    super();
+
+    const addAction = { onSelect: this.addTag, render: this.renderTag };
+
+    this.actions = [addAction];
+  }
+
   state = { entityTags: [] };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -89,8 +97,6 @@ class TagsForm extends React.Component {
     const { entityTags } = this.state;
     const dataOptions = tags.map(t => ({ value: t.label.toLowerCase(), label: t.label.toLowerCase() }));
     const tagsList = entityTags.map(tag => ({ value: tag.toLowerCase(), label: tag.toLowerCase() }));
-    const addAction = { onSelect: this.addTag, render: this.renderTag };
-    const actions = [addAction];
 
     return (
       <FormattedMessage id="stripes-smart-components.enterATag">
@@ -101,7 +107,7 @@ class TagsForm extends React.Component {
                 id="input-tag"
                 placeholder={placeholder}
                 aria-label={ariaLabel}
-                actions={actions}
+                actions={this.actions}
                 filter={this.filterItems}
                 emptyMessage=" "
                 onChange={this.onChange}

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { isEqual, difference, sortBy, noop } from 'lodash';
 
 import { MultiSelection } from '@folio/stripes-components';
 
-export default class TagsForm extends React.Component {
+class TagsForm extends React.Component {
   static propTypes = {
     entityTags: PropTypes.arrayOf(PropTypes.string),
     onAdd: PropTypes.func,
@@ -115,3 +115,8 @@ export default class TagsForm extends React.Component {
     );
   }
 }
+
+export default memo(TagsForm, (prevProps, nextProps) => {
+  return isEqual(prevProps.entityTags, nextProps.entityTags) &&
+    isEqual(prevProps.tags, nextProps.tags);
+});


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-459

This PR is doing couple things:

1. While switching between different entities (users, requests) the tags from the previous record were still visible for a while before the new tags were loaded. This should be now addressed by using `resourceShouldRefresh`.

2. It takes couple seconds before the tags are loaded for a given user in ui-users. This is due to the fact that when a new user record is opened there are 65 requests firing and the request associated with tags usually finishes last. The `<Loading />` indicator was added to provide some sort of feedback. (We probably should spend some time and think how we could refactor it in order to improve it. For example the entity we work with is usually already preloaded before we open the tags pane so perhaps we could utilize that).

3. Added `memo` to limit the number of times the `TagsForm` in rendered.
