### PR TITLE
STSMACOM-473: Refactor redux-form context in EmbeddedAddressForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Result list. Align text in the columns in the top. Refs STSMACOM-469.
 * Support searching Notes by note title and note details. Refs STSMACOM-466.
 * Allow submitting of Assign/Unassign Notes modal form by pressing Enter. Refs STSMACOM-471.
+* Refactor redux form context in `<EmbeddedAddressForm>`. Fixes STSMACOM-473.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
+import { Field, ReduxFormContext } from 'redux-form';
 import findIndex from 'lodash/findIndex';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -19,6 +19,7 @@ import {
 } from '@folio/stripes-components';
 
 import { countriesOptions } from '../data/countries';
+import withReduxFormContext from './withReduxFormContext';
 import css from './AddressEdit.css';
 
 const omitUsedOptions = (list, usedValues, key, id) => {
@@ -33,6 +34,8 @@ const omitUsedOptions = (list, usedValues, key, id) => {
   });
   return unUsedValues;
 };
+
+;
 
 class EmbeddedAddressForm extends React.Component {
   static propTypes = {
@@ -52,10 +55,7 @@ class EmbeddedAddressForm extends React.Component {
     labelMap: PropTypes.object,
     primary: PropTypes.func,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
-  };
-
-  static contextTypes = {
-    _reduxForm: PropTypes.object,
+    reduxForm: PropTypes.object,
   };
 
   static defaultProps = {
@@ -98,7 +98,7 @@ class EmbeddedAddressForm extends React.Component {
   }
 
   singlePrimary(id) {
-    const { values, dispatch, change } = this.context._reduxForm;
+    const { values, dispatch, change } = this.props.reduxForm;
     values.personal.addresses.forEach((a, i) => {
       if (i === id) {
         dispatch(change(`personal.addresses[${i}].primaryAddress`, true));
@@ -121,11 +121,8 @@ class EmbeddedAddressForm extends React.Component {
       visibleFields,
       displayKey,
       displayPrimary,
+      reduxForm: { values },
     } = this.props;
-
-    const {
-      values,
-    } = this.context._reduxForm;
 
     const PrimaryRadio = ({ input, ...props }) => (
       <label className={css.primaryToggle} htmlFor={props.id}>
@@ -193,48 +190,52 @@ class EmbeddedAddressForm extends React.Component {
     });
 
     return (
-      <div className={css.addressForm}>
-        <div className={css.addressFormHeader} start="xs">
-          <div className={css.addressLabel}>
-            { addressLabel }
-            { displayKey && (this.props.fieldKey + 1) }
+      <ReduxFormContext.Consumer>
+      {(reduxForm) => (
+        <div className={css.addressForm}>
+          <div className={css.addressFormHeader} start="xs">
+            <div className={css.addressLabel}>
+              { addressLabel }
+              { displayKey && (this.props.fieldKey + 1) }
+            </div>
+            <div>
+              { displayPrimary &&
+                <Field
+                  component={PrimaryRadio}
+                  name={`${addressFieldName}.primary`}
+                  id={`PrimaryAddress---${addressFieldName}`}
+                  fieldKey={this.props.fieldKey}
+                />
+              }
+            </div>
+            <div className={css.addressHeaderActions}>
+              {
+                canDelete &&
+                <Button
+                  data-test-delete-address-button
+                  buttonStyle="link slim"
+                  style={{ margin: 0, padding: 0 }}
+                  onClick={() => { this.props.handleDelete(fieldKey); }}
+                >
+                  <Icon icon="trash" width="24px" height="24px" />
+                  <span className="sr-only">
+                    <FormattedMessage id="stripes-smart-components.addressEdit.removeAddress" />
+                    {this.props.fieldKey + 1}
+                  </span>
+                </Button>
+              }
+            </div>
           </div>
-          <div>
-            { displayPrimary &&
-              <Field
-                component={PrimaryRadio}
-                name={`${addressFieldName}.primary`}
-                id={`PrimaryAddress---${addressFieldName}`}
-                fieldKey={this.props.fieldKey}
-              />
-            }
-          </div>
-          <div className={css.addressHeaderActions}>
-            {
-              canDelete &&
-              <Button
-                data-test-delete-address-button
-                buttonStyle="link slim"
-                style={{ margin: 0, padding: 0 }}
-                onClick={() => { this.props.handleDelete(fieldKey); }}
-              >
-                <Icon icon="trash" width="24px" height="24px" />
-                <span className="sr-only">
-                  <FormattedMessage id="stripes-smart-components.addressEdit.removeAddress" />
-                  {this.props.fieldKey + 1}
-                </span>
-              </Button>
-            }
+          <div className={css.addressFormBody}>
+            <Row key={fieldKey}>
+              {renderedFields}
+            </Row>
           </div>
         </div>
-        <div className={css.addressFormBody}>
-          <Row key={fieldKey}>
-            {renderedFields}
-          </Row>
-        </div>
-      </div>
+      )}
+      </ReduxFormContext.Consumer>
     );
   }
 }
 
-export default injectIntl(EmbeddedAddressForm);
+export default withReduxFormContext(injectIntl(EmbeddedAddressForm));

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -35,8 +35,6 @@ const omitUsedOptions = (list, usedValues, key, id) => {
   return unUsedValues;
 };
 
-;
-
 class EmbeddedAddressForm extends React.Component {
   static propTypes = {
     addressFieldName: PropTypes.string,

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field, ReduxFormContext } from 'redux-form';
+import { Field } from 'redux-form';
 import findIndex from 'lodash/findIndex';
 import cloneDeep from 'lodash/cloneDeep';
 import {

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -188,50 +188,46 @@ class EmbeddedAddressForm extends React.Component {
     });
 
     return (
-      <ReduxFormContext.Consumer>
-      {(reduxForm) => (
-        <div className={css.addressForm}>
-          <div className={css.addressFormHeader} start="xs">
-            <div className={css.addressLabel}>
-              { addressLabel }
-              { displayKey && (this.props.fieldKey + 1) }
-            </div>
-            <div>
-              { displayPrimary &&
-                <Field
-                  component={PrimaryRadio}
-                  name={`${addressFieldName}.primary`}
-                  id={`PrimaryAddress---${addressFieldName}`}
-                  fieldKey={this.props.fieldKey}
-                />
-              }
-            </div>
-            <div className={css.addressHeaderActions}>
-              {
-                canDelete &&
-                <Button
-                  data-test-delete-address-button
-                  buttonStyle="link slim"
-                  style={{ margin: 0, padding: 0 }}
-                  onClick={() => { this.props.handleDelete(fieldKey); }}
-                >
-                  <Icon icon="trash" width="24px" height="24px" />
-                  <span className="sr-only">
-                    <FormattedMessage id="stripes-smart-components.addressEdit.removeAddress" />
-                    {this.props.fieldKey + 1}
-                  </span>
-                </Button>
-              }
-            </div>
+      <div className={css.addressForm}>
+        <div className={css.addressFormHeader} start="xs">
+          <div className={css.addressLabel}>
+            { addressLabel }
+            { displayKey && (this.props.fieldKey + 1) }
           </div>
-          <div className={css.addressFormBody}>
-            <Row key={fieldKey}>
-              {renderedFields}
-            </Row>
+          <div>
+            { displayPrimary &&
+              <Field
+                component={PrimaryRadio}
+                name={`${addressFieldName}.primary`}
+                id={`PrimaryAddress---${addressFieldName}`}
+                fieldKey={this.props.fieldKey}
+              />
+            }
+          </div>
+          <div className={css.addressHeaderActions}>
+            {
+              canDelete &&
+              <Button
+                data-test-delete-address-button
+                buttonStyle="link slim"
+                style={{ margin: 0, padding: 0 }}
+                onClick={() => { this.props.handleDelete(fieldKey); }}
+              >
+                <Icon icon="trash" width="24px" height="24px" />
+                <span className="sr-only">
+                  <FormattedMessage id="stripes-smart-components.addressEdit.removeAddress" />
+                  {this.props.fieldKey + 1}
+                </span>
+              </Button>
+            }
           </div>
         </div>
-      )}
-      </ReduxFormContext.Consumer>
+        <div className={css.addressFormBody}>
+          <Row key={fieldKey}>
+            {renderedFields}
+          </Row>
+        </div>
+      </div>
     );
   }
 }

--- a/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
+++ b/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ReduxFormContext } from 'redux-form';
+
+const withReduxFormContext = WrappedComponent => props => (
+  <ReduxFormContext.Consumer>
+    {(reduxForm) => (
+      <WrappedComponent {...props} reduxForm={reduxForm} />
+    )}
+  </ReduxFormContext.Consumer>
+);
+
+export default withReduxFormContext;

--- a/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
+++ b/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
@@ -3,9 +3,7 @@ import { ReduxFormContext } from 'redux-form';
 
 const withReduxFormContext = WrappedComponent => props => (
   <ReduxFormContext.Consumer>
-    {(reduxForm) => (
-      <WrappedComponent {...props} reduxForm={reduxForm} />
-    )}
+    {reduxForm => (<WrappedComponent {...props} reduxForm={reduxForm} />)}
   </ReduxFormContext.Consumer>
 );
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-473

The previous way of accessing reduxForm via `contextTypes` was not supported any more so this uses `ReduxFormContext` instead. 