### PR TITLE
UXPROD-3148: Adding logic for translating library-defined controlled vocabularies

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -1,15 +1,27 @@
+/* eslint-disable react/sort-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage, injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { isEqual, uniqueId, pickBy, noop } from 'lodash';
 
-import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row, Loading } from '@folio/stripes-components';
+import {
+  Button,
+  Callout,
+  Col,
+  ConfirmationModal,
+  Modal,
+  Pane,
+  Paneset,
+  Row,
+  Loading
+} from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
 import css from './ControlledVocab.css';
 import makeRefdataActuatorsBoundTo from './actuators-refdata';
+import TranslationsActionsMenu from './TranslationsActionsMenu/TranslationsActionsMenu';
 
 class ControlledVocab extends React.Component {
   static manifest = Object.freeze({
@@ -20,13 +32,14 @@ class ControlledVocab extends React.Component {
       throwErrors: false,
       clientGeneratePk: '!{clientGeneratePk}',
       PUT: {
-        path: '!{baseUrl}/%{activeRecord.id}',
+        path: '!{baseUrl}/%{activeRecord.id}'
       },
       DELETE: {
-        path: '!{baseUrl}/%{activeRecord.id}',
+        path: '!{baseUrl}/%{activeRecord.id}'
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=2000'
+        path:
+          '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=2000'
       }
     },
     // Only used when actuatorType="refdata"
@@ -36,8 +49,8 @@ class ControlledVocab extends React.Component {
       clientGeneratePk: '!{clientGeneratePk}',
       throwErrors: false,
       PUT: {
-        path: '!{baseUrl}',
-      },
+        path: '!{baseUrl}'
+      }
     },
     activeRecord: {},
     updaters: {
@@ -51,11 +64,24 @@ class ControlledVocab extends React.Component {
               return `(${resourceValues.updaterIds.join(' or ')})`;
             }
             return null;
-          },
+          }
         }
       }
     },
     updaterIds: {},
+    // Translated library-defined controlled vocabularies [UXPROD-3148]
+    translations: {
+      type: 'okapi',
+      path: 'translations',
+      records: 'translations',
+      POST: {
+        path: 'translations'
+      },
+      PUT: {
+        path: 'translations'
+      }
+    },
+    translationId: ''
   });
 
   static propTypes = {
@@ -63,10 +89,7 @@ class ControlledVocab extends React.Component {
     actionSuppressor: PropTypes.object,
     actuatorType: PropTypes.string,
     baseUrl: PropTypes.string.isRequired,
-    clientGeneratePk: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string
-    ]),
+    clientGeneratePk: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     columnMapping: PropTypes.object,
     editable: PropTypes.bool,
     formatter: PropTypes.object,
@@ -81,22 +104,32 @@ class ControlledVocab extends React.Component {
     listSuppressorText: PropTypes.node,
     mutator: PropTypes.shape({
       activeRecord: PropTypes.shape({
-        update: PropTypes.func,
+        update: PropTypes.func
       }),
       updaterIds: PropTypes.shape({
-        replace: PropTypes.func,
+        replace: PropTypes.func
       }),
       updaters: PropTypes.shape({
         GET: PropTypes.func,
-        reset: PropTypes.func,
+        reset: PropTypes.func
       }),
       values: PropTypes.shape({
         DELETE: PropTypes.func,
         GET: PropTypes.func,
         POST: PropTypes.func,
         PUT: PropTypes.func,
-        reset: PropTypes.func,
+        reset: PropTypes.func
       }),
+      // translations mutator
+      translations: PropTypes.shape({
+        GET: PropTypes.func.isRequired,
+        reset: PropTypes.func.isRequired,
+        POST: PropTypes.func.isRequired,
+        PUT: PropTypes.func.isRequired
+      }),
+      translationId: PropTypes.shape({
+        replace: PropTypes.func.isRequired
+      })
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
@@ -108,13 +141,20 @@ class ControlledVocab extends React.Component {
     resources: PropTypes.shape({
       updaterIds: PropTypes.oneOfType([
         PropTypes.object, // It comes back as this early in the lifecycle
-        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.arrayOf(PropTypes.string)
       ]),
       updaters: PropTypes.object,
       values: PropTypes.shape({
         isPending: PropTypes.bool,
-        records: PropTypes.arrayOf(PropTypes.object),
+        records: PropTypes.arrayOf(PropTypes.object)
       }),
+      // translations resources
+      translations: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object)
+      }),
+      translationId: PropTypes.shape({
+        replace: PropTypes.func.isRequired
+      })
     }).isRequired,
     rowFilter: PropTypes.element,
     rowFilterFunction: PropTypes.func,
@@ -124,13 +164,21 @@ class ControlledVocab extends React.Component {
       hasPerm: PropTypes.func.isRequired
     }).isRequired,
     /*
-    * Allows for custom field validation. The function is called for each record (row) and should
-    * return an empty object for no errors, or an object where the keys are the field names and
-    * the values are the error message components/strings to display.
-    * e.g., (item, index, items) => ({ name: item.name === 'Admin' ? 'Name cannot be admin' : undefined })
-    */
+     * Allows for custom field validation. The function is called for each record (row) and should
+     * return an empty object for no errors, or an object where the keys are the field names and
+     * the values are the error message components/strings to display.
+     * e.g., (item, index, items) => ({ name: item.name === 'Admin' ? 'Name cannot be admin' : undefined })
+     */
     validate: PropTypes.func,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
+    /*
+    * Translated library-defined controlled vocabularies [UXPROD-3148]
+    * props needed for creating dynamic translation key patern
+    */
+    appName: PropTypes.string.isRequired,
+    tableName: PropTypes.string,
+    translatableFields: PropTypes.arrayOf(PropTypes.string),
+    intl: PropTypes.object
   };
 
   static defaultProps = {
@@ -141,14 +189,14 @@ class ControlledVocab extends React.Component {
     itemTemplate: {},
     nameKey: undefined,
     formatter: {
-      numberOfObjects: () => '-',
+      numberOfObjects: () => '-'
     },
     actionSuppressor: {
       edit: item => item.readOnly,
-      delete: item => item.readOnly,
+      delete: item => item.readOnly
     },
-    preCreateHook: (row) => row,
-    preUpdateHook: (row) => row,
+    preCreateHook: row => row,
+    preUpdateHook: row => row,
     sortby: 'name',
     validate: () => ({}),
     clientGeneratePk: true,
@@ -162,6 +210,7 @@ class ControlledVocab extends React.Component {
     //  !{limitParam:-limit}
     // in the manifest above.
     actuatorType: 'rest',
+    translatableFields: []
   };
 
   constructor(props) {
@@ -171,7 +220,7 @@ class ControlledVocab extends React.Component {
       showConfirmDialog: false,
       showItemInUseDialog: false,
       selectedItem: {},
-      primaryField: props.visibleFields[0],
+      primaryField: props.visibleFields[0]
     };
 
     this.validate = this.validate.bind(this);
@@ -186,7 +235,7 @@ class ControlledVocab extends React.Component {
       this.actuators = {
         onCreate: this.onCreateItem.bind(this),
         onDelete: this.onDeleteItem.bind(this),
-        onUpdate: this.onUpdateItem.bind(this),
+        onUpdate: this.onUpdateItem.bind(this)
       };
     }
   }
@@ -194,7 +243,7 @@ class ControlledVocab extends React.Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.visibleFields[0] !== prevState.primaryField) {
       return {
-        primaryField: nextProps.visibleFields[0],
+        primaryField: nextProps.visibleFields[0]
       };
     }
 
@@ -204,13 +253,21 @@ class ControlledVocab extends React.Component {
   componentDidUpdate() {
     // build a list of the ids of users who have updated CV items so
     // we can look them up all at once
-    const { stripes, resources: { values: { records } } } = this.props;
+    const {
+      stripes,
+      resources: {
+        values: { records }
+      }
+    } = this.props;
     if (stripes.hasPerm('users.collection.get')) {
       // convert the list of values-plus-metadata to a de-duped list of
       // metadata-userids
-      const userIds = [...new Set(records
-        .filter(r => r.metadata && r.metadata.updatedByUserId)
-        .map(r => `id=="${r.metadata.updatedByUserId}"`))
+      const userIds = [
+        ...new Set(
+          records
+            .filter(r => r.metadata && r.metadata.updatedByUserId)
+            .map(r => `id=="${r.metadata.updatedByUserId}"`)
+        )
       ];
 
       // only query if we have users to look for
@@ -221,19 +278,127 @@ class ControlledVocab extends React.Component {
     }
   }
 
+  // save new or update existing translations keys
+  onSaveTranslations(localeCode, newTranslations) {
+    const record = (
+      (this.props.resources.translations || {}).records || []
+    ).find(loc => loc.localeCode === localeCode);
+
+    if (record && Object.keys(record).length) {
+      this.props.mutator.translationId.replace(record.id);
+      record.messages = Object.assign(record.messages, newTranslations);
+      this.props.mutator.translations.PUT(record);
+    } else {
+      this.props.mutator.translations.POST({
+        localeCode,
+        messages: newTranslations
+      });
+    }
+  }
+
+  // build translation key patern
+  generateNewTranslationKeys(item) {
+    const { translatableFields, appName, tableName } = this.props;
+    const newTrans = {};
+
+    if (translatableFields.length) {
+      translatableFields.forEach(trans => {
+        newTrans[`${appName}.${tableName}.${trans}.${item[trans]}`] =
+          item[trans];
+      });
+    }
+    return newTrans;
+  }
+
+  // in case the library have a pre-defined controlled vocabulary and is not saved on the translations DB
+  generateAllKeys(contentData) {
+    const { translatableFields, appName, tableName } = this.props;
+    const newTrans = {};
+
+    for (const item of contentData) {
+      if (translatableFields.length && appName && tableName) {
+        translatableFields.forEach(trans => {
+          if (item[trans]) {
+            newTrans[`${appName}.${tableName}.${trans}.${item[trans]}`] =
+            item[trans];
+          }
+        });
+      }
+    }
+    return newTrans;
+  }
+
+  onDeleteTranslationKey(selectedItem) {
+    const { translatableFields, appName, tableName } = this.props;
+    const allTranslations =
+      (this.props.resources.translations || {}).records || [];
+
+    const TranslaionsKeys = [];
+
+    translatableFields.forEach(trans => {
+      TranslaionsKeys.push(
+        `${appName}.${tableName}.${trans}.${selectedItem[trans]}`
+      );
+    });
+
+    if (allTranslations) {
+      allTranslations.forEach(loc => {
+        if (loc.messages) {
+          TranslaionsKeys.forEach(key => {
+            delete loc.messages[key];
+          });
+          this.onSaveTranslations(loc.localeCode, loc.messages);
+        }
+      });
+    }
+  }
+
+  // view the translated controlled vocabularies instead of the fetched values
+  getTranslatedFieldsFormater = () => {
+    const { translatableFields, appName, tableName, intl } = this.props;
+    const translatedFieldsFormatter = {};
+    if (translatableFields.length) {
+      translatableFields.forEach(trans => {
+        translatedFieldsFormatter[trans] = item => (item[trans]
+          ? intl.formatMessage({
+            id: `${appName}.${tableName}.${trans}.${item[trans]}`,
+            defaultMessage: item[trans]
+          })
+          : '-');
+      });
+    }
+    return translatedFieldsFormatter;
+  };
+
+  onUpdateOriginalTranslations(item) {
+    const { translatableFields, appName, tableName } = this.props;
+    if (translatableFields.length && appName && tableName) {
+      this.onSaveTranslations('en', this.generateNewTranslationKeys(item));
+    }
+  }
+
   onCreateItem(item) {
-    return this.props.mutator.values.POST(this.props.preCreateHook(item));
+    return this.props.mutator.values
+      .POST(this.props.preCreateHook(item))
+      .then(() => {
+        this.onUpdateOriginalTranslations(item);
+      });
   }
 
   onDeleteItem() {
     const { selectedItem } = this.state;
+    const { translatableFields, appName, tableName } = this.props;
 
     this.props.mutator.activeRecord.update({ id: selectedItem.id });
 
-    return this.props.mutator.values.DELETE({ id: selectedItem.id })
+    return this.props.mutator.values
+      .DELETE({ id: selectedItem.id })
       .then(() => {
         this.showDeletionSuccessCallout(selectedItem);
         this.deleteItemResolve();
+        if (translatableFields.length && appName && tableName) {
+          this.onDeleteTranslationKey(selectedItem);
+        }
       })
       .catch(() => {
         this.setState({ showItemInUseDialog: true });
@@ -244,7 +409,15 @@ class ControlledVocab extends React.Component {
 
   onUpdateItem(item) {
     this.props.mutator.activeRecord.update({ id: item.id });
-    return this.props.mutator.values.PUT(this.props.preUpdateHook(item));
+    return this.props.mutator.values
+      .PUT(this.props.preUpdateHook(item))
+      .then(() => {
+        /*
+         * in this POC, we create a new translation key for the updated vocab without deleting the old translation key.
+         * in incoming releases, we need to handle such scenarios.
+        */
+        this.onUpdateOriginalTranslations(item);
+      });
   }
 
   filteredRows(rows) {
@@ -266,23 +439,25 @@ class ControlledVocab extends React.Component {
   hideConfirmDialog() {
     this.setState({
       showConfirmDialog: false,
-      selectedItem: {},
+      selectedItem: {}
     });
   }
 
   hideItemInUseDialog() {
     this.setState({
       showItemInUseDialog: false,
-      selectedItem: {},
+      selectedItem: {}
     });
   }
 
   showConfirmDialog(itemId) {
-    const selectedItem = this.props.resources.values.records.find(t => t.id === itemId);
+    const selectedItem = this.props.resources.values.records.find(
+      t => t.id === itemId
+    );
 
     this.setState({
       showConfirmDialog: true,
-      selectedItem,
+      selectedItem
     });
 
     return new Promise((resolve, reject) => {
@@ -298,7 +473,7 @@ class ControlledVocab extends React.Component {
           id="stripes-smart-components.cv.termDeleted"
           values={{
             type: this.props.labelSingular,
-            term: item[this.state.primaryField],
+            term: item[this.state.primaryField]
           }}
         />
       );
@@ -319,8 +494,9 @@ class ControlledVocab extends React.Component {
 
         // Check if the primary field has had data entered into it.
         if (!item[primaryField]) {
-          itemErrors[primaryField] =
-            <FormattedMessage id="stripes-core.label.missingRequiredField" />;
+          itemErrors[primaryField] = (
+            <FormattedMessage id="stripes-core.label.missingRequiredField" />
+          );
         }
 
         // Add the errors if we found any for this record.
@@ -343,12 +519,20 @@ class ControlledVocab extends React.Component {
     return (
       <Modal
         open={this.state.showItemInUseDialog}
-        label={<FormattedMessage id="stripes-smart-components.cv.cannotDeleteTermHeader" values={{ type }} />}
+        label={
+          <FormattedMessage
+            id="stripes-smart-components.cv.cannotDeleteTermHeader"
+            values={{ type }}
+          />
+        }
         size="small"
       >
         <Row>
           <Col xs>
-            <FormattedMessage id="stripes-smart-components.cv.cannotDeleteTermMessage" values={{ type }} />
+            <FormattedMessage
+              id="stripes-smart-components.cv.cannotDeleteTermMessage"
+              values={{ type }}
+            />
           </Col>
         </Row>
         <Row>
@@ -362,7 +546,7 @@ class ControlledVocab extends React.Component {
     );
   }
 
-  renderLastUpdated = (metadata) => {
+  renderLastUpdated = metadata => {
     const updaters = this.props.resources.updaters.records || [];
     const record = updaters.find(r => r.id === metadata.updatedByUserId);
 
@@ -379,12 +563,12 @@ class ControlledVocab extends React.Component {
           id="stripes-smart-components.cv.updatedAtAndBy"
           values={{
             date: <FormattedDate value={metadata.updatedDate} />,
-            user,
+            user
           }}
         />
       </div>
     );
-  }
+  };
 
   render() {
     const { values } = this.props.resources;
@@ -401,19 +585,33 @@ class ControlledVocab extends React.Component {
       />
     );
 
-    const rows = this.parseRows(
-      this.filteredRows(values.records || [])
-    );
+    const rows = this.parseRows(this.filteredRows(values.records || []));
 
     const hideList = this.props.listSuppressor && this.props.listSuppressor();
     const dataProps = pickBy(this.props, (_, key) => /^data-test/.test(key));
 
     return (
       <Paneset id={this.id} {...dataProps}>
-        <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
+        <Pane
+          defaultWidth="fill"
+          fluidContentWidth
+          paneTitle={this.props.label}
+          lastMenu={
+            /*
+             * in case the library have a pre-defined controlled vocabulary and is not saved on the translations DB,
+             * the library can create new keys for it from here.
+            */
+            <TranslationsActionsMenu
+              contentData={this.generateAllKeys(rows)}
+              onSaveTranslations={() => this.onSaveTranslations('en', this.generateAllKeys(rows))}
+            />
+          }
+        >
           {this.props.rowFilter}
-          { hideList && this.props.listSuppressorText && <div>{this.props.listSuppressorText}</div> }
-          { !hideList &&
+          {hideList && this.props.listSuppressorText && (
+            <div>{this.props.listSuppressorText}</div>
+          )}
+          {!hideList && (
             <EditableList
               {...this.props}
               // TODO: not sure why we need this OR if there are no groups
@@ -421,39 +619,45 @@ class ControlledVocab extends React.Component {
               // is pulled in. This still causes a JS warning, but not an error
               contentData={rows}
               totalCount={rows.length}
-              createButtonLabel={<FormattedMessage id="stripes-core.button.new" />}
+              createButtonLabel={
+                <FormattedMessage id="stripes-core.button.new" />
+              }
               label={this.props.listFormLabel || this.props.label}
               itemTemplate={this.props.itemTemplate}
               visibleFields={[
                 ...this.props.visibleFields,
                 'lastUpdated',
-                'numberOfObjects',
+                'numberOfObjects'
               ].filter(field => !this.props.hiddenFields.includes(field))}
               columnMapping={{
                 name: this.props.labelSingular,
-                lastUpdated: <FormattedMessage id="stripes-smart-components.cv.lastUpdated" />,
+                lastUpdated: (
+                  <FormattedMessage id="stripes-smart-components.cv.lastUpdated" />
+                ),
                 numberOfObjects: (
                   <FormattedMessage
                     id="stripes-smart-components.cv.numberOfObjects"
                     values={{ objects: this.props.objectLabel }}
                   />
                 ),
-                ...this.props.columnMapping,
+                ...this.props.columnMapping
               }}
               formatter={{
-                lastUpdated: (item) => {
+                lastUpdated: item => {
                   if (item.metadata) {
                     return this.renderLastUpdated(item.metadata);
                   }
-
                   return '-';
                 },
-                ...this.props.formatter,
+                ...Object.assign(
+                  this.props.formatter,
+                  this.getTranslatedFieldsFormater()
+                )
               }}
               readOnlyFields={[
                 ...this.props.readOnlyFields,
                 'lastUpdated',
-                'numberOfObjects',
+                'numberOfObjects'
               ]}
               actionSuppression={this.props.actionSuppressor}
               actionProps={this.props.actionProps}
@@ -462,33 +666,42 @@ class ControlledVocab extends React.Component {
               onDelete={this.showConfirmDialog}
               onSubmit={noop}
               isEmptyMessage={
-                values.isPending
-                  ? <Loading />
-                  : (
-                    <FormattedMessage
-                      id="stripes-smart-components.cv.noExistingTerms"
-                      values={{ terms: this.props.label }}
-                    />
-                  )
+                values.isPending ? (
+                  <Loading />
+                ) : (
+                  <FormattedMessage
+                    id="stripes-smart-components.cv.noExistingTerms"
+                    values={{ terms: this.props.label }}
+                  />
+                )
               }
               validate={this.validate}
             />
-          }
+          )}
           <ConfirmationModal
             id="delete-controlled-vocab-entry-confirmation"
             open={this.state.showConfirmDialog}
-            heading={<FormattedMessage id="stripes-core.button.deleteEntry" values={{ entry: type }} />}
+            heading={
+              <FormattedMessage
+                id="stripes-core.button.deleteEntry"
+                values={{ entry: type }}
+              />
+            }
             message={modalMessage}
             onConfirm={this.actuators.onDelete}
             onCancel={this.hideConfirmDialog}
             confirmLabel={<FormattedMessage id="stripes-core.button.delete" />}
           />
-          { this.renderItemInUseDialog() }
-          <Callout ref={(ref) => { this.callout = ref; }} />
+          {this.renderItemInUseDialog()}
+          <Callout
+            ref={ref => {
+              this.callout = ref;
+            }}
+          />
         </Pane>
       </Paneset>
     );
   }
 }
 
-export default ControlledVocab;
+export default injectIntl(ControlledVocab);

--- a/lib/ControlledVocab/TranslationsActionsMenu/CreateNewKeysModal.js
+++ b/lib/ControlledVocab/TranslationsActionsMenu/CreateNewKeysModal.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  MultiColumnList,
+  ModalFooter,
+  Button,
+  Icon
+} from '@folio/stripes-components';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+function CreateNewKeysModal(props) {
+  const intl = useIntl();
+
+  const renderFooter = () => {
+    return (
+      <ModalFooter>
+        <Button
+          buttonStyle="primary"
+          onClick={props.onSave}
+          disabled={!Object.keys(props.contentData).length}
+        >
+          <Icon icon="save" size="large">
+            <FormattedMessage id="stripes-core.button.save" />
+          </Icon>
+        </Button>
+        <Button buttonStyle="slim" onClick={props.onClose}>
+          <Icon icon="times-circle-solid" size="large">
+            <FormattedMessage id="stripes-core.button.cancel" />
+          </Icon>
+        </Button>
+      </ModalFooter>
+    );
+  };
+
+  const renderConfirmationModal = () => {
+    const newKeysArray = [];
+
+    for (const key in props.contentData) {
+      if (key) {
+        const translationObj = {};
+        translationObj.keyName = key;
+        translationObj.keyValue = props.contentData[key];
+        newKeysArray.push(translationObj);
+      }
+    }
+
+    return (
+      <Modal
+        footer={renderFooter()}
+        open={props.open}
+        onClose={props.onClose}
+        label={
+          <Icon icon="plus-sign" size="large">
+            <FormattedMessage id="stripes-smart-components.translationsActionsMenu.createNewKeysModal.label" />
+          </Icon>
+        }
+      >
+        <MultiColumnList
+          interactive={false}
+          contentData={newKeysArray}
+          visibleColumns={['keyName', 'keyValue']}
+          columnWidths={{ keyName: '50%', keyValue: '50%' }}
+          columnMapping={{
+            keyName: intl.formatMessage({
+              id:
+                'stripes-smart-components.translationsActionsMenu.createNewKeysModal.keyName'
+            }),
+            keyValue: intl.formatMessage({
+              id:
+                'stripes-smart-components.translationsActionsMenu.createNewKeysModal.keyValue'
+            })
+          }}
+        />
+      </Modal>
+    );
+  };
+
+  return <>{renderConfirmationModal()}</>;
+}
+
+CreateNewKeysModal.propTypes = {
+  contentData: PropTypes.object,
+  onClose: PropTypes.func,
+  onSave: PropTypes.func,
+  open: PropTypes.bool
+};
+
+export default CreateNewKeysModal;

--- a/lib/ControlledVocab/TranslationsActionsMenu/TranslationsActionsMenu.js
+++ b/lib/ControlledVocab/TranslationsActionsMenu/TranslationsActionsMenu.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Dropdown, DropdownMenu, Icon, NavList, NavListItem, NavListSection } from '@folio/stripes-components';
+import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes-core';
+import CreateNewKeysModal from './CreateNewKeysModal';
+
+function TranslationsActionsMenu(props) {
+  const [dropdownOpen, setdropdownOpen] = useState(false);
+  const [openNewKeysModal, setOpenNewKeysModal] = useState(false);
+
+  const toggleDropdown = () => {
+    setdropdownOpen(!dropdownOpen);
+  };
+
+  const handleClose = () => {
+    setOpenNewKeysModal(false);
+  };
+
+  const renderCreateNewKeysModal = () => {
+    return (
+      <CreateNewKeysModal
+        onClose={handleClose}
+        onSave={() => {
+          props.onSaveTranslations();
+          handleClose();
+        }}
+        open={openNewKeysModal}
+        contentData={props.contentData}
+      />
+    );
+  };
+
+  const getDropdownContent = () => {
+    return (
+      <>
+        <NavList>
+          <NavListSection>
+            <IfPermission perm="ui-translations.create">
+              <NavListItem
+                id="clickable-create-new-translation-keys"
+                type="button"
+                onClick={() => setOpenNewKeysModal(true)}
+              >
+                <Icon icon="plus-sign">
+                  <FormattedMessage
+                    id="stripes-smart-components.translationsActionsMenu.createNewKeysModal.label"
+                  />
+                </Icon>
+              </NavListItem>
+            </IfPermission>
+          </NavListSection>
+        </NavList>
+      </>
+    );
+  };
+
+  const renderActionsMenuTrigger = ({ getTriggerProps }) => {
+    return (
+      <FormattedMessage id="stripes-smart-components.translationsActionsMenu.ariaLabel">
+        {label => (
+          <div style={{ paddingRight: '0.25em', paddingLeft: '0.25em' }}>
+            <Button
+              data-test-pane-header-actions-button
+              buttonStyle="primary"
+              marginBottom0
+              ariaLabel={label}
+              type="button"
+              {...getTriggerProps()}
+            >
+              <Icon icon="ellipsis" size="large" />
+            </Button>
+          </div>
+        )}
+      </FormattedMessage>
+    );
+  };
+
+  const renderActionsMenu = ({ open }) => (
+    <DropdownMenu open={open}>{getDropdownContent()}</DropdownMenu>
+  );
+
+  const renderDropdownComponent = () => {
+    return (
+      <Dropdown
+        id="editableList-actionsMenu-Dropdown"
+        renderTrigger={renderActionsMenuTrigger}
+        renderMenu={renderActionsMenu}
+        open={dropdownOpen}
+        onToggle={toggleDropdown}
+        placement="bottom-end"
+        relativePosition
+        focusHandlers={{ open: () => null }}
+      />
+    );
+  };
+
+  return (
+    <>
+      {renderCreateNewKeysModal()}
+      {renderDropdownComponent()}
+    </>
+  );
+}
+
+TranslationsActionsMenu.propTypes = {
+  contentData: PropTypes.object.isRequired,
+  onSaveTranslations: PropTypes.func.isRequired
+};
+
+export default TranslationsActionsMenu;

--- a/lib/ControlledVocab/TranslationsActionsMenu/index.js
+++ b/lib/ControlledVocab/TranslationsActionsMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from './TranslationsActionsMenu';

--- a/translations/stripes-smart-components/ar.json
+++ b/translations/stripes-smart-components/ar.json
@@ -268,5 +268,9 @@
     "notes.popupModal.delete": "حذف الملاحظة",
     "notes.close": "إغلاق",
     "customFields.noCustomFieldsFound": "لم يتم العثور على حقول مخصصة",
-    "customFields.fieldValue.whitespace": "غير مسموح بالمسافة البيضاء فقط."
+    "customFields.fieldValue.whitespace": "غير مسموح بالمسافة البيضاء فقط.",
+
+    "translationsActionsMenu.createNewKeysModal.label": "إنشاء مفاتيح ترجمة جديده",
+    "translationsActionsMenu.createNewKeysModal.keyName": "مفتاح الترجمة",
+    "translationsActionsMenu.createNewKeysModal.keyValue": "القيمة"
 }

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -271,5 +271,9 @@
 
   "clipCopy.success": "Successfully copied \"{text}\" to clipboard.",
 
-  "columnManager.showColumns": "Show columns"
+  "columnManager.showColumns": "Show columns",
+
+  "translationsActionsMenu.createNewKeysModal.label": "Create new translations keys",
+  "translationsActionsMenu.createNewKeysModal.keyName": "Key name",
+  "translationsActionsMenu.createNewKeysModal.keyValue": "Key Value"
 }


### PR DESCRIPTION
## Description
Each FOLIO installation has lists of controlled vocabulary terms (for instance, “Formats” and “Resource types” in Inventory, “Patron Groups” and “Refund Reasons” in Users — see FOLIO-2802 for a more complete list).  In installations that use more than one language, these terms do not display translated values when the locale of the session is changed.

## Use case(s)
More than one component has been monitored to control the library-defined controlled vocabularies, such as:
* ControlledVocab component.
* EntryManager component.

...This PR is for a ControlledVocab component, and more PRs for all the appropriate components will be added later.

## Workflow
For the complete translation workflow, see [Workflow](https://github.com/folio-org/ui-translations/blob/master/README.md#workflow)

## Jira Related Issues Links
https://issues.folio.org/browse/UXPROD-3148 <br />
https://issues.folio.org/browse/FOLIO-3258 <br />
https://issues.folio.org/browse/UXPROD-515 <br />
https://issues.folio.org/browse/FOLIO-2802