### PR TITLE
Change next release version from 7.0.1 to 7.1.0 to avoid confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-smart-components
 
-## [7.0.1] (IN PROGRESS)
+## [7.1.0] (IN PROGRESS)
 
 * Add disabled prop for `<LocationLookup>` component.
 * Config Manager | Apply baseline keyboard shortcuts. Refs STSMACOM-544.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": [


### PR DESCRIPTION
## Description
Change future release version to `7.1.0` so that no one thinks that these changes require release for Kiwi Bugfix