### PR TITLE
STSMACOM-476: Settings > Users > Custom Fields | Saving a record's focus is confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix singular/plural translation strings. Refs STSMACOM-235.
 * Fix color contrast issues with Notes Accordion Show/Edit note buttons. Refs STSMACOM-416.
 * Increment `@folio/stripes-cli` to `v2`. Refs STSMACOM-481.
+* Fix Edit Custom Field Settings focus issues. Fixes STSMACOM-476, STSMACOM-477.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -1,4 +1,8 @@
-import React, { useMemo } from 'react';
+import React, {
+  useMemo,
+  useRef,
+  useEffect,
+} from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -63,8 +67,15 @@ const ViewCustomFieldsSettings = ({
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
+  const paneTitleRef = useRef(null);
 
   const noDataSaved = isEmpty(customFields) && !sectionTitle.value;
+
+  useEffect(() => {
+    if (paneTitleRef.current) {
+      paneTitleRef.current.focus();
+    }
+  }, []);
 
   const formattedCustomFieldsData = useMemo(() => {
     if (customFieldsLoaded) {
@@ -146,6 +157,7 @@ const ViewCustomFieldsSettings = ({
             paneTitle={<FormattedMessage id="stripes-smart-components.customFields" />}
             lastMenu={renderLastMenu()}
             defaultWidth="fill"
+            paneTitleRef={paneTitleRef}
           >
             {renderSectionTitle()}
             {renderFieldAccordions()}

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -75,7 +75,7 @@ const ViewCustomFieldsSettings = ({
     if (paneTitleRef.current) {
       paneTitleRef.current.focus();
     }
-  }, []);
+  }, [paneTitleRef.current]);
 
   const formattedCustomFieldsData = useMemo(() => {
     if (customFieldsLoaded) {


### PR DESCRIPTION
## Description
Focus Custom Fields pane title after Custom Fields are saved and when View Custom Fields are first opened

## Issues
[STSMACOM-476](https://issues.folio.org/browse/STSMACOM-476)
[STSMACOM-477](https://issues.folio.org/browse/STSMACOM-477)