### PR TITLE
STSMACOM-526: Use selectedIndex when locallyChangedQueryIndex is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add default value for `validate` prop in `<EditableListForm>`. Fixes STSMACOM-525.
 * Disable save button for `<NoteForm>` when form were no changes. Fixes STSMACOM-522. 
 * View Notes Record: List indentations are not retained. Fixes STSMACOM-527.
+* Use `selectedIndex` when `locallyChangedQueryIndex` is not present during search. Fixes STSMACOM-526.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -456,10 +456,11 @@ class SearchAndSort extends React.Component {
       locallyChangedSearchTerm,
       locallyChangedQueryIndex,
     } = this.state;
+    const qindex = locallyChangedQueryIndex || this.props.selectedIndex;
 
     this.performSearch({
       query: locallyChangedSearchTerm,
-      qindex: locallyChangedQueryIndex,
+      qindex,
     });
   };
 


### PR DESCRIPTION
Use `selectedIndex` when `locallyChangedQueryIndex` is not present during search. 

https://issues.folio.org/browse/STSMACOM-526