### PR TITLE
UITAG-37 fix filtered tags sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.1.0 IN PROGRESS
 
+* Suggested tags are showing in reverse alpha order. Refs UITAG-37
 * Increase returned Note Types per response limit. Refs STSMACOM-449.
 * Do not execute search automatically when query index changes. Fixes STSMACOM-350.
 * `<CollapseFilterPaneButton>` must pass a string to `<ToolTip>`. Refs STSMACOM-447.

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -46,7 +46,10 @@ class Tags extends React.Component {
     onToggle: PropTypes.func,
     refreshRemote: PropTypes.func.isRequired,
     resources: PropTypes.shape({
-      entities: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
+      entities: PropTypes.shape({
+        isPending: PropTypes.bool,
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
       tags: PropTypes.shape({ records: PropTypes.arrayOf(PropTypes.object) }),
     }).isRequired,
   };

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -5,6 +5,8 @@ import { isEqual, difference, sortBy, noop } from 'lodash';
 
 import { MultiSelection } from '@folio/stripes-components';
 
+const localeCompareCB = (a, b) => a.value.localeCompare(b.value);
+
 class TagsForm extends React.Component {
   static propTypes = {
     entityTags: PropTypes.arrayOf(PropTypes.string),
@@ -54,14 +56,16 @@ class TagsForm extends React.Component {
     if (!filter) {
       return { renderedItems: list };
     }
+    const filterLowercased = filter.toLowerCase();
 
-    const filtered = list.filter(item => item.value.toLowerCase().includes(filter.toLowerCase()));
-    const renderedItems = filtered.sort((a, b) => {
-      if (a.value.toLowerCase().startsWith(filter.toLowerCase())) return -1;
-      if (b.value.toLowerCase().startsWith(filter.toLowerCase())) return 1;
-
-      return a.value.localeCompare(b.value);
-    });
+    const renderedItems = [
+      ...list
+        .filter(({ value }) => value.toLowerCase().startsWith(filterLowercased))
+        .sort(localeCompareCB),
+      ...list
+        .filter(({ value }) => !value.toLowerCase().startsWith(filterLowercased) && value.toLowerCase().includes(filterLowercased))
+        .sort(localeCompareCB),
+    ];
 
     return { renderedItems };
   };

--- a/lib/Tags/TagsForm.js
+++ b/lib/Tags/TagsForm.js
@@ -63,7 +63,10 @@ class TagsForm extends React.Component {
         .filter(({ value }) => value.toLowerCase().startsWith(filterLowercased))
         .sort(localeCompareCB),
       ...list
-        .filter(({ value }) => !value.toLowerCase().startsWith(filterLowercased) && value.toLowerCase().includes(filterLowercased))
+        .filter(({ value }) => (
+          !value.toLowerCase().startsWith(filterLowercased)
+          && value.toLowerCase().includes(filterLowercased)
+        ))
         .sort(localeCompareCB),
     ];
 


### PR DESCRIPTION
first we show items that start with filtered text, sort them, and then we show items that contain filtered text but don't start with it.
https://issues.folio.org/browse/UITAG-37