### PR TITLE
STSMACOM-509 Fix Note popup not showing up after creation

### DIFF
--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -87,12 +88,13 @@ const NotePopupModal = ({
   const [namespace] = useNamespace({ key: POPUP_NOTE_SESSION_STORAGE_PREFIX });
   const [popupNote, setPopupNote] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
+  const isNotesLoading = useRef(false);
 
-  const getSessionStorageKey = (noteId) => `${namespace}.${noteId}`;
+  const getSessionStorageKey = useCallback((noteId) => `${namespace}.${noteId}`, [namespace]);
 
   const getSessionStorageNoteInfo = useCallback((noteId) => {
     return JSON.parse(sessionStorage.getItem(getSessionStorageKey(noteId)));
-  }, []);
+  }, [getSessionStorageKey]);
 
   const getPopupNoteFromNotes = useCallback((notes) => {
     return notes.find(note => !!note[popUpPropertyName]);
@@ -111,13 +113,22 @@ const NotePopupModal = ({
     setPopupNote(note);
     mutator.popupNote.update({ id: note.id });
     setIsOpen(shouldShowPopup);
-  }, [mutator.popupNote, getPopupNoteFromNotes, getSessionStorageNoteInfo]);
+    sessionStorage.removeItem(getSessionStorageKey(note.id));
+  }, [
+    mutator.popupNote,
+    getPopupNoteFromNotes,
+    getSessionStorageNoteInfo,
+    getSessionStorageKey,
+  ]);
 
   useEffect(() => {
-    if (!popupNote && entityId) {
-      mutator.NotePopupModal_assignedNotes.GET().then(handleGetNotesRequest);
+    if (!popupNote && entityId && !isNotesLoading.current) {
+      mutator.NotePopupModal_assignedNotes.GET()
+        .then(handleGetNotesRequest);
+
+      isNotesLoading.current = true;
     }
-  }, [entityId, handleGetNotesRequest, popupNote]);
+  }, [entityId, handleGetNotesRequest, popupNote, mutator.NotePopupModal_assignedNotes]);
 
   const onDelete = () => {
     mutator.note.DELETE({

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -46,7 +46,7 @@ const propTypes = {
 const defaultProps = {
   entityId: '',
   label: <FormattedMessage id="stripes-smart-components.notes.popupModal.label" />,
-  closeLabel: <FormattedMessage id="stripes-smart-components.notes.cancel" />,
+  closeLabel: <FormattedMessage id="stripes-smart-components.notes.close" />,
   deleteLabel: <FormattedMessage id="stripes-smart-components.notes.popupModal.delete" />,
 };
 

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -150,6 +150,7 @@
   "notes.editNote": "Edit note",
   "notes.saveAndClose": "Save & close",
   "notes.cancel": "Cancel",
+  "notes.close": "Close",
   "notes.copy": "Copy",
   "notes.unassign": "Unassign",
   "notes.delete": "Delete",


### PR DESCRIPTION
## Description
Fix Popup Note not showing up on users by clearing session storage when note was just created and loaded. Also, prevented sending multiple requests to notes endpoint

## Issues
[STSMACOM-509](https://issues.folio.org/browse/STSMACOM-509)