### PR TITLE
STSMACOM-606: Add id attribute to Note elements that are used in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Lock to `axe-core` `4.3.3`; `4.3.4` causes test failures in CI/CD.
 * Use correct `css-loader` syntax. Refs STSMACOM-545.
 * Apply baseline keyboard shortcuts for controlled vocabulary. Refs STSMACOM-548.
+* Add id attribute to Note elements that are used in e2e tests. Refs STSMACOM-606.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/Notes/NoteViewPage/NoteViewPage.js
+++ b/lib/Notes/NoteViewPage/NoteViewPage.js
@@ -26,6 +26,7 @@ class NoteViewPage extends Component {
   static propTypes = {
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
     entityTypeTranslationKeys: PropTypes.objectOf(PropTypes.string),
+    id: PropTypes.string,
     intl: PropTypes.shape({
       formatMessage: PropTypes.isRequired,
     }).isRequired,
@@ -54,6 +55,10 @@ class NoteViewPage extends Component {
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
     }),
+  }
+
+  static defaultProps = {
+    id: 'pane-note-view',
   }
 
   static manifest = Object.freeze({
@@ -233,6 +238,7 @@ class NoteViewPage extends Component {
       navigateBack,
       stripes,
       intl,
+      id,
     } = this.props;
 
     if (!stripes.hasPerm('ui-notes.item.view')) {
@@ -251,6 +257,7 @@ class NoteViewPage extends Component {
         {([pageTitle]) => (
           <TitleManager record={pageTitle}>
             <NoteView
+              id={id}
               renderReferredRecord={renderReferredRecord}
               referredEntityData={referredEntityData}
               entityTypeTranslationKeys={entityTypeTranslationKeys}

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -39,6 +39,7 @@ export default class NoteView extends Component {
   static propTypes = {
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
     entityTypeTranslationKeys: PropTypes.objectOf(PropTypes.string),
+    id: PropTypes.string,
     noteData: noteDataShape,
     noteMetadata: PropTypes.shape({
       createdBy: PropTypes.string,
@@ -202,6 +203,7 @@ export default class NoteView extends Component {
       entityTypePluralizedTranslationKeys,
       paneHeaderAppIcon,
       noteMetadata,
+      id,
     } = this.props;
 
     const {
@@ -218,6 +220,7 @@ export default class NoteView extends Component {
     return (
       <Paneset>
         <Pane
+          id={id}
           data-test-note-view
           paneTitle={paneTitle}
           appIcon={paneTitleAppIcon}

--- a/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
+++ b/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
@@ -75,6 +75,7 @@ export default class NoteFields extends Component {
         <Row>
           <Col xs={12}>
             <Field
+              id="note-details-field"
               name="content"
               type="text"
               editorRef={detailsEditorRef}


### PR DESCRIPTION
## Description
Add `id` to some elements to make it's easier to query them in e2e tests

## Issues
[STSMACOM-606](https://issues.folio.org/browse/STSMACOM-606)
