### PR TITLE
STSMACOM-481 increment @folio/stripes-cli to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix axe error with `aria-label` on Assign/Unassign modal. Refs STSMACOM-475.
 * Fix singular/plural translation strings. Refs STSMACOM-235.
 * Fix color contrast issues with Notes Accordion Show/Edit note buttons. Refs STSMACOM-416.
+* Increment `@folio/stripes-cli` to `v2`. Refs STSMACOM-481.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+
   "name": "@folio/stripes-smart-components",
   "version": "6.0.0",
   "description": "Connected Stripes components",
@@ -32,7 +32,7 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes-cli": "^1.5.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-components": "^9.0.0",
     "@folio/stripes-connect": "^6.0.0",
     "@folio/stripes-core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-
+{
   "name": "@folio/stripes-smart-components",
   "version": "6.0.0",
   "description": "Connected Stripes components",


### PR DESCRIPTION
Build with `@folio/stripes-cli` `v2`.

Refs [STSMACOM-481](https://issues.folio.org/browse/STSMACOM-481)