### PR TITLE
STSMACOM-465: Make `searchField` to use `SearchFieldInteractor` in `SearchAndSortInteractor`

### DIFF
--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -88,8 +88,8 @@ describe('SearchAndSort', () => {
 
   describe('clicking on reset all button', () => {
     beforeEach(async () => {
-      await searchAndSort.searchField.fillAndBlur('search');
-      await searchAndSort.resetAll();
+      await searchAndSort.searchField.fillInput('search');
+      await searchAndSort.resetAll.click();
     });
 
     it('should call the provided callback', () => {

--- a/lib/SearchAndSort/tests/interactor.js
+++ b/lib/SearchAndSort/tests/interactor.js
@@ -4,9 +4,11 @@ import {
   isPresent,
   text,
   selectable,
-  clickable,
+  scoped,
 } from '@bigtest/interactor';
-import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+
+import SearchFieldInteractor from '@folio/stripes-components/lib/SearchField/tests/interactor';
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 
 import ExpandFilterPaneButtonInteractor from '../components/ExpandFilterPaneButton/tests/interactor';
 
@@ -20,6 +22,6 @@ export default interactor(class SearchAndSortInteractor {
   noResultsMessageIsPresent = isPresent('[class^=mclEmptyMessage]');
   noResultsMessage = text('[class^=mclEmptyMessage]');
   selectQueryIndex = selectable('#input-user-search-qindex');
-  searchField = new TextFieldInteractor('[class^=searchFieldWrap]');
-  resetAll = clickable('#clickable-reset-all');
+  searchField = scoped('[class^=searchFieldWrap]', SearchFieldInteractor);
+  resetAll = scoped('#clickable-reset-all', ButtonInteractor);
 });


### PR DESCRIPTION
## Purpose

In the scope of the [STSMACOM-465](https://issues.folio.org/browse/STSMACOM-465).
- Make `searchField` to use `SearchFieldInteractor` in `SearchAndSortInteractor`;
- Use `ButtonInteractor` for `resetAll` in `SearchAndSortInteractor` so props like `isPresent` and `idDisabled` can be used;