### PR TITLE
STSMACOM-479: Adding a new custom field focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)
 
 * Export `ConfigReduxForm`, `ConfigFinalForm`. Refs STSMACOM-490.
+* Adding a new custom field focus. Refs STSMACOM-479.
 
 ## [6.0.0](https://github.com/folio-org/stripes-smart-components/tree/v6.0.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v5.0.0...v6.0.0)

--- a/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
+++ b/lib/CustomFields/components/CustomFieldsForm/CustomFieldsForm.js
@@ -140,6 +140,7 @@ const CustomFieldsForm = ({
     [cf.id]: false,
   }), {});
   const [accordions, setAccordions] = useState(getInitialAccordionsState);
+  const [lastAddedAccordionId, setLastAddedAccordionId] = useState('');
 
   const firstMenu = (
     <PaneMenu>
@@ -322,6 +323,7 @@ const CustomFieldsForm = ({
                       onDragEnd={onDragEnd}
                     >
                       <CustomFieldsAccordions
+                        lastAddedAccordionId={lastAddedAccordionId}
                         fields={fields}
                         permissions={permissions}
                         accordions={accordions}
@@ -351,6 +353,7 @@ const CustomFieldsForm = ({
                         ...currentAccordions,
                         [id]: true,
                       }));
+                      setLastAddedAccordionId(id);
                     }}
                     data-test-custom-fields-add-button
                   />

--- a/lib/CustomFields/components/CustomFieldsForm/components/CustomFieldsAccordions/CustomFieldsAccordions.js
+++ b/lib/CustomFields/components/CustomFieldsForm/components/CustomFieldsAccordions/CustomFieldsAccordions.js
@@ -32,6 +32,7 @@ const propTypes = {
       ]).isRequired,
     })).isRequired,
   }).isRequired,
+  lastAddedAccordionId: PropTypes.string.isRequired,
   onDeleteClick: PropTypes.func.isRequired,
   onOptionDelete: PropTypes.func.isRequired,
   onToggleAccordion: PropTypes.func.isRequired,
@@ -49,6 +50,7 @@ const CustomFieldsAccordions = ({
   optionsStatsLoaded,
   fieldOptionsStats,
   onOptionDelete,
+  lastAddedAccordionId,
 }) => {
   const renderAccordions = () => {
     return fields.map((name, index) => {
@@ -69,6 +71,7 @@ const CustomFieldsAccordions = ({
         permissions,
         index,
         isDragDisabled,
+        lastAddedAccordionId,
       };
 
       if (fieldTypesWithOptions.includes(fields.value[index].values.type)) {

--- a/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
+++ b/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
@@ -280,6 +280,10 @@ describe('CustomFieldsForm', () => {
       it('should show correct field type in accordion label', () => {
         expect(customFieldsForm.customFieldAccordions(1).label).to.include('Checkbox');
       });
+
+      // it('should set focus on last added accordion', () => {
+      //   expect(customFieldsForm.customFieldAccordions(1).accordions.isFocused).to.be.true;
+      // });
     });
   });
 

--- a/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
+++ b/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
@@ -281,9 +281,9 @@ describe('CustomFieldsForm', () => {
         expect(customFieldsForm.customFieldAccordions(1).label).to.include('Checkbox');
       });
 
-      // it('should set focus on last added accordion', () => {
-      //   expect(customFieldsForm.customFieldAccordions(1).accordions.isFocused).to.be.true;
-      // });
+      it('should set focus on last added accordion', () => {
+        expect(customFieldsForm.customFieldAccordions(1).accordions.isFocused).to.be.true;
+      });
     });
   });
 

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -50,6 +50,7 @@ const propTypes = {
   id: PropTypes.string.isRequired,
   isDragDisabled: PropTypes.bool,
   isEditMode: PropTypes.bool,
+  lastAddedAccordionId: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   onOptionDelete: PropTypes.func,
   optionsStatsLoaded: PropTypes.bool,
@@ -79,6 +80,7 @@ const FieldAccordion = (props) => {
     usedOptions,
     optionsStatsLoaded,
     onOptionDelete,
+    lastAddedAccordionId,
   } = props;
   const accordionLabel = (
     <>
@@ -160,6 +162,7 @@ const FieldAccordion = (props) => {
       label={accordionLabel}
       displayWhenOpen={isEditMode && renderHeaderButtons()}
       displayWhenClosed={isEditMode && renderHeaderButtons()}
+      autoFocus={isEditMode && (lastAddedAccordionId === id)}
       separator={separator}
       closedByDefault={!isEditMode}
     >


### PR DESCRIPTION
## Purpose:
Adding a new custom field focus (Settings > Users > Custom Fields)
Related task: [STSMACOM-479](https://issues.folio.org/browse/STSMACOM-479)

## Screenshot:
![Screenshot 2021-03-19 at 17 03 21](https://user-images.githubusercontent.com/60929399/111800893-13691f00-88d5-11eb-9c64-e0e2256438fe.png)
![Screenshot 2021-03-22 at 15 09 07](https://user-images.githubusercontent.com/60929399/111995545-b910ce00-8b21-11eb-924e-4ad50aa16428.png)

