### PR TITLE
STSMACOM-478: Make the move custom field icon a button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## [6.0.2](IN PROGRESS)
+
+* Make the move custom field icon a button. Refs STSMACOM-478.
+
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)
 

--- a/lib/CustomFields/components/CustomFieldsForm/tests/interactor.js
+++ b/lib/CustomFields/components/CustomFieldsForm/tests/interactor.js
@@ -49,33 +49,15 @@ export default interactor(class CustomFieldsFormInteractor {
   moveAccordionDown() {
     return this.draggableAccordion.focus()
       .draggableAccordion.pressSpace()
-      .whenFieldLifted()
       .draggableAccordion.pressArrowDown()
-      .whenFieldMoved()
-      .draggableAccordion.pressSpace()
-      .whenFieldDropped();
+      .draggableAccordion.pressSpace();
   }
 
   moveAccordionUp() {
     return this.draggableAccordion.focus()
       .draggableAccordion.pressSpace()
-      .whenFieldLifted()
       .draggableAccordion.pressArrowUp()
-      .whenFieldMoved()
-      .draggableAccordion.pressSpace()
-      .whenFieldDropped();
-  }
-
-  whenFieldLifted() {
-    return this.when(() => !!this.log.match(/You have lifted field/i));
-  }
-
-  whenFieldMoved() {
-    return this.when(() => !!this.log.match(/You have moved field [a-zA-Z0-9\s]+ to position \d+/i));
-  }
-
-  whenFieldDropped() {
-    return this.when(() => !!this.log.match(/You have moved field [a-zA-Z0-9\s]+ from position \d+ to position \d+/i));
+      .draggableAccordion.pressSpace();
   }
 
   whenLoaded() {

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
-  Icon,
   IconButton,
   Tooltip,
 } from '@folio/stripes-components';
@@ -114,18 +113,13 @@ const FieldAccordion = (props) => {
                   text={message}
                 >
                   {({ ref, ariaIds }) => (
-                    <span
-                      role="button"
+                    <IconButton
+                      icon="drag-drop"
+                      aria-labelledby={ariaIds.text}
+                      aria-describedby={ariaIds.sub}
+                      ref={ref}
                       {...dragHandleProps}
-                      data-test-custom-field-drag-drop-button
-                    >
-                      <Icon
-                        icon="drag-drop"
-                        aria-labelledby={ariaIds.text}
-                        aria-describedby={ariaIds.sub}
-                        ref={ref}
-                      />
-                    </span>
+                    />
                   )}
                 </Tooltip>
               )}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.1.0",
     "query-string": "^5.0.0",
-    "react-beautiful-dnd": "^11.0.5",
+    "react-beautiful-dnd": "^13.1.0",
     "react-copy-to-clipboard": "^5.0.1",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.1",


### PR DESCRIPTION
## Description
- Make Custom Fields drag and drop icon a button to improve accessibility
- Bump version of `react-beautiful-dnd` to `13.1.0`. This is needed because new version includes some bugfixes and accessibility improvements that we need.
There were no breaking changes that could affect our existing implementation so we can safely do the update. Here's the changelog of the library https://github.com/atlassian/react-beautiful-dnd/releases

## Issues
[STSMACOM-478](https://issues.folio.org/browse/STSMACOM-478)