### PR TITLE
STSMACOM-523: Add missing value to locationOpts

### DIFF
--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -42,7 +42,10 @@ const LocationForm = ({
     [loc => loc.name.toLowerCase(), loc => loc.code.toLowerCase()]
   ).map(({ name, code, id }) => {
     const remoteLabel = remoteMap[id] ? intl.formatMessage({ id: 'stripes-smart-components.ll.remoteLabel' }) : '';
-    return { label: `${name} (${code}) ${remoteLabel}` };
+    return {
+      label: `${name} (${code}) ${remoteLabel}`,
+      value: id,
+    };
   });
 
   return (


### PR DESCRIPTION
I screwed up in https://github.com/folio-org/stripes-smart-components/pull/1084 and removed the `value` by accident.

Thank you @zburke for catching this!