### PR TITLE
STSMACOM-508 - Expose props for MCL scrollItemToView functionality

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -199,7 +199,12 @@ class SearchAndSort extends React.Component {
     renderNavigation: PropTypes.func,
     resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
     resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
+    resultsCachedPosition: PropTypes.object,
     resultsFormatter: PropTypes.shape({}),
+    resultsKey: PropTypes.string,
+    resultsOnMarkPosition: PropTypes.func,
+    resultsOnResetMarkedPosition: PropTypes.func,
+    resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
@@ -1072,6 +1077,11 @@ class SearchAndSort extends React.Component {
       pageAmount,
       pagingType,
       getCellClass,
+      resultsKey,
+      resultsVirtualize,
+      resultsOnMarkPosition,
+      resultsCachedPosition,
+      resultsOnResetMarkedPosition,
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1099,6 +1109,7 @@ class SearchAndSort extends React.Component {
       >
         {([ariaLabel]) => (
           <MultiColumnList
+            key={resultsKey}
             id={`list-${moduleName}`}
             ariaLabel={ariaLabel}
             totalCount={count}
@@ -1113,7 +1124,7 @@ class SearchAndSort extends React.Component {
             columnMapping={columnMapping}
             loading={source.pending()}
             autosize
-            virtualize
+            virtualize={resultsVirtualize}
             hasMargin
             rowFormatter={this.anchoredRowFormatter}
             containerRef={(ref) => { this.resultsList = ref; }}
@@ -1123,6 +1134,9 @@ class SearchAndSort extends React.Component {
             pageAmount={pageAmount}
             pagingType={pagingType}
             getCellClass={getCellClass}
+            onMarkPosition={resultsOnMarkPosition}
+            onMarkReset={resultsOnResetMarkedPosition}
+            itemToView={resultsCachedPosition}
           />
         )}
       </FormattedMessage>

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -60,6 +60,12 @@ getHelperComponent | func | An optional function which can be used to return con
 title | string/element | An optional property to specify title of results pane. By default module display name is used.
 hasNewButton | boolean | An optional property to specify appearance Of `New` button of results pane. By default pane displays with `New` button.
 basePath | string | An optional string to customize the path which should be used after performing search.
+resultsVirtualize | boolean | controls the `virtualize` prop to the internally rendered `<MultiColumnList>` component. 
+resultsOnMarkPosition | func | sets the `onMarkPosition` prop to the internally rendered `<MultiColumnList>` component. A paramater "position" object with a list offset and selector is provided. This can be stored on the application side to resume scroll position of the results list (if using next/prev pagination.)
+resultsOnResetMarkedPosition | func | sets the `onMarkReset` prop to the internally rendered `<MultiColumnList>` component. It can be used to nullify the "position" object in application state. 
+resultsCachedPosition | position object |  sets the `ItemToView` prop of the internally rendered `<MultiColumnList>` component. It's in the shape of `{selector: string, clientTopOffset: number}`. This object is provided by the `resultsOnMarkPosition` prop.
+resultsKey | string | Sets a `key` prop on the internally rendered `<MultiColumnList>`. Changing this value will re-initialize the MCL. If necessary, this can be used to refresh the component so that it resets/readjusts to updates in data. This should be used sparingly as it can cause multiple re-renders of the list.
+
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.
 


### PR DESCRIPTION
This PR exposes the `virtualize`, `onMarkPosition`, `onMarkReset`, `ItemToView`, `key`,  props for the internally rendered `<MultiColumnList>` component.
The props are exposed as follows:
- resultsVirtualize = virtualize
- resultsOnMarkPosition = onMarkPosition
- resultsOnResetMarkedPosition = onMarkReset
- resultsCachedPosition = ItemToView
- resultsKey = key
