### PR TITLE
WIP: STSMACOM-508: expose virtualize, key, onScroll props of rendered MCL

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -200,8 +200,8 @@ class SearchAndSort extends React.Component {
     resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
     resultsFormatter: PropTypes.shape({}),
-    resultsKey: PropTypes.oneOfType([PropTypes.string(), PropTypes.number()]),
-    resultsOnScroll: PropTypes.func(),
+    resultsKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    resultsOnScroll: PropTypes.func,
     resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -200,6 +200,9 @@ class SearchAndSort extends React.Component {
     resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
     resultsFormatter: PropTypes.shape({}),
+    resultsKey: PropTypes.oneOfType([PropTypes.string(), PropTypes.number()]),
+    resultsOnScroll: PropTypes.func(),
+    resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
@@ -232,6 +235,8 @@ class SearchAndSort extends React.Component {
     renderNavigation: noop,
     selectedIndex: '',
     hasNewButton: true,
+    resultsVirtualize: true,
+    resultsKey: '000',
   };
 
   constructor(props) {
@@ -1072,6 +1077,9 @@ class SearchAndSort extends React.Component {
       pageAmount,
       pagingType,
       getCellClass,
+      resultsKey,
+      resultsVirtualize,
+      resultsOnScroll,
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1105,6 +1113,7 @@ class SearchAndSort extends React.Component {
             contentData={records}
             selectedRow={selectedItem}
             formatter={resultsFormatter}
+            key={resultsKey}
             visibleColumns={visibleColumnsProp || visibleColumns}
             sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
             sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
@@ -1113,11 +1122,12 @@ class SearchAndSort extends React.Component {
             columnMapping={columnMapping}
             loading={source.pending()}
             autosize
-            virtualize
+            virtualize={resultsVirtualize}
             hasMargin
             rowFormatter={this.anchoredRowFormatter}
             containerRef={(ref) => { this.resultsList = ref; }}
             onRowClick={viewRecordPathById ? undefined : this.onSelectRow}
+            onScroll={resultsOnScroll}
             onHeaderClick={this.onSort}
             onNeedMoreData={this.onNeedMore}
             pageAmount={pageAmount}


### PR DESCRIPTION
This PR surfaces the `virtualize`, `key`, and `onScroll` props of MCL through the SearchAndSort level of props as `resultsVirtualize`, `resultsKey`, and `resultsOnScroll`, respectively. These allow further customization of SearchAndSort for application needs...