### PR TITLE
STSMACOM-467: Extend SearchAndSort with customPaneSub prop to display additional element in paneSub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Extend `SearchAndSort` with the functionality to execute callback on reset search and filter button. Refs STSMACOM-465.
 * Add closedByDefault prop to `<TagsAccordion>`. Fixes UIIN-308.
 * AdressView headers are not translated. Fixes UIORGS-220.
+* Extend `SearchAndSort` with `customPaneSub` prop to display additional elements in `paneSub`. Refs STSMACOM-467.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -13,3 +13,9 @@
 .searchField {
   margin-bottom: calc(var(--control-margin-bottom) / 2);
 }
+
+.delimiter {
+  & > span:not(:last-child)::after {
+    content: "\00a0\B7\00a0";
+  }
+}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -84,6 +84,7 @@ class SearchAndSort extends React.Component {
     columnMapping: PropTypes.object,
     columnWidths: PropTypes.object,
     createRecordPath: PropTypes.string,
+    customPaneSub: PropTypes.node,
     detailProps: PropTypes.object,
     disableFilters: PropTypes.object,
     disableRecordCreation: PropTypes.bool,
@@ -216,6 +217,7 @@ class SearchAndSort extends React.Component {
   };
 
   static defaultProps = {
+    customPaneSub: null,
     showSingleResult: false,
     maxSortKeys: 2,
     onComponentWillUnmount: noop,
@@ -1121,12 +1123,43 @@ class SearchAndSort extends React.Component {
     );
   }
 
+  getPaneSub(source) {
+    const {
+      customPaneSub,
+      resultCountMessageKey,
+    } = this.props;
+
+    const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
+    const isSourceLoaded = source.loaded();
+    const isTotalCountUndefined = source.totalCount() === undefined;
+    const isSearchResultCountUnknown = isSourceLoaded && isTotalCountUndefined;
+    const isSearchResultCountPresent = isSourceLoaded && !isTotalCountUndefined;
+
+    return (
+      <div className={css.delimiter}>
+        <span>
+          {isSearchResultCountUnknown && (
+            <FormattedMessage id="stripes-smart-components.searchResultsCountUnknown" />
+          )}
+          {isSearchResultCountPresent && (
+            <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />
+          )}
+          {!isSourceLoaded && (
+            <FormattedMessage id="stripes-smart-components.searchCriteria" />
+          )}
+        </span>
+        {customPaneSub && (
+          <span data-test-custom-pane-sub>{customPaneSub}</span>
+        )}
+      </div>
+    );
+  }
+
   render() {
     const {
       stripes,
       actionMenu,
       module,
-      resultCountMessageKey,
       title,
       hasNewButton,
     } = this.props;
@@ -1134,19 +1167,6 @@ class SearchAndSort extends React.Component {
 
     const source = makeConnectedSource(this.props, stripes.logger);
     const moduleName = this.getModuleName();
-
-    const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
-
-    let paneSub;
-    if (source.loaded()) {
-      if (source.totalCount() === undefined) {
-        paneSub = <FormattedMessage id="stripes-smart-components.searchResultsCountUnknown" />;
-      } else {
-        paneSub = <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />;
-      }
-    } else {
-      paneSub = <FormattedMessage id="stripes-smart-components.searchCriteria" />;
-    }
 
     return (
       <Paneset data-test-search-and-sort>
@@ -1180,7 +1200,7 @@ class SearchAndSort extends React.Component {
           actionMenu={actionMenu}
           appIcon={<AppIcon app={moduleName} />}
           paneTitle={title || (module && module.displayName)}
-          paneSub={paneSub}
+          paneSub={this.getPaneSub(source)}
           lastMenu={hasNewButton ? this.renderNewRecordBtn() : null}
           firstMenu={this.renderResultsFirstMenu()}
           noOverflow

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -48,6 +48,7 @@ describe('SearchAndSort', () => {
           name: 'Search and sort test',
         }}
         viewRecordComponent={() => <div />}
+        customPaneSub="Custom pane sub"
         onResetAll={onResetAllSpy}
       />
     );
@@ -94,6 +95,12 @@ describe('SearchAndSort', () => {
 
     it('should call the provided callback', () => {
       expect(onResetAllSpy.called).to.be.true;
+    });
+  });
+
+  describe('passing custom pane sub', () => {
+    it('should display correct custom pane sub', () => {
+      expect(searchAndSort.customPaneSub.text).to.equal('Custom pane sub');
     });
   });
 });

--- a/lib/SearchAndSort/tests/interactor.js
+++ b/lib/SearchAndSort/tests/interactor.js
@@ -19,6 +19,7 @@ export default interactor(class SearchAndSortInteractor {
   expandFilterPaneButton = new ExpandFilterPaneButtonInteractor();
 
   resultsSubtitle = text('#paneHeaderpane-results-subtitle');
+  customPaneSub = scoped('[data-test-custom-pane-sub]');
   noResultsMessageIsPresent = isPresent('[class^=mclEmptyMessage]');
   noResultsMessage = text('[class^=mclEmptyMessage]');
   selectQueryIndex = selectable('#input-user-search-qindex');

--- a/lib/SearchAndSort/tests/record-count-test.js
+++ b/lib/SearchAndSort/tests/record-count-test.js
@@ -87,6 +87,10 @@ describe('SearchAndSort results', () => {
     it('should show 99,999 records found', () => {
       expect(searchAndSort.resultsSubtitle).to.equal('99,999 records found');
     });
+
+    it('should not display custom pane sub', () => {
+      expect(searchAndSort.customPaneSub.isPresent).to.be.false;
+    });
   });
 
   /**
@@ -170,6 +174,20 @@ describe('SearchAndSort results', () => {
 
     it('no-results message should indicate pristine form state', () => {
       expect(searchAndSort.noResultsMessage).to.equal('Choose a filter or enter a search query to show results.');
+    });
+  });
+
+  describe('passing custom pane sub', () => {
+    setupApplication();
+    const searchAndSort = new SearchAndSortInteractor();
+    const ConnectedComponent = connectStripes(SearchAndSort);
+
+    beforeEach(async () => {
+      await mount(<ConnectedComponent {...defaultProps} customPaneSub="Custom pane sub" />);
+    });
+
+    it('should display correct custom pane sub', () => {
+      expect(searchAndSort.customPaneSub.text).to.equal('Custom pane sub');
     });
   });
 });


### PR DESCRIPTION
## Purpose 
In scope of [STSMACOM-467](https://issues.folio.org/browse/STSMACOM-467).

In order to comply with [UIDEXP-168](https://issues.folio.org/browse/UIDEXP-168), where there search results pane subheader should display the number of selected items the `SearchAndSort` should be extended to support this.

## Screenshots
![image](https://user-images.githubusercontent.com/69502158/100759576-70f66000-33f9-11eb-883b-2448852b65e2.png)
