### PR TITLE
STSMACOM-516 SearchAndSort autofocus handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Create/Edit Note | Addded Display note as a pop-up field. Refs STSMACOM-489
 * Relax `EditCustomFieldsRecord` proptypes to handle multi-select values. Refs STSMACOM-507.
 * Add `NotePopupModal` component. Refs STSMACOM-509.
+* Add 'autofocusSearchField` prop to SearchAndSort. fixes STSMACOM-516
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -80,6 +80,7 @@ class SearchAndSort extends React.Component {
     actionMenu: PropTypes.func, // parameter properties provided by caller
     apolloQuery: PropTypes.object, // machine-readable
     apolloResource: PropTypes.string,
+    autofocusSearchField: PropTypes.bool,
     basePath: PropTypes.string,
     browseOnly: PropTypes.bool,
     columnManagerProps: PropTypes.object,
@@ -225,6 +226,7 @@ class SearchAndSort extends React.Component {
   };
 
   static defaultProps = {
+    autofocusSearchField: true,
     columnManagerProps: {},
     customPaneSub: null,
     showSingleResult: false,
@@ -1001,6 +1003,7 @@ class SearchAndSort extends React.Component {
       disableFilters,
       searchableIndexes,
       selectedIndex,
+      autofocusSearchField,
     } = this.props;
     const {
       locallyChangedSearchTerm,
@@ -1024,7 +1027,7 @@ class SearchAndSort extends React.Component {
           {([ariaLabel]) => (
             <SearchField
               id={`input-${objectName}-search`}
-              autoFocus
+              autoFocus={autofocusSearchField}
               ariaLabel={ariaLabel}
               className={css.searchField}
               searchableIndexes={searchableIndexes}


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-516

## Purpose
The purpose of this PR is to give ui module developers control over the autofocus prop of SearchAndSort's rendered SearchField component. This will allow modules to implement their own focus management.