### PR TITLE
Conditionally access `discovery` in redux store

### DIFF
--- a/lib/CustomFields/selectors/selectModuleId.js
+++ b/lib/CustomFields/selectors/selectModuleId.js
@@ -1,5 +1,5 @@
 const selectModuleId = (store, moduleName) => {
-  const { modules } = store.discovery;
+  const modules = store?.discovery?.modules;
 
   if (!modules) return null;
 


### PR DESCRIPTION
`discovery` may not exist. It's [removed during a `DESTROY_STORE` action](https://github.com/folio-org/stripes-core/blob/629c92769d62aacf41dc5af830332a0de127714e/src/enhanceReducer.js#L16-L19) when Stripes is being unmounted.

@skomorokh, this is the other unrelated fix during my react-redux work.