### PR TITLE
STSMACOM-501 avoid @rehooks/local-storage 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Organizations alternate address label in org view not showing correctly. Refs STSMACOM-497.
 * Execute validation manually when record is being saved. Fixes STSMACOM-496.
 * Fix `<MultiSelect>` when using `<CustomField>` via final form. Fixes STSMACOM-500.
+* buggy @rehooks/local-storage 2.4.1 must be avoided. Refs STSMACOM-501.
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^3.0.0",
-    "@rehooks/local-storage": "^2.3.0",
+    "@rehooks/local-storage": "2.4.0",
     "classnames": "^2.2.6",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.2",


### PR DESCRIPTION
Lock onto `2.4.0` to avoid https://github.com/rehooks/local-storage/issues/77

Refs [STSMACOM-501](https://issues.folio.org/browse/STSMACOM-501)