### PR TITLE
Document canCreate prop of EditableList

### DIFF
--- a/lib/EditableList/readme.md
+++ b/lib/EditableList/readme.md
@@ -31,6 +31,7 @@ Use the `EditableList` component in your jsx
 ### Configuration (props)
 Name | type | description | default | required
 --- | --- | --- | --- | ---
+canCreate | boolean | Determines if the '+ New' button is active. | | no
 contentData | array of objects | Array of objects to be rendered as list items. | | yes
 nameKey | string | The key that uniquely names listed objects: defaults to 'name'. | | no
 onCreate | function | Callback for creating new list items. | | no


### PR DESCRIPTION
It is in fact possible to disable record creation on this component, but that functionality was undocumented... until now.