### PR TITLE
STSMACOM-490 export missing ConfigManager components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 6.0.1 (IN PROGRESS)
+
+* Export `ConfigReduxForm`, `ConfigFinalForm`. Refs STSMACOM-490.
+
 ## [6.0.0](https://github.com/folio-org/stripes-smart-components/tree/v6.0.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v5.0.0...v6.0.0)
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ export { default as ClipCopy } from './lib/ClipCopy';
 
 export { default as ConfigManager } from './lib/ConfigManager';
 export { default as ConfigForm } from './lib/ConfigManager/ConfigForm';
+export { default as ConfigReduxForm } from './lib/ConfigManager/ConfigReduxForm';
+export { default as ConfigFinalForm } from './lib/ConfigManager/ConfigFinalForm';
 
 export { default as ControlledVocab } from './lib/ControlledVocab';
 

--- a/lib/ConfigManager/index.js
+++ b/lib/ConfigManager/index.js
@@ -1,2 +1,4 @@
 export { default } from './ConfigManager';
 export { default as ConfigForm } from './ConfigForm';
+export { default as ConfigReduxForm } from './ConfigReduxForm';
+export { default as ConfigFinalForm } from './ConfigFinalForm';


### PR DESCRIPTION
`ConfigForm` was replaced with `ConfigReduxForm` (and a parallel
component `ConfigFinalForm`) but (a) neither was exported and (b)
`ConfigForm` continued to be exported but now is an entirely different
component.

Rather than try to restore things as they were since use of `ConfigForm`
appears to be confined to a couple of pages in ui-developer, this PR
simply exports `ConfigReduxForm` and `ConfigFinalForm`, restoring the
old behavior but under a new name. That's good enough, and small enough,
and gosh darn it, people should like it.

Refs [STSMACOM-490](https://issues.folio.org/browse/STSMACOM-490), [UID-72](https://issues.folio.org/browse/UID-72)