### PR TITLE
STSMACOM-617 Settings : Move focus to second pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update internal state in SASQ when sort changes. Fixes STSMACOM-614.
 * Add preferred name to the Proxy Modal. Fixes STSMACOM-615.
 * Lint
+* Settings : Move focus to second pane. Refs STSMACOM-617
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -46,6 +46,15 @@ class Settings extends Component {
     });
   }
 
+  navigateTo(link) {
+    this.props.history.push(link);
+  }
+
+  // checks first focusable item in first section
+  isFirstFocusableElement(sectionIndex, itemIndex) {
+    return sectionIndex === 0 && itemIndex === 0;
+  }
+
   render() {
     const props = this.props;
     const stripes = props.stripes;
@@ -53,14 +62,25 @@ class Settings extends Component {
     let { activeLink } = this.props;
 
     // links in a given section
-    const navlinks = (section) => {
-      const navItems = section.pages.map((p) => {
+    const navlinks = (section, sectionIndex) => {
+      const navItems = section.pages.map((p, itemIndex) => {
         const link = `${props.match.path}/${p.route}`;
+
         if (props.location.pathname.startsWith(link)) {
           activeLink = link;
         }
+
         if (p.perm && !stripes.hasPerm(p.perm)) return null;
-        return <NavListItem key={p.route} to={link}>{p.label}</NavListItem>;
+
+        return (
+          <NavListItem
+            key={p.route}
+            onClick={() => this.navigateTo(link)}
+            autoFocus={this.isFirstFocusableElement(sectionIndex, itemIndex)}
+          >
+            {p.label}
+          </NavListItem>
+        );
       }).filter(x => x !== null);
 
       return (
@@ -101,7 +121,7 @@ class Settings extends Component {
                 key={index}
                 aria-label={id}
               >
-                {navlinks(section)}
+                {navlinks(section, index)}
               </NavList>
             );
           })
@@ -121,6 +141,9 @@ Settings.propTypes = {
   additionalRoutes: PropTypes.arrayOf(
     PropTypes.object.isRequired,
   ),
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }),
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-617

## Problem
In the current implementation, when you click on the link in the "settings" panel, the focus does not switch to the newly opened one. 

![current](https://issues.folio.org/secure/attachment/43487/fixed.gif)

## Solution
- Add an onClick prop that makes the element focusable
- When rendering a block, focus on the first element of the first section. 

![fixed](https://issues.folio.org/secure/attachment/43487/fixed.gif)