### PR TITLE
STSMACOM-525: Cannot add access status types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##[6.2.0] (IN PROGRESS)
 
 * Fix filtering in `<LocationSelection>`, Fixes STSMACOM-523.
+* Add default value for `validate` prop in `<EditableListForm>`. Fixes STSMACOM-525.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -2,6 +2,7 @@ import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import isEmpty from 'lodash/isEmpty';
+import noop from 'lodash/noop';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
@@ -160,7 +161,7 @@ const defaultProps = {
   fieldComponents: {},
   itemTemplate: {},
   uniqueField: 'id',
-  validate: () => {},
+  validate: noop,
 };
 
 class EditableListForm extends React.Component {

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -160,6 +160,7 @@ const defaultProps = {
   fieldComponents: {},
   itemTemplate: {},
   uniqueField: 'id',
+  validate: () => {},
 };
 
 class EditableListForm extends React.Component {


### PR DESCRIPTION
## Description
Added default value for not required `validate` prop in `<EditableListForm>`. We're using `<EditableList>` in eHoldings and don't need to validate rows before sending because validate happens on field blur.

## Issues
[STSMACOM-525](https://issues.folio.org/browse/STSMACOM-525)
