### PR TITLE
STSMACOM-497 remove typo across locale files

### DIFF
--- a/translations/stripes-smart-components/ar.json
+++ b/translations/stripes-smart-components/ar.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "فشل تغيير تاريخ الاستحقاق: تقادمت المادة وتم اعتبارها ضائعة",
     "success.message": "تم <strong>{action}</strong> ال{entry} <strong>{name}1</strong> بنجاح.",
     "address.primary": "رئيسي",
-    "address.alternate ": "بديل",
+    "address.alternate": "بديل",
     "ll.remoteLabel": "البعيد",
     "columnManager.showColumns": "عرض الأعمدة"
 }

--- a/translations/stripes-smart-components/ber.json
+++ b/translations/stripes-smart-components/ber.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/ca.json
+++ b/translations/stripes-smart-components/ca.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/da.json
+++ b/translations/stripes-smart-components/da.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/de.json
+++ b/translations/stripes-smart-components/de.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Fälligkeitsdatumsänderung fehlgeschlagen: Exemplar wurde für verloren erklärt",
     "success.message": "Der {entry} <strong>{name}</strong> wurde erfolgreich <strong>{action}</strong>.",
     "address.primary": "Primär",
-    "address.alternate ": "Alternativ",
+    "address.alternate": "Alternativ",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Spalten anzeigen"
 }

--- a/translations/stripes-smart-components/en_GB.json
+++ b/translations/stripes-smart-components/en_GB.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/en_SE.json
+++ b/translations/stripes-smart-components/en_SE.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/en_US.json
+++ b/translations/stripes-smart-components/en_US.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/es.json
+++ b/translations/stripes-smart-components/es.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "El cambio de fecha de vencimiento falló: el artículo está señalado como perdido por el tiempo",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/es_419.json
+++ b/translations/stripes-smart-components/es_419.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "El cambio de fecha de vencimiento falló: el artículo está señalado como perdido por el tiempo",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remoto",
     "columnManager.showColumns": "Mostrar columnas"
 }

--- a/translations/stripes-smart-components/es_ES.json
+++ b/translations/stripes-smart-components/es_ES.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "El cambio de fecha de vencimiento falló: el artículo está señalado como perdido por el tiempo",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/fr.json
+++ b/translations/stripes-smart-components/fr.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/fr_FR.json
+++ b/translations/stripes-smart-components/fr_FR.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "L ' {entry} <strong> {name} </strong> a été <strong> {action} </strong> avec succès.",
     "address.primary": "Principal",
-    "address.alternate ": "Autre",
+    "address.alternate": "Autre",
     "ll.remoteLabel": "À distance",
     "columnManager.showColumns": "Afficher les colonnes"
 }

--- a/translations/stripes-smart-components/he.json
+++ b/translations/stripes-smart-components/he.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/hi_IN.json
+++ b/translations/stripes-smart-components/hi_IN.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/hu.json
+++ b/translations/stripes-smart-components/hu.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/it_IT.json
+++ b/translations/stripes-smart-components/it_IT.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Impossibile modificare la data di scadenza: l'item è stato dichiarato perso dall'utente",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primario",
-    "address.alternate ": "Alternativo",
+    "address.alternate": "Alternativo",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/ja.json
+++ b/translations/stripes-smart-components/ja.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/ko.json
+++ b/translations/stripes-smart-components/ko.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/nb.json
+++ b/translations/stripes-smart-components/nb.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/nn.json
+++ b/translations/stripes-smart-components/nn.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/pl.json
+++ b/translations/stripes-smart-components/pl.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Zmiana terminu zwrotu nie powiodła się: egzemplarz jest uznany za zagubiony",
     "success.message": "Ten {entry} <strong>{name}</strong> został pomyślnie <strong>{action}</strong>.",
     "address.primary": "Główny",
-    "address.alternate ": "Alternatywny",
+    "address.alternate": "Alternatywny",
     "ll.remoteLabel": "Zdalny",
     "columnManager.showColumns": "Pokaż kolumny"
 }

--- a/translations/stripes-smart-components/pt_BR.json
+++ b/translations/stripes-smart-components/pt_BR.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Falha na alteração da data de vencimento: o item está envelhecido para perdido",
     "success.message": "A {entry} <strong>{name}</strong> foi <strong>{action}</strong> com sucesso.",
     "address.primary": "Primário",
-    "address.alternate ": "Alternar",
+    "address.alternate": "Alternar",
     "ll.remoteLabel": "Remoto",
     "columnManager.showColumns": "Mostrar colunas"
 }

--- a/translations/stripes-smart-components/pt_PT.json
+++ b/translations/stripes-smart-components/pt_PT.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/ru.json
+++ b/translations/stripes-smart-components/ru.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/sv.json
+++ b/translations/stripes-smart-components/sv.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/ur.json
+++ b/translations/stripes-smart-components/ur.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }

--- a/translations/stripes-smart-components/zh_CN.json
+++ b/translations/stripes-smart-components/zh_CN.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "到期日更改失败：单件已超期太久视为遗失",
     "success.message": "{entry} <strong> {name} </strong>已成功<strong> {action} </strong> 。",
     "address.primary": "主要",
-    "address.alternate ": "备用",
+    "address.alternate": "备用",
     "ll.remoteLabel": "远程",
     "columnManager.showColumns": "显示列"
 }

--- a/translations/stripes-smart-components/zh_TW.json
+++ b/translations/stripes-smart-components/zh_TW.json
@@ -258,7 +258,7 @@
     "cddd.itemAgedToLost": "Due date change failed: item is Aged to lost",
     "success.message": "The {entry} <strong>{name}</strong> was successfully <strong>{action}</strong>.",
     "address.primary": "Primary",
-    "address.alternate ": "Alternate",
+    "address.alternate": "Alternate",
     "ll.remoteLabel": "Remote",
     "columnManager.showColumns": "Show columns"
 }


### PR DESCRIPTION
Ordinarily we would wait for this typo to be fixed in the next push from
Lokalise but given we need it to be included in the upcoming patch
release I'm just gonna make the change directly here. (All we're doing
is removing whitespace from from a key.)

Refs [STSMACOM-497](https://issues.folio.org/browse/STSMACOM-497)