### PR TITLE
STSMACOM-527 View Notes Record: List indentations are not retained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix filtering in `<LocationSelection>`, Fixes STSMACOM-523.
 * Add default value for `validate` prop in `<EditableListForm>`. Fixes STSMACOM-525.
+* View Notes Record: List indentations are not retained. Fixes STSMACOM-527.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -268,7 +268,7 @@ export default class NoteView extends Component {
                       label={<FormattedMessage id="stripes-smart-components.details" />}
                     >
                       <div
-                        className="editor-preview"
+                        className="editor-preview ql-editor"
                         data-test-note-view-note-details
                         dangerouslySetInnerHTML={noteContentMarkup}
                       />


### PR DESCRIPTION
## Description
Add proper styles for Note details element to display details as they were saved

## Issues
[STSMACOM-527](https://issues.folio.org/browse/STSMACOM-527)