### PR TITLE
STSMACOM-546 lock to axe-core 4.3.3 to avoid test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add disabled prop for `<LocationLookup>` component.
 * Config Manager | Apply baseline keyboard shortcuts. Refs STSMACOM-544.
+* Lock to `axe-core` `4.3.3`; `4.3.4` causes test failures in CI/CD.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@folio/stripes-logger": "^1.0.0",
     "@folio/stripes-util": "^5.0.0",
     "@formatjs/cli": "^4.2.20",
-    "axe-core": "^4.0.2",
+    "axe-core": "4.3.3",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.5",


### PR DESCRIPTION
`axe-core` `4.3.4` causes test failures here on the master branch that `4.3.3` does not. 

From https://github.com/dequelabs/axe-core/issues/3241: 
>  it seems we released something from develop that shouldn't have been there yet. 

We should look at this again in a few weeks and hope to revert this PR. Locking directly onto a patch version is not great. 

Refs [STSMACOM-546](https://issues.folio.org/browse/STSMACOM-546)