### PR TITLE
STSMACOM-522: Disable save button for <NoteForm> when form were no changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix filtering in `<LocationSelection>`, Fixes STSMACOM-523.
 * Add default value for `validate` prop in `<EditableListForm>`. Fixes STSMACOM-525.
+* Disable save button for `<NoteForm>` when form were no changes. Fixes STSMACOM-522. 
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -268,8 +268,8 @@ export default class NoteForm extends Component {
 
     const popUpValues = showDisplayAsPopupOptions
       ? {
-        popUpOnCheckOut: !!noteData.popUpOnCheckOut,
-        popUpOnUser: !!noteData.popUpOnUser,
+        popUpOnCheckOut: !!noteData?.popUpOnCheckOut,
+        popUpOnUser: !!noteData?.popUpOnUser,
       }
       : {};
 

--- a/lib/Notes/components/NoteForm/NoteForm.js
+++ b/lib/Notes/components/NoteForm/NoteForm.js
@@ -266,8 +266,16 @@ export default class NoteForm extends Component {
       ? noteData.type
       : get(this.sortedNoteTypes, '[0].value');
 
+    const popUpValues = showDisplayAsPopupOptions
+      ? {
+        popUpOnCheckOut: !!noteData.popUpOnCheckOut,
+        popUpOnUser: !!noteData.popUpOnUser,
+      }
+      : {};
+
     const initialValues = {
       ...noteData,
+      ...popUpValues,
       type: noteTypeInitialValue,
     };
 


### PR DESCRIPTION
## STSMACOM-522: The Save button is active when editing in the Note if there were NO changes

### Description
It's needed to set initial boolean values for `popUpOnCheckOut` and `popUpOnUser` instead of default `undefined`

### Issue
[STSMACOM-522](https://issues.folio.org/browse/STSMACOM-522)

### Screenshot
![zbiRGuTGxC](https://user-images.githubusercontent.com/55701515/124125928-cfb0b480-da82-11eb-8f33-333a218f997c.gif)
