### PR TITLE
STSMACOM-615 - Add preferred name to the Proxy Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Apply baseline keyboard shortcuts for controlled vocabulary. Refs STSMACOM-548.
 * Add id attribute to Note elements that are used in e2e tests. Refs STSMACOM-606.
 * Update internal state in SASQ when sort changes. Fixes STSMACOM-614.
+* Add preferred name to the Proxy Modal. Fixes STSMACOM-615.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/ProxyManager/proxyUtil.js
+++ b/lib/ProxyManager/proxyUtil.js
@@ -18,7 +18,11 @@ export function isRequestForSponsorInvalid(user, proxyMap) {
 }
 
 export function getFullName(user) {
-  return `${get(user, ['personal', 'lastName'], '')},
-    ${get(user, ['personal', 'firstName'], '')}
-    ${get(user, ['personal', 'middleName'], '')}`;
+  const lastName = get(user, ['personal', 'lastName'], '');
+  const firstName = get(user, ['personal', 'firstName'], '');
+  const middleName = get(user, ['personal', 'middleName'], '');
+  const preferredFirstName = get(user, ['personal', 'preferredFirstName'], '');
+  const displayedFirstName = preferredFirstName || firstName;
+
+  return `${lastName}${displayedFirstName ? ', ' : ' '}${displayedFirstName} ${middleName}`;
 }


### PR DESCRIPTION
## Purpose
As a staff user,
I want to see the patron's preferred first name in the Proxy Modal
so that I might address the patron properly.

## Approach
condition, included preferredFirstName has been added to the getFullName function

## Refs
https://issues.folio.org/browse/STSMACOM-615