### PR TITLE
STSMACOM-502 hooks approach for ColumnManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix `<MultiSelect>` when using `<CustomField>` via final form. Fixes STSMACOM-500.
 * buggy @rehooks/local-storage 2.4.1 must be avoided. Refs STSMACOM-501.
 * Fix View Notes Record: Numbered / Nested lists not retained after editing/saving. Fixes STSMACOM-498.
+* hooks approach for ColumnManager. Refs STSMACOM-502.
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/index.js
+++ b/index.js
@@ -72,5 +72,5 @@ export { default as EditCustomFieldsSettings } from './lib/CustomFields/pages/Ed
 export { default as EditCustomFieldsRecord } from './lib/CustomFields/pages/EditCustomFieldsRecord';
 export { default as ViewCustomFieldsRecord } from './lib/CustomFields/pages/ViewCustomFieldsRecord';
 
-export { default as ColumnManager } from './lib/ColumnManager';
+export * from './lib/ColumnManager';
 export * from './lib/utils';

--- a/lib/ColumnManager/ColumnManager.js
+++ b/lib/ColumnManager/ColumnManager.js
@@ -30,9 +30,15 @@ const ColumnManager = ({ id, columnMapping, children, excludeKeys }) => {
     />
   ), [prefixId, columnMapping, visibleColumns, nonToggleableColumns, toggleColumn]);
 
+  /**
+   * @deprecated Will be deleted in version 7.0. Use renderColumnsMenu.
+   */
+  const renderCheckboxes = renderColumnsMenu;
+
   const renderProps = {
     visibleColumns,
     renderColumnsMenu,
+    renderCheckboxes,
     toggleColumn
   };
 

--- a/lib/ColumnManager/ColumnManager.js
+++ b/lib/ColumnManager/ColumnManager.js
@@ -2,71 +2,17 @@
  * ColumnManager
  */
 
-import React, { useState, useCallback, useMemo, useRef, memo } from 'react';
+import React, { useMemo, useRef, memo } from 'react';
 import PropTypes from 'prop-types';
-import { useIntl } from 'react-intl';
-import { Checkbox, MenuSection } from '@folio/stripes-components';
 
-const STORAGE = sessionStorage;
+import useColumnManager from './useColumnManager';
+import ColumnManagerMenu from './ColumnManagerMenu';
 
 const ColumnManager = ({ id, columnMapping, children, excludeKeys }) => {
-  const intl = useIntl();
-  const nonToggleableColumns = useRef(excludeKeys).current;
   const prefixId = `column-manager-${id}`;
-  const storageKey = `${prefixId}-storage`;
 
-  // The column mapping object determines the default visible columns and order
-  const defaultColumnKeys = Object.keys(columnMapping);
-
-  const initialVisibleColumns = useMemo(() => {
-    const stored = STORAGE.getItem(storageKey);
-    return stored ? JSON.parse(stored) : defaultColumnKeys;
-  }, [storageKey, defaultColumnKeys]);
-
-  const [visibleColumns, setVisibleColumns] = useState(initialVisibleColumns);
-
-  const orderedVisibleColumns = useMemo(() => {
-    const visible = new Set(visibleColumns);
-    return defaultColumnKeys.filter(key => visible.has(key));
-  }, [defaultColumnKeys, visibleColumns]);
-
-  /**
-   * Toggle column visibility
-   */
-  const toggleColumn = useCallback(key => {
-    setVisibleColumns(currVisibleColumns => {
-      const nextVisibleColumns = currVisibleColumns.includes(key) ?
-        currVisibleColumns.filter(k => key !== k) :
-        [...currVisibleColumns, key];
-
-      STORAGE.setItem(storageKey, JSON.stringify(nextVisibleColumns));
-
-      return nextVisibleColumns;
-    });
-  }, [storageKey]);
-
-  /**
-   * Render column checkboxes for toggling columns
-   */
-
-  const renderCheckboxes = useMemo(() => {
-    const nonToggleableSet = new Set(nonToggleableColumns);
-
-    return defaultColumnKeys
-      .filter(key => !nonToggleableSet.has(key))
-      .map(key => (
-        <Checkbox
-          data-test-column-manager-checkbox={key}
-          key={key}
-          name={key}
-          label={columnMapping[key]}
-          id={`${prefixId}-column-checkbox-${key}`}
-          checked={visibleColumns.includes(key)}
-          value={key}
-          onChange={() => toggleColumn(key)}
-        />
-      ));
-  }, [nonToggleableColumns, visibleColumns, toggleColumn, prefixId, defaultColumnKeys, columnMapping]);
+  const nonToggleableColumns = useRef(excludeKeys).current;
+  const { visibleColumns, toggleColumn } = useColumnManager(prefixId, columnMapping);
 
   /**
    * Render columns menu section
@@ -75,19 +21,18 @@ const ColumnManager = ({ id, columnMapping, children, excludeKeys }) => {
    * an easy way for developers to render a column menu section inside e.g. a dropdown
    */
   const renderColumnsMenu = useMemo(() => (
-    <MenuSection
-      data-test-column-manager-menu
-      label={intl.formatMessage({ id: 'stripes-smart-components.columnManager.showColumns' })}
-      id={`${prefixId}-columns-menu-section`}
-    >
-      {renderCheckboxes}
-    </MenuSection>
-  ), [renderCheckboxes, intl, prefixId]);
+    <ColumnManagerMenu
+      prefix={prefixId}
+      columnMapping={columnMapping}
+      visibleColumns={visibleColumns}
+      excludeColumns={nonToggleableColumns}
+      toggleColumn={toggleColumn}
+    />
+  ), [prefixId, columnMapping, visibleColumns, nonToggleableColumns, toggleColumn]);
 
   const renderProps = {
-    visibleColumns: orderedVisibleColumns,
+    visibleColumns,
     renderColumnsMenu,
-    renderCheckboxes,
     toggleColumn
   };
 

--- a/lib/ColumnManager/ColumnManagerMenu.js
+++ b/lib/ColumnManager/ColumnManagerMenu.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+
+import { Checkbox, MenuSection } from '@folio/stripes-components';
+
+const ColumnManagerMenu = ({
+  prefix,
+  columnMapping,
+  visibleColumns,
+  excludeColumns,
+  toggleColumn,
+}) => {
+  const intl = useIntl();
+
+  const renderMenuItems = () => {
+    const nonToggleableSet = new Set(excludeColumns);
+
+    return Object.keys(columnMapping)
+      .filter(key => !nonToggleableSet.has(key))
+      .map(key => (
+        <Checkbox
+          data-test-column-manager-checkbox={key}
+          key={key}
+          name={key}
+          label={columnMapping[key]}
+          id={`${prefix}-column-checkbox-${key}`}
+          checked={visibleColumns.includes(key)}
+          value={key}
+          onChange={() => toggleColumn(key)}
+        />
+      ));
+  };
+
+  return (
+    <MenuSection
+      data-test-column-manager-menu
+      label={intl.formatMessage({ id: 'stripes-smart-components.columnManager.showColumns' })}
+      id={`${prefix}-columns-menu-section`}
+    >
+      {renderMenuItems()}
+    </MenuSection>
+  );
+};
+
+ColumnManagerMenu.propTypes = {
+  columnMapping: PropTypes.object.isRequired,
+  excludeColumns: PropTypes.arrayOf(PropTypes.string),
+  prefix: PropTypes.string.isRequired,
+  toggleColumn: PropTypes.func.isRequired,
+  visibleColumns: PropTypes.arrayOf(PropTypes.string),
+};
+
+ColumnManagerMenu.defaultProps = {
+  visibleColumns: [],
+  excludeColumns: [],
+};
+
+export default ColumnManagerMenu;

--- a/lib/ColumnManager/index.js
+++ b/lib/ColumnManager/index.js
@@ -1,1 +1,3 @@
-export { default } from './ColumnManager';
+export { default as ColumnManager } from './ColumnManager';
+export { default as ColumnManagerMenu } from './ColumnManagerMenu';
+export { default as useColumnManager } from './useColumnManager';

--- a/lib/ColumnManager/readme.md
+++ b/lib/ColumnManager/readme.md
@@ -79,13 +79,56 @@ In the example below, we wrap the `<ColumnManager>` around the results pane and 
     </ColumnManager>
 ```
 
+## Hooks Usage
+A typical use-case for the `<ColumnManager>` is the implementation of toggleable columns in a results view.
+
+In the example below, we use `useColumnManager` hook to manage columns visiblity and `ColumnManagerMenu` component to display controls instead of wrapping components by `ColumnManager`.
+
+```js
+    import { ColumnManagerMenu, useColumnManager } from '@folio/stripes/smart-components';
+    import { Pane, MultiColumnList } from '@folio/stripes/components';
+
+    const columnMapping = {
+        status: 'Status',
+        name: 'Name',
+        barcode: 'Barcode',
+        username: 'Username',
+        email: 'Email'
+    }
+
+    const { visibleColumns, toggleColumn } = useColumnManager('users-column-manager', columnMapping);
+
+    const actionMenu = () => (
+        <>
+            {/* Other menu sections */}
+            <ColumnManagerMenu
+                prefix="users"
+                columnMapping={columnMapping}
+                visibleColumns={visibleColumns}
+                toggleColumn={toggleColumn}
+            />
+        </>
+    );
+
+    <Pane
+        id="users-search-results-pane"
+        firstMenu={actionMenu}
+        ...
+    >
+        <MultiColumnList
+            id="list-users"
+            visibleColumns={visibleColumns}
+            ...
+        />
+    </Pane>
+```
+
 ## Render Props
 A set of useful props is passed down to the render-prop function
 
 Prop | Description
 --- | ---
 visibleColumns | An array of visible column keys that can be passed directly down to the `<MultiColumnList>`
-renderCheckboxes | Renders an array of checkboxes for toggling columns.
 renderColumnsMenu | Renders a `<MenuSection>` that wraps `renderCheckboxes` for toggling columns. This makes it easy to implement inside e.g. a pane action menu.
 toggleColumn | A method that toggles the visiblity for a given column – e.g. toggleColumn('email')
 
@@ -94,5 +137,5 @@ Name | Type | Description | Default | Required
 --- | --- | --- | --- | --- |
 children | func | The render-prop function that will receive the relevant props for implementing toggleable columns | | ☑️
 columnMapping | object | An object that maps keys to labels. The order of the keys will determine the default order of the columns. | | ☑️
-excludeKeys | array | Exclude some columns from being toggleable. These keys will be excluded from the columns menu UI. | | 
+excludeKeys | array | Exclude some columns from being toggleable. These keys will be excluded from the columns menu UI. | |
 id | string | The unique ID is used to generate the storage key for persisting the visible columns in sessionStorage. The ID will also be used as a prefixed ID for any UI that is passed down to the render-prop function. | | ☑️

--- a/lib/ColumnManager/useColumnManager.js
+++ b/lib/ColumnManager/useColumnManager.js
@@ -1,0 +1,44 @@
+import { useMemo, useState, useCallback } from 'react';
+
+const STORAGE = sessionStorage;
+
+const useColumnManager = (prefix, columnMapping) => {
+  const storageKey = `${prefix}-storage`;
+
+  // The column mapping object determines the default visible columns and order
+  const defaultColumnKeys = Object.keys(columnMapping);
+
+  const [visibleColumns, setVisibleColumns] = useState(() => {
+    const stored = STORAGE.getItem(storageKey);
+
+    return stored ? JSON.parse(stored) : defaultColumnKeys;
+  });
+
+  const orderedVisibleColumns = useMemo(() => {
+    const visibleColumnsSet = new Set(visibleColumns);
+
+    return defaultColumnKeys.filter(key => visibleColumnsSet.has(key));
+  }, [defaultColumnKeys, visibleColumns]);
+
+  /**
+   * Toggle column visibility
+   */
+  const toggleColumn = useCallback(key => {
+    setVisibleColumns(currVisibleColumns => {
+      const nextVisibleColumns = currVisibleColumns.includes(key)
+        ? currVisibleColumns.filter(k => key !== k)
+        : [...currVisibleColumns, key];
+
+      STORAGE.setItem(storageKey, JSON.stringify(nextVisibleColumns));
+
+      return nextVisibleColumns;
+    });
+  }, [storageKey]);
+
+  return {
+    visibleColumns: orderedVisibleColumns,
+    toggleColumn,
+  };
+};
+
+export default useColumnManager;

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -52,7 +52,7 @@ import {
 import makeConnectedSource from './ConnectedSource';
 import Tags from '../Tags';
 import { NoResultsMessage, ResetButton, CollapseFilterPaneButton, ExpandFilterPaneButton } from './components';
-import ColumnManager from '../ColumnManager';
+import { ColumnManager } from '../ColumnManager';
 
 import buildUrl from './buildUrl';
 


### PR DESCRIPTION
purpose:
https://issues.folio.org/browse/STSMACOM-502
many modules are built with hooks, it would be nice to have one more way to configure columns manager

approach:
move visibility control to hook, define ColumnsMenu as a separate component, expose them + reuse in ColumnManager to support composition approach

initial tests are passed

documentation is updated

