### PR TITLE
STSMACOM-506 avoid calling setState after unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * buggy @rehooks/local-storage 2.4.1 must be avoided. Refs STSMACOM-501.
 * Fix View Notes Record: Numbered / Nested lists not retained after editing/saving. Fixes STSMACOM-498.
 * hooks approach for ColumnManager. Refs STSMACOM-502.
+* Avoid calling `setState` when a promise returns after unmount. Refs STSMACOM-506.
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/lib/CustomFields/utils/useCustomFieldsFetch.js
+++ b/lib/CustomFields/utils/useCustomFieldsFetch.js
@@ -41,7 +41,7 @@ const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
 
     return () => {
       isMounted = false;
-    }
+    };
   }, [backendModuleId, makeOkapiRequest, entityType]);
 
   return {

--- a/lib/CustomFields/utils/useCustomFieldsFetch.js
+++ b/lib/CustomFields/utils/useCustomFieldsFetch.js
@@ -16,24 +16,31 @@ const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
   );
 
   useEffect(() => {
+    let isMounted = true;
     const fetchCustomFields = async () => {
       const response = await makeOkapiRequest(`custom-fields?limit=${MAX_RECORDS}`)({
         method: 'GET',
       });
 
-      if (response.ok) {
-        const { customFields: requestBody } = await response.json();
-        const fieldsFilteredByEntityType = requestBody.filter(customField => customField.entityType === entityType);
+      if (isMounted) {
+        if (response.ok) {
+          const { customFields: requestBody } = await response.json();
+          const fieldsFilteredByEntityType = requestBody.filter(customField => customField.entityType === entityType);
 
-        setCustomFields(fieldsFilteredByEntityType);
-        setCustomFieldsLoaded(true);
-      } else {
-        setCustomFieldsFetchFailed(true);
+          setCustomFields(fieldsFilteredByEntityType);
+          setCustomFieldsLoaded(true);
+        } else {
+          setCustomFieldsFetchFailed(true);
+        }
       }
     };
 
     if (backendModuleId) {
       fetchCustomFields();
+    }
+
+    return () => {
+      isMounted = false;
     }
   }, [backendModuleId, makeOkapiRequest, entityType]);
 

--- a/lib/CustomFields/utils/useOptionsStatsFetch.js
+++ b/lib/CustomFields/utils/useOptionsStatsFetch.js
@@ -80,7 +80,6 @@ const useOptionsStatsFetch = (okapi, backendModuleId, customFields, entityType) 
     return () => {
       isMounted = false;
     };
-
   }, [customFields, getOptionUsageStatistics, entityType]);
 
   return {

--- a/lib/CustomFields/utils/useOptionsStatsFetch.js
+++ b/lib/CustomFields/utils/useOptionsStatsFetch.js
@@ -41,6 +41,7 @@ const useOptionsStatsFetch = (okapi, backendModuleId, customFields, entityType) 
   const [optionsStatsFetchFailed, setOptionsStatsFetchFailed] = useState(false);
 
   useEffect(() => {
+    let isMounted = true;
     const fetchOptionsUsageStatistics = async () => {
       const promises = customFields.reduce((curr, customField) => {
         if (fieldTypesWithOptions.includes(customField.type)) {
@@ -55,24 +56,31 @@ const useOptionsStatsFetch = (okapi, backendModuleId, customFields, entityType) 
 
       const responses = await Promise.all(promises);
 
-      if (responses.every(({ ok }) => !!ok)) {
-        const optionsUsageData = await Promise.all(responses.map(response => response.json()));
+      if (isMounted) {
+        if (responses.every(({ ok }) => !!ok)) {
+          const optionsUsageData = await Promise.all(responses.map(response => response.json()));
 
-        const usedFieldOptions = optionsUsageData
-          .filter(isEntityTypeMathing(entityType))
-          .filter(isOptionUsed)
-          .reduce(optionsStatsReducer, {});
+          const usedFieldOptions = optionsUsageData
+            .filter(isEntityTypeMathing(entityType))
+            .filter(isOptionUsed)
+            .reduce(optionsStatsReducer, {});
 
-        setOptionsStats(usedFieldOptions);
-        setOptionsStatsLoaded(true);
-      } else {
-        setOptionsStatsFetchFailed(true);
+          setOptionsStats(usedFieldOptions);
+          setOptionsStatsLoaded(true);
+        } else {
+          setOptionsStatsFetchFailed(true);
+        }
       }
     };
 
     if (customFields) {
       fetchOptionsUsageStatistics();
     }
+
+    return () => {
+      isMounted = false;
+    };
+
   }, [customFields, getOptionUsageStatistics, entityType]);
 
   return {

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -13,23 +13,31 @@ const useSectionTitleFetch = (okapi, moduleName) => {
   );
 
   useEffect(() => {
+    let isMounted = true;
     const url = `configurations/entries?query=(module==${moduleName} and configName==custom_fields_label)`;
     const fetchCustomFields = async () => {
       const response = await makeOkapiRequest(url)({
         method: 'GET',
       });
 
-      if (response.ok) {
-        const { configs } = await response.json();
+      if (isMounted) {
+        if (response.ok) {
+          const { configs } = await response.json();
 
-        setSectionTitle({ ...configs[0] });
-        setSectionTitleLoaded(true);
-      } else {
-        setSectionTitleFetchFailed(true);
+          setSectionTitle({ ...configs[0] });
+          setSectionTitleLoaded(true);
+        } else {
+          setSectionTitleFetchFailed(true);
+        }
       }
     };
 
     fetchCustomFields();
+
+    return () => {
+      isMounted = false;
+    };
+
   }, [makeOkapiRequest, moduleName, sectionTitleLoaded]);
 
   return {

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -37,7 +37,6 @@ const useSectionTitleFetch = (okapi, moduleName) => {
     return () => {
       isMounted = false;
     };
-
   }, [makeOkapiRequest, moduleName, sectionTitleLoaded]);
 
   return {


### PR DESCRIPTION
A Promise may return after a component has unmounted. If it does so, it
must not call `setState()`, which is a memory leak reported in the
console.

Refs [STSMACOM-506](https://issues.folio.org/browse/STSMACOM-506)