### PR TITLE
STSMACOM-480 fix permission for View Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.0.0 IN PROGRESS
 
+* Require back-end permission `users.collection.get` instead of ui `ui-users.view` for ViewMetaData. Refs STSMACOM-480
 * Suggested tags are showing in reverse alpha order. Refs UITAG-37
 * Increase returned Note Types per response limit. Refs STSMACOM-449.
 * Do not execute search automatically when query index changes. Fixes STSMACOM-350.

--- a/lib/ViewMetaData/ViewMetaData.js
+++ b/lib/ViewMetaData/ViewMetaData.js
@@ -25,7 +25,7 @@ class ViewMetaData extends React.Component {
 
         return query ? { query } : null;
       },
-      permissionsRequired: ['ui-users.view'],
+      permissionsRequired: ['users.collection.get'],
     },
   });
 

--- a/lib/ViewMetaData/tests/ViewMetaData-test.js
+++ b/lib/ViewMetaData/tests/ViewMetaData-test.js
@@ -17,7 +17,7 @@ describe('ViewMetaData', () => {
   describe('MetaData is displayed given proper permissions', () => {
     setupApplication({
       permissions: {
-        'ui-users.view': true,
+        'users.collection.get': true,
       },
     });
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-480
basically, we should ask back-end permission for the API call, since it's a common component.