### PR TITLE
Use correct PropTypes

### DIFF
--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -22,8 +22,8 @@ import {
 import { POPUP_NOTE_SESSION_STORAGE_PREFIX } from '../constants';
 
 const propTypes = {
-  closeLabel: PropTypes.oneOf([PropTypes.node, PropTypes.string]),
-  deleteLabel: PropTypes.oneOf([PropTypes.node, PropTypes.string]),
+  closeLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  deleteLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   domainName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
   entityId: PropTypes.string,
   entityType: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types


### PR DESCRIPTION
`PropTypes.oneOf()` takes an array of values; `PropTypes.oneOfType()`
takes an array of value-types. Thus, the previous implementation always
threw a warning.