### PR TITLE
STSMACOM-518 results list not reflecting selection on return from edit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add `NotePopupModal` component. Refs STSMACOM-509.
 * Always show `<NotePopupModal>` when popup notes exist. Refs STSMACOM-515.
 * Add `autofocusSearchField` prop to SearchAndSort. fixes STSMACOM-516
+* Use `isSelected` prop of MCL in SearchAndSort to highlight selected item with fewer criteria properties. fixes STSMACOM-518
 
 ## [6.0.1](https://github.com/folio-org/stripes-smart-components/tree/v6.0.1) (2021-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.0...v6.0.1)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -15,6 +15,7 @@ import {
   includes,
   debounce,
   get,
+  isMatch,
   upperFirst,
   noop,
   isEmpty,
@@ -1140,6 +1141,7 @@ class SearchAndSort extends React.Component {
             onMarkPosition={resultsOnMarkPosition}
             onMarkReset={resultsOnResetMarkedPosition}
             itemToView={resultsCachedPosition}
+            isSelected={({ item, criteria }) => isMatch(item, criteria)}
           />
         )}
       </FormattedMessage>


### PR DESCRIPTION
# Problem
After editing and saving a record, returning to the results list will not have the currently seleted item highlighted.

## Approach
Make use of MultiColumnList's `isSelected` prop so that objects containing a subset of like values can be used for criteria.