### PR TITLE
STSMACOM-542: Add disabled prop for LocationLookup component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## [7.0.1] (IN PROGRESS)
+
+* Add disabled prop for `<LocationLookup>` component.
+
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)
 

--- a/lib/LocationLookup/LocationLookup.js
+++ b/lib/LocationLookup/LocationLookup.js
@@ -8,6 +8,7 @@ import LocationModal from './LocationModal';
 class LocationLookup extends React.Component {
   static propTypes = {
     isTemporaryLocation: PropTypes.bool,
+    disabled: PropTypes.bool,
     label: PropTypes.node,
     marginBottom0: PropTypes.bool,
     onLocationSelected: PropTypes.func.isRequired,
@@ -38,7 +39,7 @@ class LocationLookup extends React.Component {
   }
 
   render() {
-    const { label, marginBottom0, onLocationSelected, isTemporaryLocation, stripes, ...rest } = this.props;
+    const { label, marginBottom0, onLocationSelected, isTemporaryLocation, stripes, disabled, ...rest } = this.props;
 
     return (
       <div>
@@ -48,6 +49,7 @@ class LocationLookup extends React.Component {
           buttonStyle="link"
           marginBottom0={marginBottom0}
           onClick={this.openModal}
+          disabled={disabled}
         >
           {label}
         </Button>


### PR DESCRIPTION
# STSMACOM-542: Add prop to disable LocationLookup component

Issue: [STSMACOM-542](https://issues.folio.org/browse/STSMACOM-542)

Need to story [UIIN-1639](https://issues.folio.org/browse/UIIN-1639)

Related [PR](https://github.com/folio-org/ui-inventory/pull/1468)

