### PR TITLE
STSMACOM-532: Add validation for custom fields whitespace values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Always show `<ViewCustomFieldsRecord>`, even if no custom-fields are present. Refs STSMACOM-470.
 * Sort institutions, campuses and libraries in alphabetical order. Fixes STSMACOM-530.
 * Make sure custom-fields fetch has returned before evaluating its result-size. Refs STSMACOM-531.
+* Add validation for custom fields whitespace values. Refs BF-182.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/CustomFields/utils/validateCustomFields.js
+++ b/lib/CustomFields/utils/validateCustomFields.js
@@ -3,9 +3,8 @@ import { FormattedMessage } from 'react-intl';
 import { fieldLimits } from '../constants';
 
 const validateCustomFields = customField => value => {
-  console.log(value);
   const isValueEmpty = Array.isArray(value) ? !value.length : !value;
-  
+
   if (customField.required && isValueEmpty) {
     return <FormattedMessage
       id="stripes-smart-components.customFields.fieldValue.required"

--- a/lib/CustomFields/utils/validateCustomFields.js
+++ b/lib/CustomFields/utils/validateCustomFields.js
@@ -3,8 +3,9 @@ import { FormattedMessage } from 'react-intl';
 import { fieldLimits } from '../constants';
 
 const validateCustomFields = customField => value => {
+  console.log(value);
   const isValueEmpty = Array.isArray(value) ? !value.length : !value;
-
+  
   if (customField.required && isValueEmpty) {
     return <FormattedMessage
       id="stripes-smart-components.customFields.fieldValue.required"
@@ -17,6 +18,10 @@ const validateCustomFields = customField => value => {
       id="stripes-smart-components.customFields.fieldValue.length"
       values={{ field: customField.name }}
     />;
+  }
+
+  if (value && !value.trim()) {
+    return <FormattedMessage id="stripes-smart-components.customFields.fieldValue.whitespace" />;
   }
 
   return null;

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -216,6 +216,7 @@
   "customFields.fieldFormat": "Field format",
   "customFields.fieldValue.required": "{field} is required",
   "customFields.fieldValue.length": "{field} character limit has been exceeded. Please revise.",
+  "customFields.fieldValue.whitespace": "Whitespace only character(s) is not allowed.",
   "customFields.helperText": "Help text",
   "customFields.helperText.description": "This will show under an information icon",
   "customFields.required": "Required",


### PR DESCRIPTION
# STSMACOM-532: Custom fields: After filling in some text boxes with only whitespace character(s) and saving there is no switch to the user profile preview window in the Users app

Add validation message for custom fields with whitespace values

## Issue
[STSMACOM-532](https://issues.folio.org/browse/STSMACOM-532)