### PR TITLE
STSMACOM-515: Users/Checkout pop-up note: Change logic for when to display pop-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Create/Edit Note | Addded Display note as a pop-up field. Refs STSMACOM-489
 * Relax `EditCustomFieldsRecord` proptypes to handle multi-select values. Refs STSMACOM-507.
 * Add `NotePopupModal` component. Refs STSMACOM-509.
+* Always show `<NotePopupModal>` when popup notes exist. Refs STSMACOM-515.
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/lib/Notes/NoteCreatePage/NoteCreatePage.js
+++ b/lib/Notes/NoteCreatePage/NoteCreatePage.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
 import {
   stripesConnect,
   TitleManager,
-  withNamespace,
 } from '@folio/stripes-core';
 
 import { Icon } from '@folio/stripes-components';
@@ -15,7 +14,6 @@ import { Icon } from '@folio/stripes-components';
 import NoteForm from '../components/NoteForm';
 import { noteTypesCollectionShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
-import { POPUP_NOTE_SESSION_STORAGE_PREFIX } from '../constants';
 
 @stripesConnect
 class NoteCreatePage extends Component {
@@ -27,7 +25,6 @@ class NoteCreatePage extends Component {
         POST: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
-    namespace: PropTypes.string.isRequired,
     navigateBack: PropTypes.func.isRequired,
     paneHeaderAppIcon: PropTypes.string.isRequired,
     paneTitle: PropTypes.node,
@@ -68,8 +65,8 @@ class NoteCreatePage extends Component {
 
   onSubmit = async (noteData) => {
     try {
-      const { id } = await this.sendNoteData(noteData);
-      this.handleSuccessResponse(id);
+      await this.sendNoteData(noteData);
+      this.handleSuccessResponse();
     } catch (err) {
       this.handleFailedResponse();
     }
@@ -101,11 +98,7 @@ class NoteCreatePage extends Component {
     };
   }
 
-  handleSuccessResponse(id) {
-    sessionStorage.setItem(`${this.props.namespace}.${id}`, JSON.stringify({
-      justCreated: true,
-    }));
-
+  handleSuccessResponse() {
     this.setState({
       submitSucceeded: true,
       submitIsPending: false,
@@ -182,4 +175,4 @@ class NoteCreatePage extends Component {
   }
 }
 
-export default withNamespace(NoteCreatePage, { key: POPUP_NOTE_SESSION_STORAGE_PREFIX });
+export default NoteCreatePage;

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -1,4 +1,4 @@
-import {
+import React, {
   useState,
   useEffect,
   useCallback,
@@ -17,10 +17,7 @@ import {
 import {
   stripesConnect,
   useStripes,
-  useNamespace,
 } from '@folio/stripes-core';
-
-import { POPUP_NOTE_SESSION_STORAGE_PREFIX } from '../constants';
 
 const propTypes = {
   closeLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
@@ -85,16 +82,9 @@ const NotePopupModal = ({
   label,
 }) => {
   const stripes = useStripes();
-  const [namespace] = useNamespace({ key: POPUP_NOTE_SESSION_STORAGE_PREFIX });
   const [popupNote, setPopupNote] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
   const isNotesLoading = useRef(false);
-
-  const getSessionStorageKey = useCallback((noteId) => `${namespace}.${noteId}`, [namespace]);
-
-  const getSessionStorageNoteInfo = useCallback((noteId) => {
-    return JSON.parse(sessionStorage.getItem(getSessionStorageKey(noteId)));
-  }, [getSessionStorageKey]);
 
   const getPopupNoteFromNotes = useCallback((notes) => {
     return notes.find(note => !!note[popUpPropertyName]);
@@ -107,19 +97,10 @@ const NotePopupModal = ({
       return;
     }
 
-    const noteInfo = getSessionStorageNoteInfo(note.id);
-    const shouldShowPopup = !noteInfo || (!noteInfo.isDismissed && !noteInfo.justCreated);
-
     setPopupNote(note);
     mutator.popupNote.update({ id: note.id });
-    setIsOpen(shouldShowPopup);
-    sessionStorage.removeItem(getSessionStorageKey(note.id));
-  }, [
-    mutator.popupNote,
-    getPopupNoteFromNotes,
-    getSessionStorageNoteInfo,
-    getSessionStorageKey,
-  ]);
+    setIsOpen(true);
+  }, [mutator.popupNote, getPopupNoteFromNotes]);
 
   useEffect(() => {
     if (!popupNote && entityId && !isNotesLoading.current) {
@@ -138,9 +119,6 @@ const NotePopupModal = ({
   };
 
   const onClose = () => {
-    sessionStorage.setItem(getSessionStorageKey(popupNote.id), JSON.stringify({
-      isDismissed: true,
-    }));
     setIsOpen(false);
   };
 

--- a/lib/Notes/NotePopupModal/tests/NotePopupModal-test.js
+++ b/lib/Notes/NotePopupModal/tests/NotePopupModal-test.js
@@ -70,19 +70,5 @@ describe('NotePopupModal', () => {
     it('should display note content', () => {
       expect(notePopupModal.noteContent).to.equal('Note details');
     });
-
-    describe('when clicking on close button', () => {
-      beforeEach(async () => {
-        await notePopupModal.closeButton.click();
-      });
-
-      it('should set note as dismissed', () => {
-        const storageItem = JSON.parse(sessionStorage.getItem('@folio/ui-dummy:popUpNoteInfo.providerNoteId'));
-
-        expect(storageItem).to.eql({
-          isDismissed: true,
-        });
-      });
-    });
   });
 });

--- a/lib/Notes/constants.js
+++ b/lib/Notes/constants.js
@@ -43,5 +43,3 @@ export const notesColumnsWidth = {
   [notesColumnNames.TITLE_AND_DETAILS]: '60%',
   [notesColumnNames.TYPE]: '20%',
 };
-
-export const POPUP_NOTE_SESSION_STORAGE_PREFIX = 'popUpNoteInfo';


### PR DESCRIPTION
## Description
Always show NotePopupModal when popup notes exist.

`<NotePopupModal>` breaks tests in modules that aren't yet using new jsx transforms. This PR adds import React to this component
@zburke Do we want to create tickets for all UI modules to use new jsx transforms for the next release?