### PR TITLE
STSMACOM-463 refactor ClipCopy with useIntl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Increase record limit for tags query in `<Tags>`. Fixes STSMACOM-457.
 * Return promise from `createRecord` to make `submitting` works correctly. Fixes STCOM-782.
 * Improve tags loading experience. Fixes STSMACOM-459.
+* Refactor `<ClipCopy>` with `useIntl` to avoid context problems. Refs STCOR-481; Fixes STSMACOM-463.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/ClipCopy/ClipCopy.js
+++ b/lib/ClipCopy/ClipCopy.js
@@ -4,7 +4,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import {
-  FormattedMessage,
+  useIntl
 } from 'react-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
@@ -17,16 +17,16 @@ import {
 
 const ClipCopy = ({ text }) => {
   const callout = useContext(CalloutContext);
+  const intl = useIntl();
   const handleCopy = useCallback(() => {
     callout.sendCallout({
       type: 'success',
-      message: (
-        <FormattedMessage
-          id="stripes-smart-components.clipCopy.success"
-          values={{ text }}
-        />)
+      message: intl.formatMessage(
+        { id: 'stripes-smart-components.clipCopy.success' },
+        { text }
+      ),
     });
-  }, [text, callout]);
+  }, [text, callout, intl]);
 
   return (
     <CopyToClipboard


### PR DESCRIPTION
There was a bad interaction between `<FormattedMessage>` and
`useCallback` in `<ClipCopy>`, likely because `<FormattedMessage>`
implicitly relies on the `<IntlProvider>` context being available, but
this is not passed into `useCallback`.

Refactoring with `useIntl`, allowing the `intl` object to become an
explicit dependency of the `useCallback` hook, resolves this issue.

We moved the `CalloutContext` up a level in the component hierarchy in
STCOR-481, which is probably the root cause of this.

Refs [STSMACOM-463](https://issues.folio.org/browse/STSMACOM-463), [UIIN-1357](https://issues.folio.org/browse/UIIN-1357), [UIOR-635](https://issues.folio.org/browse/UIOR-635), [STCOR-481](https://issues.folio.org/browse/STCOR-481)