### PR TITLE
STSMACOM-531 validate array before accessing its length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * View Notes Record: List indentations are not retained. Fixes STSMACOM-527.
 * Use `selectedIndex` when `locallyChangedQueryIndex` is not present during search. Fixes STSMACOM-526.
 * Always show `<ViewCustomFieldsRecord>`, even if no custom-fields are present. Refs STSMACOM-470.
+* Make sure custom-fields fetch has returned before evaluating its result-size. Refs STCOM-531.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -96,7 +96,7 @@ const ViewCustomFieldsRecord = ({
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
 
-  const displayWhenClosed = sectionTitleLoaded
+  const displayWhenClosed = (sectionTitleLoaded && customFieldsLoaded)
     ? (<Badge>{visibleCustomFields.length}</Badge>)
     : (<Icon icon="spinner-ellipsis" width="10px" />);
 


### PR DESCRIPTION
If the section-title fetch returns before the custom-fields fetch, then
`visibleCustomFields` will be undefined, not an array. Thus, the
`...Loaded` properties of both `sectionTitle` and `customFields` need to
be tested, not just `sectionTitle`.

I believe this bug was introduced in #1093.

Refs [STSMACOM-531](https://issues.folio.org/browse/STSMACOM-531)