### PR TITLE
STSMACOM-482: Upgrade ControlledVocab to final form

### DIFF
--- a/lib/ConfigManager/ConfigFinalForm.js
+++ b/lib/ConfigManager/ConfigFinalForm.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import stripesFinalForm from '@folio/stripes-final-form';
+
+import ConfigForm from './ConfigForm';
+
+export default stripesFinalForm({
+  navigationCheck: true,
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(props => <ConfigForm {...props} />);

--- a/lib/ConfigManager/ConfigForm.js
+++ b/lib/ConfigManager/ConfigForm.js
@@ -6,7 +6,6 @@ import {
   Pane,
   PaneFooter,
 } from '@folio/stripes-components';
-import stripesForm from '@folio/stripes-form';
 
 import styles from './ConfigManager.css';
 
@@ -60,9 +59,4 @@ ConfigForm.propTypes = {
   submitting: PropTypes.bool,
 };
 
-export default stripesForm({
-  form: 'configForm',
-  navigationCheck: true,
-  enableReinitialize: true,
-  destroyOnUnmount: false,
-})(ConfigForm);
+export default ConfigForm;

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Callout } from '@folio/stripes-components';
 
-import ConfigForm from './ConfigForm';
+import ConfigReduxForm from './ConfigReduxForm';
+import ConfigFinalForm from './ConfigFinalForm';
 
 class ConfigManager extends React.Component {
   static manifest = Object.freeze({
@@ -26,6 +27,7 @@ class ConfigManager extends React.Component {
     children: PropTypes.node,
     configFormComponent: PropTypes.func,
     configName: PropTypes.string.isRequired,
+    formType: PropTypes.oneOf(['redux-form', 'final-form']),
     getInitialValues: PropTypes.func,
     label: PropTypes.node.isRequired,
     moduleName: PropTypes.string.isRequired,
@@ -48,7 +50,8 @@ class ConfigManager extends React.Component {
   };
 
   static defaultProps = {
-    calloutMessage: <FormattedMessage id="stripes-smart-components.cm.success" />
+    calloutMessage: <FormattedMessage id="stripes-smart-components.cm.success" />,
+    formType: 'redux-form',
   };
 
   constructor(props) {
@@ -79,8 +82,9 @@ class ConfigManager extends React.Component {
   }
 
   getConfigForm() {
-    const { label, children } = this.props;
+    const { label, children, formType } = this.props;
     const initialValues = this.getInitialValues();
+    const ConfigForm = formType === 'redux-form' ? ConfigReduxForm : ConfigFinalForm;
     const ConfigFormComponent = (this.props.configFormComponent) ?
       this.props.configFormComponent : ConfigForm;
 

--- a/lib/ConfigManager/ConfigReduxForm.js
+++ b/lib/ConfigManager/ConfigReduxForm.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import stripesForm from '@folio/stripes-form';
+
+import ConfigForm from './ConfigForm';
+
+export default stripesForm({
+  form: 'configForm',
+  navigationCheck: true,
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(props => <ConfigForm {...props} />);

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { isEqual, uniqueId, pickBy } from 'lodash';
+import { isEqual, uniqueId, pickBy, noop } from 'lodash';
 
 import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row, Loading } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -460,6 +460,7 @@ class ControlledVocab extends React.Component {
               onUpdate={this.actuators.onUpdate}
               onCreate={this.actuators.onCreate}
               onDelete={this.showConfirmDialog}
+              onSubmit={noop}
               isEmptyMessage={
                 values.isPending
                   ? <Loading />

--- a/lib/EditableList/EditableList.js
+++ b/lib/EditableList/EditableList.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import sortBy from 'lodash/sortBy';
-import EditableListForm from './EditableListForm';
+import EditableListFinalForm from './EditableListFinalForm';
+import EditableListReduxForm from './EditableListReduxForm';
+
 
 const propTypes = {
   /**
@@ -25,6 +27,10 @@ const propTypes = {
    */
   formatter: PropTypes.object,
   /**
+   * Form type implementation
+   */
+  formType: PropTypes.oneOf(['redux-form', 'final-form']),
+  /**
    * id for add button
    */
   id: PropTypes.string,
@@ -40,11 +46,15 @@ const propTypes = {
 
 const defaultProps = {
   nameKey: 'name',
+  formType: 'redux-form',
 };
 
 const EditableList = (props) => {
-  const { contentData, nameKey } = props;
+  const { contentData, nameKey, formType } = props;
   const items = sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
+  const EditableListForm = (formType === 'redux-form')
+    ? EditableListReduxForm
+    : EditableListFinalForm;
   return (<EditableListForm initialValues={{ items }} {...props} />);
 };
 

--- a/lib/EditableList/EditableListFinalForm.js
+++ b/lib/EditableList/EditableListFinalForm.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FieldArray } from 'react-final-form-arrays';
+import { Field } from 'react-final-form';
+
+import stripesFinalForm from '@folio/stripes-final-form';
+
+import EditableListForm from './EditableListForm';
+
+export default stripesFinalForm({
+  navigationCheck: true,
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(props => <EditableListForm
+  {...props}
+  FieldArray={FieldArray}
+  FieldComponent={Field}
+/>);

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -3,8 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import stripesForm from '@folio/stripes-form';
-import { FieldArray } from 'redux-form';
+
 import PropTypes from 'prop-types';
 
 import { Button, Col, Headline, IconButton, MultiColumnList, Row, Layout } from '@folio/stripes-components';
@@ -52,13 +51,30 @@ const propTypes = {
    */
   editable: PropTypes.bool,
   /**
+   * FieldArray implementation coming from final-form or redux-form
+   */
+  FieldArray: PropTypes.object,
+  /**
+   * FieldComponent implementation coming from final-form or redux-form
+   */
+  FieldComponent: PropTypes.object,
+  /**
    *  set custom component for editing
    */
   fieldComponents: PropTypes.object,
   /**
+   * form object provided by final-form and redux-form
+   */
+  form: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+  /**
    * passed to MultiColumnList, formatter allows control over how the data is rendered in the cells of the grid.
    */
   formatter: PropTypes.object,
+
+  handleSubmit: PropTypes.func.isRequired,
   /**
    * id for Add action.
    */
@@ -199,7 +215,7 @@ class EditableListForm extends React.Component {
 
   onCancel(fields, index) {
     const { uniqueField } = this.props;
-    const item = fields.get(index);
+    const item = this.getValue(fields, index);
 
     // if the item has a unique identifier, toggle its edit mode... if not, remove it.
     if (item[uniqueField]) {
@@ -215,11 +231,32 @@ class EditableListForm extends React.Component {
     }
 
     // Reset the field values.
-    this.props.reset();
+    this.reset();
+  }
+
+  getValues(fields = {}) {
+    const { getAll, value } = fields;
+    return getAll ? getAll() : value;
+  }
+
+  getValue(fields = {}, index) {
+    const { get, value } = fields;
+    return get ? get(index) : value[index];
+  }
+
+  reset = () => {
+    const { reset, form } = this.props;
+    (reset || form.reset)();
+  }
+
+  // Set props.initialValues to the currently-saved field values.
+  initializeValues = () => {
+    const { initialize, form } = this.props;
+    (initialize || form.initialize)();
   }
 
   onSave(fields, index) {
-    const item = fields.get(index);
+    const item = this.getValue(fields, index);
     // if item has no id, it's new...
     const callback = (item.id) ?
       this.props.onUpdate :
@@ -227,8 +264,7 @@ class EditableListForm extends React.Component {
     const res = callback(item);
     Promise.resolve(res).then(
       () => {
-        // Set props.initialValues to the currently-saved field values.
-        this.props.initialize(fields.getAll());
+        this.initializeValues(this.getValues());
 
         this.toggleEdit(index);
         this.setState({ creating: false });
@@ -243,7 +279,7 @@ class EditableListForm extends React.Component {
 
   onDelete(fields, index) {
     const { uniqueField } = this.props;
-    const item = fields.get(index);
+    const item = this.getValue(fields, index);
     const res = this.props.onDelete(item[uniqueField]);
     Promise.resolve(res).then(
       () => {
@@ -347,9 +383,18 @@ class EditableListForm extends React.Component {
     columnWidths,
     rowProps,
   }) => {
+    const {
+      FieldComponent,
+      columnMapping,
+      actionSuppression,
+      actionProps,
+      additionalFields,
+      fieldComponents,
+    } = this.props;
     let isEditing;
     let hasError;
-    if (this.state.status.length > 0) {
+
+    if (this.state.status.length > 0 && this.state.status[rowIndex]) {
       isEditing = this.state.status[rowIndex].editing;
       hasError = this.state.status[rowIndex].error;
     } else {
@@ -363,19 +408,20 @@ class EditableListForm extends React.Component {
         error={hasError}
         key={rowIndex}
         field="items"
+        FieldComponent={FieldComponent}
         item={rowData}
         rowIndex={rowIndex}
-        columnMapping={this.props.columnMapping}
-        actionSuppression={this.props.actionSuppression}
-        actionProps={this.props.actionProps}
+        columnMapping={columnMapping}
+        actionSuppression={actionSuppression}
+        actionProps={actionProps}
         visibleFields={this.getVisibleColumns()}
         onCancel={() => this.onCancel(fields, rowIndex)}
         onSave={() => this.onSave(fields, rowIndex)}
         onEdit={() => this.onEdit(rowIndex)}
         onDelete={() => this.onDelete(fields, rowIndex)}
-        additionalFields={this.props.additionalFields}
+        additionalFields={additionalFields}
         readOnlyFields={this.getReadOnlyColumns()}
-        fieldComponents={this.props.fieldComponents}
+        fieldComponents={fieldComponents}
         widths={columnWidths}
         cells={cells}
         {...rowProps}
@@ -400,7 +446,7 @@ class EditableListForm extends React.Component {
       return null;
     }
 
-    if (status[item.rowIndex].editing) {
+    if (status[item.rowIndex]?.editing) {
       return (
         <Layout className="flex">
           <Button
@@ -471,6 +517,7 @@ class EditableListForm extends React.Component {
 
     const isEditing = this.state.status.some(el => el.editing === true);
     const cellFormatters = Object.assign({}, this.props.formatter, { actions: item => this.getActions(fields, item) });
+    const contentData = this.getValues(fields);
 
     return (
       <div>
@@ -502,7 +549,7 @@ class EditableListForm extends React.Component {
               {...this.props}
               visibleColumns={this.getVisibleColumns()}
               rowUpdater={this.rowUpdater}
-              contentData={fields.getAll()}
+              contentData={contentData}
               rowFormatter={this.ItemFormatter}
               rowProps={{ fields }}
               formatter={cellFormatters}
@@ -520,6 +567,8 @@ class EditableListForm extends React.Component {
   }
 
   render() {
+    const { FieldArray } = this.props;
+
     return (
       <form>
         <FieldArray name="items" component={this.RenderItems} toUpdate={this.state.lastAction} />
@@ -531,9 +580,4 @@ class EditableListForm extends React.Component {
 EditableListForm.propTypes = propTypes;
 EditableListForm.defaultProps = defaultProps;
 
-export default stripesForm({
-  form: 'editableListForm',
-  navigationCheck: true,
-  enableReinitialize: true,
-  destroyOnUnmount: false,
-})(EditableListForm);
+export default EditableListForm;

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -53,7 +53,10 @@ const propTypes = {
   /**
    * FieldArray implementation coming from final-form or redux-form
    */
-  FieldArray: PropTypes.object,
+  FieldArray: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+  ]),
   /**
    * FieldComponent implementation coming from final-form or redux-form
    */

--- a/lib/EditableList/EditableListReduxForm.js
+++ b/lib/EditableList/EditableListReduxForm.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FieldArray, Field } from 'redux-form';
+
+import stripesForm from '@folio/stripes-form';
+
+import EditableListForm from './EditableListForm';
+
+export default stripesForm({
+  form: 'editableListForm',
+  navigationCheck: true,
+  enableReinitialize: true,
+  destroyOnUnmount: false,
+})(props => <EditableListForm
+  {...props}
+  FieldArray={FieldArray}
+  FieldComponent={Field}
+/>);

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Field } from 'redux-form';
 import { TextField } from '@folio/stripes-components';
 import css from './EditableList.css';
 
@@ -24,7 +23,8 @@ const ItemEdit = ({
   readOnlyFields,
   widths,
   cells,
-  autoFocus
+  autoFocus,
+  FieldComponent,
 }) => {
   const fields = visibleFields.map((name, fieldIndex) => {
     if (readOnlyFields.indexOf(name) === -1) {
@@ -52,7 +52,7 @@ const ItemEdit = ({
 
       return (
         <div key={fieldKey} style={fieldStyle}>
-          <Field
+          <FieldComponent
             {...fieldProps}
             component={TextField}
             marginBottom0
@@ -99,6 +99,7 @@ ItemEdit.propTypes = {
     PropTypes.bool,
   ]),
   field: PropTypes.string,
+  FieldComponent: PropTypes.object,
   fieldComponents: PropTypes.object,
   readOnlyFields: PropTypes.arrayOf(PropTypes.string),
   rowIndex: PropTypes.number.isRequired,


### PR DESCRIPTION
This PR introduces a new prop called `formType` (which by default is set to `redux-form`) which can be used to switch `ControlledVocab` to use `final-form`.

https://issues.folio.org/browse/STSMACOM-482

There are couple other alternative approaches we could take here:

1. Expose a new component via `stripes-smart-components` called `ControlledVocabFF` or something similar.
2. Do not provide  backwards compatibility and just switch completely to final-form and bump a major version of stripes-smart-components.

I'm not sure which one is the best. The current approach allows us to move gradually. For example update ui-users, check if everything works, etc.
