### PR TITLE
 STSMACOM-484: Upgrade AddressFieldGroup to final form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 * Fix color contrast issues with Notes Accordion Show/Edit note buttons. Refs STSMACOM-416.
 * Increment `@folio/stripes-cli` to `v2`. Refs STSMACOM-481.
 * Fix Edit Custom Field Settings focus issues. Fixes STSMACOM-476, STSMACOM-477.
+* Upgrade `<ControlledVocab>` to final form. Refs STSMACOM-482.
+* Upgrade `<AddressFieldGroup>` to final form. Refs STSMACOM-484.
 
 ## [5.0.0](https://github.com/folio-org/stripes-smart-components/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v4.1.1...v5.0.0)

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import has from 'lodash/has';
 import { FormattedMessage } from 'react-intl';
-import { Field } from 'redux-form';
+import { Field } from 'react-final-form';
 
-import stripesForm from '@folio/stripes-form';
+import stripesFinalForm from '@folio/stripes-final-form';
 import {
   Button,
   Checkbox,
@@ -13,6 +13,31 @@ import {
   Row,
   TextField,
 } from '@folio/stripes-components';
+
+// example validation for a required country field
+//
+// const validate = values => {
+//  const errors = {};
+//  if (values.country == "") {
+//    errors.country = 'Required';
+//  }
+//
+//  return errors;
+// };
+
+const validateAddressType = (addressType, props) => {
+  const addresses = props.addresses || [];
+
+  if (!addressType) {
+    return <FormattedMessage id="stripes-smart-components.error.addressTypeRequired" />;
+  }
+  if (addresses.find(addr => addr.addressType === addressType)) {
+    return <FormattedMessage id="stripes-smart-components.error.addressTypeTaken" />;
+  }
+
+  return undefined;
+};
+
 
 const propTypes = {
   addresses: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/no-unused-prop-types
@@ -36,7 +61,10 @@ const defaultProps = {
     city: TextField,
     stateRegion: TextField,
     zipCode: TextField,
-    addressType: TextField,
+    addressType: {
+      component: TextField,
+      validate: validateAddressType,
+    },
   },
   headerComponent: address => (
     <Field
@@ -67,32 +95,6 @@ const defaultProps = {
   ],
 };
 
-// example validation for a required country field
-//
-// const validate = values => {
-//  const errors = {};
-//  if (values.country == "") {
-//    errors.country = 'Required';
-//  }
-//
-//  return errors;
-// };
-
-const validate = (values, props) => {
-  const errors = {};
-  const addressType = values.addressType;
-  const addresses = props.addresses || [];
-
-  if (!addressType) {
-    errors.addressType = <FormattedMessage id="stripes-smart-components.error.addressTypeRequired" />;
-  }
-  if (addresses.find(addr => addr.addressType === addressType)) {
-    errors.addressType = <FormattedMessage id="stripes-smart-components.error.addressTypeTaken" />;
-  }
-
-  return errors;
-};
-
 const AddressEdit = (props) => {
   const {
     addressObject,
@@ -116,6 +118,7 @@ const AddressEdit = (props) => {
     const componentData = mergedFieldComponents[field];
     let component = componentData;
     let compProps = {};
+    let validate;
 
     if (componentData.component) {
       component = componentData.component;
@@ -125,13 +128,17 @@ const AddressEdit = (props) => {
       compProps = componentData.props;
     }
 
+    if (componentData.validate) {
+      validate = value => componentData.validate(value, props);
+    }
+
     const fieldComponent = (
       <Col
         key={`col-${i}`}
         xs={4}
         {...{ [`data-test-${field}`]: true }}
       >
-        <Field label={fieldLabel} name={field} {...compProps} component={component} />
+        <Field label={fieldLabel} name={field} {...compProps} component={component} validate={validate} />
       </Col>);
     rowArray.push(fieldComponent);
 
@@ -174,9 +181,7 @@ const AddressEdit = (props) => {
 AddressEdit.propTypes = propTypes;
 AddressEdit.defaultProps = defaultProps;
 
-export default stripesForm({
-  form: 'addressForm',
-  validate,
+export default stripesFinalForm({
   navigationCheck: true,
   enableReinitialize: true,
 })(AddressEdit);

--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -3,13 +3,20 @@
 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FieldArray } from 'redux-form';
-import { Button, Col, Layout, Row } from '@folio/stripes-components';
+import { FieldArray as FinalFormFieldArray } from 'react-final-form-arrays';
+import { FieldArray as ReduxFormFieldArray } from 'redux-form';
+import { FormSpy } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
-import EmbeddedAddressForm from './EmbeddedAddressForm';
+
+import { Button, Col, Layout, Row } from '@folio/stripes-components';
+
+import EmbeddedAddressFinalForm from './EmbeddedAddressFinalForm';
+import EmbeddedAddressReduxForm from './EmbeddedAddressReduxForm';
+
 import css from './AddressEdit.css';
 
 const propTypes = {
+  formType: PropTypes.oneOf(['redux-form', 'final-form']),
   label: PropTypes.node,
   name: PropTypes.string,
   onAdd: PropTypes.func,
@@ -18,6 +25,7 @@ const propTypes = {
 
 const defaultProps = {
   label: <FormattedMessage id="stripes-smart-components.addresses" />,
+  formType: 'redux-form',
 };
 
 class AddressEditList extends React.Component {
@@ -43,9 +51,46 @@ class AddressEditList extends React.Component {
     }
   }
 
-  renderFieldGroups({ fields }) {
+  renderFinalFormItems = (fields) => {
     return (
+      <FormSpy>
+        {
+          ({ values, form: { change } }) => (
+            fields.map((fieldName, i) => (
+              <li className={css.addressFormListItem} key={i}>
+                <EmbeddedAddressFinalForm
+                  fieldKey={i}
+                  values={values}
+                  change={change}
+                  addressFieldName={fieldName}
+                  handleDelete={(index) => { this.onDelete(fields, index); }}
+                  {...this.props}
+                />
+              </li>
+            ))
+          )
+        }
+      </FormSpy>
+    );
+  }
 
+  renderReduxFormItems = (fields) => {
+    return fields.map((fieldName, i) => (
+      <li className={css.addressFormListItem} key={i}>
+        <EmbeddedAddressReduxForm
+          fieldKey={i}
+          addressFieldName={fieldName}
+          handleDelete={(index) => { this.onDelete(fields, index); }}
+          {...this.props}
+        />
+      </li>
+    ));
+  }
+
+  renderFieldGroups({ fields }) {
+    const { formType } = this.props;
+
+    return (
       <div className={css.addressEditList}>
         <Row>
           <Col xs>
@@ -58,16 +103,10 @@ class AddressEditList extends React.Component {
               <div><em><FormattedMessage id="stripes-smart-components.address.noAddressesStored" /></em></div>
             }
             <ul className={css.addressFormList} aria-labelledby="addressGroupLabel">
-              {fields.map((fieldName, i) => (
-                <li className={css.addressFormListItem} key={i}>
-                  <EmbeddedAddressForm
-                    fieldKey={i}
-                    addressFieldName={fieldName}
-                    handleDelete={(index) => { this.onDelete(fields, index); }}
-                    {...this.props}
-                  />
-                </li>
-              ))}
+              { formType === 'redux-form' ?
+                this.renderReduxFormItems(fields) :
+                this.renderFinalFormItems(fields)
+              }
             </ul>
           </Col>
         </Row>
@@ -87,11 +126,15 @@ class AddressEditList extends React.Component {
           </Col>
         </Row>
       </div>
-
     );
   }
 
   render() {
+    const { formType } = this.props;
+    const FieldArray = (formType === 'redux-form') ?
+      ReduxFormFieldArray :
+      FinalFormFieldArray;
+
     return (
       <FieldArray name={this.props.name} component={this.renderFieldGroups} />
     );

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressFinalForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressFinalForm.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Field } from 'react-final-form';
+
+import EmbeddedAddressForm from './EmbeddedAddressForm';
+
+const EmbeddedAddressFinalForm = (props) => <EmbeddedAddressForm {...props} Field={Field} />;
+
+export default EmbeddedAddressFinalForm;
+

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
 import findIndex from 'lodash/findIndex';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -19,7 +18,6 @@ import {
 } from '@folio/stripes-components';
 
 import { countriesOptions } from '../data/countries';
-import withReduxFormContext from './withReduxFormContext';
 import css from './AddressEdit.css';
 
 const omitUsedOptions = (list, usedValues, key, id) => {
@@ -41,8 +39,10 @@ class EmbeddedAddressForm extends React.Component {
     addressLabel: PropTypes.node,
     // addressObject: PropTypes.object,
     canDelete: PropTypes.bool,
+    change: PropTypes.func,
     displayKey: PropTypes.bool,
     displayPrimary: PropTypes.bool,
+    Field: PropTypes.node,
     fieldComponents: PropTypes.object,
     fieldKey: PropTypes.number,
     handleDelete: PropTypes.func,
@@ -52,7 +52,7 @@ class EmbeddedAddressForm extends React.Component {
     // headerComponent: PropTypes.func,
     labelMap: PropTypes.object,
     primary: PropTypes.func,
-    reduxForm: PropTypes.object,
+    values: PropTypes.object,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
   };
 
@@ -96,14 +96,15 @@ class EmbeddedAddressForm extends React.Component {
   }
 
   singlePrimary(id) {
-    const { values, dispatch, change } = this.props.reduxForm;
+    const { change, values } = this.props;
+
     values.personal.addresses.forEach((a, i) => {
       if (i === id) {
-        dispatch(change(`personal.addresses[${i}].primaryAddress`, true));
-        dispatch(change(`personal.addresses[${i}].primary`, true));
+        change(`personal.addresses[${i}].primaryAddress`, true);
+        change(`personal.addresses[${i}].primary`, true);
       } else {
-        dispatch(change(`personal.addresses[${i}].primaryAddress`, false));
-        dispatch(change(`personal.addresses[${i}].primary`, false));
+        change(`personal.addresses[${i}].primaryAddress`, false);
+        change(`personal.addresses[${i}].primary`, false);
       }
     });
   }
@@ -119,7 +120,8 @@ class EmbeddedAddressForm extends React.Component {
       visibleFields,
       displayKey,
       displayPrimary,
-      reduxForm: { values },
+      values,
+      Field,
     } = this.props;
 
     const PrimaryRadio = ({ input, ...props }) => (
@@ -232,4 +234,4 @@ class EmbeddedAddressForm extends React.Component {
   }
 }
 
-export default withReduxFormContext(injectIntl(EmbeddedAddressForm));
+export default injectIntl(EmbeddedAddressForm);

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressReduxForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressReduxForm.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Field } from 'redux-form';
+
+import EmbeddedAddressForm from './EmbeddedAddressForm';
+
+import withReduxFormContext from './withReduxFormContext';
+
+const EmbeddedAddressReduxForm = (props) => <EmbeddedAddressForm {...props} Field={Field} />;
+
+export default withReduxFormContext(EmbeddedAddressReduxForm);

--- a/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
+++ b/lib/AddressFieldGroup/AddressEdit/withReduxFormContext.js
@@ -3,7 +3,13 @@ import { ReduxFormContext } from 'redux-form';
 
 const withReduxFormContext = WrappedComponent => props => (
   <ReduxFormContext.Consumer>
-    {reduxForm => (<WrappedComponent {...props} reduxForm={reduxForm} />)}
+    {({ values, dispatch, change }) => (
+      <WrappedComponent
+        {...props}
+        values={values}
+        change={(name, value) => dispatch(change(name, value))}
+      />
+    )}
   </ReduxFormContext.Consumer>
 );
 


### PR DESCRIPTION
This approach is very similar to the one in: https://github.com/folio-org/stripes-smart-components/pull/1003

`formType` prop (with `refux-form` or `final-form` options) can be used to choose the form implementation. 

https://issues.folio.org/browse/STSMACOM-484