### PR TITLE
STSMACOM-465: Extend `SearchAndSort` with the functionality to execute callback on reset search and filter button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Return promise from `createRecord` to make `submitting` works correctly. Fixes STCOM-782.
 * Improve tags loading experience. Fixes STSMACOM-459.
 * Refactor `<ClipCopy>` with `useIntl` to avoid context problems. Refs STCOR-481; Fixes STSMACOM-463.
+* Extend `SearchAndSort` with the functionality to execute callback on reset search and filter button. Refs STSMACOM-465.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -139,6 +139,7 @@ class SearchAndSort extends React.Component {
     onComponentWillUnmount: PropTypes.func,
     onCreate: PropTypes.func,
     onFilterChange: PropTypes.func,
+    onResetAll: PropTypes.func,
     onSelectRow: PropTypes.func,
     packageInfo: PropTypes.shape({ // values pulled from the provider's package.json config object
       initialFilters: PropTypes.string, // default filters
@@ -218,6 +219,7 @@ class SearchAndSort extends React.Component {
     showSingleResult: false,
     maxSortKeys: 2,
     onComponentWillUnmount: noop,
+    onResetAll: noop,
     filterChangeCallback: noop,
     getHelperComponent: noop,
     massageNewRecord: noop,
@@ -504,6 +506,7 @@ class SearchAndSort extends React.Component {
     });
 
     this.props.filterChangeCallback({});
+    this.props.onResetAll();
   };
 
   onClearSearchQuery = () => {

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { setupApplication, mount, wait } from '../../../tests/helpers';
 import connectStripes from '../../../tests/connectStripes';
@@ -12,8 +13,11 @@ describe('SearchAndSort', () => {
   setupApplication();
   const searchAndSort = new SearchAndSortInteractor();
   const ConnectedComponent = connectStripes(SearchAndSort);
+  const onResetAllSpy = sinon.spy();
 
   beforeEach(() => {
+    onResetAllSpy.resetHistory();
+
     mount(
       <ConnectedComponent
         initialResultCount={0}
@@ -44,6 +48,7 @@ describe('SearchAndSort', () => {
           name: 'Search and sort test',
         }}
         viewRecordComponent={() => <div />}
+        onResetAll={onResetAllSpy}
       />
     );
   });
@@ -78,6 +83,17 @@ describe('SearchAndSort', () => {
 
     it('search is not performed', function () {
       expect(this.location.search).to.equal('');
+    });
+  });
+
+  describe('clicking on reset all button', () => {
+    beforeEach(async () => {
+      await searchAndSort.searchField.fillAndBlur('search');
+      await searchAndSort.resetAll();
+    });
+
+    it('should call the provided callback', () => {
+      expect(onResetAllSpy.called).to.be.true;
     });
   });
 });

--- a/lib/SearchAndSort/tests/interactor.js
+++ b/lib/SearchAndSort/tests/interactor.js
@@ -4,7 +4,10 @@ import {
   isPresent,
   text,
   selectable,
+  clickable,
 } from '@bigtest/interactor';
+import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+
 import ExpandFilterPaneButtonInteractor from '../components/ExpandFilterPaneButton/tests/interactor';
 
 export default interactor(class SearchAndSortInteractor {
@@ -17,4 +20,6 @@ export default interactor(class SearchAndSortInteractor {
   noResultsMessageIsPresent = isPresent('[class^=mclEmptyMessage]');
   noResultsMessage = text('[class^=mclEmptyMessage]');
   selectQueryIndex = selectable('#input-user-search-qindex');
+  searchField = new TextFieldInteractor('[class^=searchFieldWrap]');
+  resetAll = clickable('#clickable-reset-all');
 });


### PR DESCRIPTION
## Purpose

Extend `SearchAndSort` with the functionality to execute a callback on reset search and filter button in the scope of the [STSMACOM-465](https://issues.folio.org/browse/STSMACOM-465).

## Motivation
In order to comply with scenario 5 from [UIIN-1350](https://issues.folio.org/browse/UIIN-1350), SearchAndSort should be extended to execute callback upon reset button clicked.

> *  Given: the results list is populated and at least one checkbox is selected
> *  When: the user selects Reset all button  and the result list clears out
> *  Then: the previously selected records are unselected and the records count label is hidden as well.