### PR TITLE
STSMACOM-535: Can't edit a user record with a custom field in Snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Sort institutions, campuses and libraries in alphabetical order. Fixes STSMACOM-530.
 * Make sure custom-fields fetch has returned before evaluating its result-size. Refs STSMACOM-531.
 * Add validation for custom fields whitespace values. Refs BF-182.
+* Fix edit a user record with a custom field. Refs STSMACOM-535.
 
 ## [6.1.0](https://github.com/folio-org/stripes-smart-components/tree/v6.1.0) (2021-06-09)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.0.1...v6.1.0)

--- a/lib/CustomFields/utils/validateCustomFields.js
+++ b/lib/CustomFields/utils/validateCustomFields.js
@@ -19,7 +19,7 @@ const validateCustomFields = customField => value => {
     />;
   }
 
-  if (value && !value.trim()) {
+  if (value && typeof value === 'string' && !value.trim()) {
     return <FormattedMessage id="stripes-smart-components.customFields.fieldValue.whitespace" />;
   }
 


### PR DESCRIPTION
## Purpose
Fix edit a user record with a custom field.

## Description
This bug happened because of the `trim()` function on the custom fields value, and in case when custom field was not the text field, but radio buttons/multi-select/checkbox etc., the `trim()` function gave error when applied to an array or boolean.

## Issue
[STSMACOM-535](https://issues.folio.org/browse/STSMACOM-535)