### PR TITLE
STSMACOM-498: View Notes Record: Numbered / Bulleted Lists are not retained after editing/saving it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Execute validation manually when record is being saved. Fixes STSMACOM-496.
 * Fix `<MultiSelect>` when using `<CustomField>` via final form. Fixes STSMACOM-500.
 * buggy @rehooks/local-storage 2.4.1 must be avoided. Refs STSMACOM-501.
+* Fix View Notes Record: Numbered / Nested lists not retained after editing/saving. Fixes STSMACOM-498.
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -6,6 +6,8 @@ import {
   injectIntl,
 } from 'react-intl';
 import classnames from 'classnames';
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
 
 import { MultiColumnList } from '@folio/stripes-components';
 
@@ -193,22 +195,24 @@ class NotesList extends React.Component {
       <FormattedMessage id="stripes-smart-components.notes">
         {
           ([ariaLabel]) => (
-            <MultiColumnList
-              id="notes-list"
-              interactive
-              ariaLabel={ariaLabel}
-              contentData={this.getItems()}
-              visibleColumns={Object.values(notesColumnNames)}
-              columnMapping={columnMapping}
-              columnWidths={notesColumnsWidth}
-              isEmptyMessage={<FormattedMessage id="stripes-smart-components.notes.notFound" />}
-              loading={notes.loading}
-              onRowClick={onNoteClick}
-              getCellClass={this.getCellClass}
-              onHeaderClick={onHeaderClick}
-              sortedColumn={sortedColumn}
-              sortDirection={sortDirection}
-            />
+            <div className="ql-editor">
+              <MultiColumnList
+                id="notes-list"
+                interactive
+                ariaLabel={ariaLabel}
+                contentData={this.getItems()}
+                visibleColumns={Object.values(notesColumnNames)}
+                columnMapping={columnMapping}
+                columnWidths={notesColumnsWidth}
+                isEmptyMessage={<FormattedMessage id="stripes-smart-components.notes.notFound" />}
+                loading={notes.loading}
+                onRowClick={onNoteClick}
+                getCellClass={this.getCellClass}
+                onHeaderClick={onHeaderClick}
+                sortedColumn={sortedColumn}
+                sortDirection={sortDirection}
+              />
+            </div>
           )
         }
       </FormattedMessage>


### PR DESCRIPTION
## Description
Fix issue when adding nested lists to note details and saving the lists are collapsed into one.
To fix this apply styles from React Quill library. 