### PR TITLE
SPECULATIVE: allow <EntryList> lines to be rendered by a nominated component

### DIFF
--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -318,6 +318,7 @@ class EntrySelector extends React.Component {
       nameKey,
       addMenu,
       paneSetWidth
+      entryComponent
     } = this.props;
 
     const rows = this.filteredRows(contentData);
@@ -327,7 +328,7 @@ class EntrySelector extends React.Component {
           to={this.linkPath(item.id)}
           onClick={() => this.props.onClick(item)}
         >
-          {item[nameKey] || '[unnamed]'}
+          entryComponent ? <entryComponent item={item} /> : {item[nameKey] || '[unnamed]'}
         </NavListItem>
       </div>
     ));


### PR DESCRIPTION
As things stand, `<EntryList>` items are always rendered only as the value of a nominated field (often `name`). Sometimes it would be nice to show something more elaborate, e.g. the name and URL fields together. Something like the change outlined here should do it in a general and straightforward way. Thoughts?

**NOTE.** Do not merge this. I have not even tried to run it. It's a sketch.