### PR TITLE
STSMACOM-470: ViewCustomFieldsRecord must never return an empty element (<>)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Disable save button for `<NoteForm>` when form were no changes. Fixes STSMACOM-522. 
 * View Notes Record: List indentations are not retained. Fixes STSMACOM-527.
 * Use `selectedIndex` when `locallyChangedQueryIndex` is not present during search. Fixes STSMACOM-526.
+* Always show `<ViewCustomFieldsRecord>`, even if no custom-fields are present. Refs STSMACOM-470.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -84,8 +84,6 @@ const ViewCustomFieldsRecord = ({
     sectionTitleFetchFailed,
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
 
-  const CUSTOM_FIELDS = 'Custom fields';
-
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const columnWidth = rowShapes / columnCount;
 
@@ -96,7 +94,7 @@ const ViewCustomFieldsRecord = ({
     ? (<Badge>{visibleCustomFields.length}</Badge>)
     : (<Icon icon="spinner-ellipsis" width="10px" />);
 
-  const customFieldsAccordionTitle = sectionTitle.value || CUSTOM_FIELDS;
+  const customFieldsAccordionTitle = sectionTitle.value || <FormattedMessage id="ui-users.custom.customFields" />;
 
   const findOptionLabelById = customField => optionId => {
     return customField.selectField.options.values.find(option => option.id === optionId).value;
@@ -182,10 +180,7 @@ const ViewCustomFieldsRecord = ({
               }
             </Row>
           ))
-          : <FormattedMessage
-            id="ui-users.noItemFound"
-            values={{ item: CUSTOM_FIELDS.toLowerCase() }}
-          />
+          : <FormattedMessage id="ui-users.custom.noCustomFieldsFound" />
         }
       </Accordion>
       <Callout ref={calloutRef} />

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { chunk } from 'lodash';
 import { FormattedMessage } from 'react-intl';
@@ -46,11 +46,11 @@ const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
   columnCount: PropTypes.number,
-  customFieldsLabel: PropTypes.string,
+  customFieldsLabel: PropTypes.node,
   customFieldsValues: PropTypes.object.isRequired,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
-  noCustomFieldsFoundLabel: PropTypes.string,
+  noCustomFieldsFoundLabel: PropTypes.node,
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     token: PropTypes.string.isRequired,
@@ -61,8 +61,8 @@ const propTypes = {
 
 const defaultProps = {
   columnCount: 4,
-  customFieldsLabel: 'stripes-smart-components.customFields',
-  noCustomFieldsFoundLabel: 'stripes-smart-components.customFields.noCustomFieldsFound',
+  customFieldsLabel: <FormattedMessage id="stripes-smart-components.customFields" />,
+  noCustomFieldsFoundLabel: <FormattedMessage id="stripes-smart-components.customFields.noCustomFieldsFound" />,
 };
 
 const ViewCustomFieldsRecord = ({
@@ -100,7 +100,7 @@ const ViewCustomFieldsRecord = ({
     ? (<Badge>{visibleCustomFields.length}</Badge>)
     : (<Icon icon="spinner-ellipsis" width="10px" />);
 
-  const customFieldsAccordionTitle = sectionTitle.value || <FormattedMessage id={customFieldsLabel} />;
+  const customFieldsAccordionTitle = sectionTitle.value || customFieldsLabel;
 
   const findOptionLabelById = customField => optionId => {
     return customField.selectField.options.values.find(option => option.id === optionId).value;
@@ -186,7 +186,7 @@ const ViewCustomFieldsRecord = ({
               }
             </Row>
           ))
-          : <FormattedMessage id={noCustomFieldsFoundLabel} />
+          : noCustomFieldsFoundLabel
         }
       </Accordion>
       <Callout ref={calloutRef} />

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -46,9 +46,11 @@ const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
   columnCount: PropTypes.number,
+  customFieldsLabel: PropTypes.string,
   customFieldsValues: PropTypes.object.isRequired,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
+  noCustomFieldsFoundLabel: PropTypes.string,
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     token: PropTypes.string.isRequired,
@@ -59,6 +61,8 @@ const propTypes = {
 
 const defaultProps = {
   columnCount: 4,
+  customFieldsLabel: 'stripes-smart-components.customFields',
+  noCustomFieldsFoundLabel: 'stripes-smart-components.customFields.noCustomFieldsFound',
 };
 
 const ViewCustomFieldsRecord = ({
@@ -71,6 +75,8 @@ const ViewCustomFieldsRecord = ({
   entityType,
   customFieldsValues,
   columnCount,
+  customFieldsLabel,
+  noCustomFieldsFoundLabel,
 }) => {
   const {
     customFields,
@@ -94,7 +100,7 @@ const ViewCustomFieldsRecord = ({
     ? (<Badge>{visibleCustomFields.length}</Badge>)
     : (<Icon icon="spinner-ellipsis" width="10px" />);
 
-  const customFieldsAccordionTitle = sectionTitle.value || <FormattedMessage id="ui-users.custom.customFields" />;
+  const customFieldsAccordionTitle = sectionTitle.value || <FormattedMessage id={customFieldsLabel} />;
 
   const findOptionLabelById = customField => optionId => {
     return customField.selectField.options.values.find(option => option.id === optionId).value;
@@ -180,7 +186,7 @@ const ViewCustomFieldsRecord = ({
               }
             </Row>
           ))
-          : <FormattedMessage id="ui-users.custom.noCustomFieldsFound" />
+          : <FormattedMessage id={noCustomFieldsFoundLabel} />
         }
       </Accordion>
       <Callout ref={calloutRef} />

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
 import { chunk } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -12,6 +13,7 @@ import {
   Col,
   Checkbox,
   Icon,
+  Badge,
 } from '@folio/stripes-components';
 
 import {
@@ -82,12 +84,19 @@ const ViewCustomFieldsRecord = ({
     sectionTitleFetchFailed,
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
 
+  const CUSTOM_FIELDS = 'Custom fields';
+
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
-  const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);
   const columnWidth = rowShapes / columnCount;
 
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
+
+  const displayWhenClosed = sectionTitleLoaded
+    ? (<Badge>{visibleCustomFields.length}</Badge>)
+    : (<Icon icon="spinner-ellipsis" width="10px" />);
+
+  const customFieldsAccordionTitle = sectionTitle.value || CUSTOM_FIELDS;
 
   const findOptionLabelById = customField => optionId => {
     return customField.selectField.options.values.find(option => option.id === optionId).value;
@@ -142,18 +151,19 @@ const ViewCustomFieldsRecord = ({
 
   return (
     <>
-      {(!customFieldsLoaded || customFieldsIsVisible) && (
-        <Accordion
-          open={expanded}
-          id={accordionId}
-          onToggle={onToggle}
-          label={sectionTitleLoaded
-            ? sectionTitle.value
-            : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
-          }
-          data-test-custom-fields-view-accordion
-        >
-          {customFieldsLoaded && formattedCustomFields.map((row, i) => (
+      <Accordion
+        open={expanded}
+        id={accordionId}
+        onToggle={onToggle}
+        label={sectionTitleLoaded
+          ? customFieldsAccordionTitle
+          : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
+        }
+        displayWhenClosed={displayWhenClosed}
+        data-test-custom-fields-view-accordion
+      >
+        {customFieldsLoaded && formattedCustomFields.length
+          ? formattedCustomFields.map((row, i) => (
             <Row key={i}>
               {
                 row.map(customField => (
@@ -172,9 +182,12 @@ const ViewCustomFieldsRecord = ({
               }
             </Row>
           ))
-          }
-        </Accordion>
-      )}
+          : <FormattedMessage
+            id="ui-users.noItemFound"
+            values={{ item: CUSTOM_FIELDS.toLowerCase() }}
+          />
+        }
+      </Accordion>
       <Callout ref={calloutRef} />
     </>
   );

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -203,6 +203,7 @@
   "customFields": "Custom fields",
   "customFields.edit": "Edit",
   "customFields.new": "New",
+  "customFields.noCustomFieldsFound": "No custom fields found",
   "customFields.editCustomFields": "Edit custom fields",
   "customFields.metadata.createdBy": "Created by {userName} {date}",
   "customFields.fieldTypes.TEXTFIELD": "Text field",


### PR DESCRIPTION
## Description
`ViewCustomFieldsRecord` doesn't disappear even if no custom-fields are present.
If an accordion contains no content, the closed accordion shows a 0 badge.
If an accordion contains no content, the opened accordion shows a "No custom fields found" message.

## Screenshots
![image](https://user-images.githubusercontent.com/84023879/125315522-e6d38a00-e33f-11eb-9230-08ddfaec8016.png)
![image](https://user-images.githubusercontent.com/84023879/125315634-ff43a480-e33f-11eb-8fd3-8cb91bf85bed.png)

## Issues
[STSMACOM-470](https://issues.folio.org/browse/STSMACOM-470)
Also, change in ui-users was required ([UIU-2210](https://issues.folio.org/browse/UIU-2210))