### PR TITLE
PERF-62 use more efficient query clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Allow submitting of Assign/Unassign Notes modal form by pressing Enter. Refs STSMACOM-471.
 * Fix modal a11y issues in NoteViewPage and NoteForm components. Refs UIEH-1017.
 * Refactor redux form context in `<EmbeddedAddressForm>`. Fixes STSMACOM-473.
+* Use more efficient query clauses. Refs PERF-62.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateDialog.js
@@ -68,7 +68,7 @@ class ChangeDueDateDialog extends React.Component {
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=!{user.id} and status.name<>Closed)&limit=1000',
+      path: 'circulation/loans?query=(userId==!{user.id} and status.name<>Closed)&limit=1000',
       throwErrors: false,
       accumulate: true,
       PUT: {

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -11,7 +11,7 @@ class ConfigManager extends React.Component {
     settings: {
       type: 'okapi',
       records: 'configs',
-      path: 'configurations/entries?query=(module=!{moduleName} and configName=!{configName})',
+      path: 'configurations/entries?query=(module==!{moduleName} and configName==!{configName})',
       POST: {
         path: 'configurations/entries',
       },


### PR DESCRIPTION
Use `==` instead of `=` when querying by ID.

I found an earlier version of this fix from June 2020 when cleaning up
some old branches. I don't know why it was never PR-ified then. :shrug:

Refs [PERF-62](https://issues.folio.org/browse/PERF-62)