### PR TITLE
STSMACOM-475: Fix axe error with aria-label on Assign/Unassign modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Fix modal a11y issues in NoteViewPage and NoteForm components. Refs UIEH-1017.
 * Refactor redux form context in `<EmbeddedAddressForm>`. Fixes STSMACOM-473.
 * Use more efficient query clauses. Refs PERF-62.
-* Fix axe error with `aria-label` on Assign/Unassign modal. Refs UINOTES-86.
+* Fix axe error with `aria-label` on Assign/Unassign modal. Refs STSMACOM-475.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix modal a11y issues in NoteViewPage and NoteForm components. Refs UIEH-1017.
 * Refactor redux form context in `<EmbeddedAddressForm>`. Fixes STSMACOM-473.
 * Use more efficient query clauses. Refs PERF-62.
+* Fix axe error with `aria-label` on Assign/Unassign modal. Refs UINOTES-86.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+} from 'react-intl';
 
 import {
   get,
@@ -86,7 +89,7 @@ const notesShape = PropTypes.shape({
   totalCount: PropTypes.number,
 });
 
-export default class NotesAssigningModal extends React.Component {
+class NotesAssigningModal extends React.Component {
   static propTypes = {
     fetchDomainNotes: PropTypes.func.isRequired,
     notes: notesShape,
@@ -444,6 +447,7 @@ export default class NotesAssigningModal extends React.Component {
       open,
       notes,
       onClose,
+      intl,
     } = this.props;
 
     const {
@@ -465,6 +469,7 @@ export default class NotesAssigningModal extends React.Component {
         contentClass={css['modal-content']}
         open={open}
         label={<FormattedMessage id="stripes-smart-components.notes.assignUnassignNote" />}
+        aria-label={intl.formatMessage({ id: "stripes-smart-components.notes.assignUnassignNote" })}
         onClose={onClose}
         footer={this.renderFooter()}
         dismissible
@@ -610,3 +615,5 @@ export default class NotesAssigningModal extends React.Component {
     );
   }
 }
+
+export default injectIntl(NotesAssigningModal);

--- a/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesAssigningModal/NotesAssigningModal.js
@@ -92,6 +92,9 @@ const notesShape = PropTypes.shape({
 class NotesAssigningModal extends React.Component {
   static propTypes = {
     fetchDomainNotes: PropTypes.func.isRequired,
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }).isRequired,
     notes: notesShape,
     noteTypes: PropTypes.arrayOf(PropTypes.string),
     onClose: PropTypes.func.isRequired,
@@ -469,7 +472,7 @@ class NotesAssigningModal extends React.Component {
         contentClass={css['modal-content']}
         open={open}
         label={<FormattedMessage id="stripes-smart-components.notes.assignUnassignNote" />}
-        aria-label={intl.formatMessage({ id: "stripes-smart-components.notes.assignUnassignNote" })}
+        aria-label={intl.formatMessage({ id: 'stripes-smart-components.notes.assignUnassignNote' })}
         onClose={onClose}
         footer={this.renderFooter()}
         dismissible


### PR DESCRIPTION
## Purpose:
Fix axe error with aria-label on Assign/Unassign modal (NotesAssigningModal)
Related issue: [STSMACOM-475](https://issues.folio.org/browse/STSMACOM-475)

## Screenshot:
(only color related errors left)

![Screenshot 2021-01-25 at 13 58 48](https://user-images.githubusercontent.com/60929399/105706373-1f121800-5f1a-11eb-8fc9-b0c7dc4759ab.png)
