### PR TITLE
STSMACOM-618 lower-case all data-test-... attributes

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.js
@@ -136,7 +136,7 @@ const AddressEdit = (props) => {
       <Col
         key={`col-${i}`}
         xs={4}
-        {...{ [`data-test-${field}`]: true }}
+        {...{ [`data-test-${field.toLowerCase()}`]: true }}
       >
         <Field label={fieldLabel} name={field} {...compProps} component={component} validate={validate} />
       </Col>);

--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -91,7 +91,7 @@ class AddressEditList extends React.Component {
     const { formType } = this.props;
 
     return (
-      <div className={css.addressEditList} data-test-addressList-container>
+      <div className={css.addressEditList} data-test-address-list-container>
         <Row>
           <Col xs>
             <div className={css.legend} id="addressGroupLabel">{this.props.label}</div>

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -308,7 +308,7 @@ class AddressList extends React.Component {
     }
 
     return (
-      <div data-test-addressList-container>
+      <div data-test-address-list-container>
         <Headline tag="h4" size="medium">{label}</Headline>
         {addAddressButton}
         <div
@@ -324,7 +324,7 @@ class AddressList extends React.Component {
             <div style={{ marginTop: '8px' }}>
               <Row>
                 <Col xs={12}>
-                  <Button fullWidth data-test-addresslist-toggle onClick={this.onToggleExpansion}>
+                  <Button fullWidth data-test-address-list-toggle onClick={this.onToggleExpansion}>
                     {!this.state.expanded ? (
                       <Layout className="flex centerContent">
                         <Icon icon="arrow-down" />

--- a/lib/AddressFieldGroup/tests/interactor.js
+++ b/lib/AddressFieldGroup/tests/interactor.js
@@ -5,11 +5,11 @@ import {
 import { TextField as TextFieldInteractor } from '@folio/stripes-testing';
 
 export default interactor(class AddressEditInteractor {
-  addressType= scoped('[data-test-addressType]', TextFieldInteractor('Address Type'));
-  addressLine1= scoped('[data-test-addressLine1]', TextFieldInteractor('Address Line 1'));
-  addressLine2= scoped('[data-test-addressLine2]', TextFieldInteractor('Address Line 2'));
-  stateRegion= scoped('[data-test-stateRegion]', TextFieldInteractor('State/Prov/Region'));
-  zipCode= scoped('[data-test-zipCode]', TextFieldInteractor('Zip/Postal Code'));
-  country= scoped('[data-test-country]', TextFieldInteractor('Country'));
-  city= scoped('[data-test-city]', TextFieldInteractor('City'));
+  addressType = scoped('[data-test-addresstype]', TextFieldInteractor('Address Type'));
+  addressLine1 = scoped('[data-test-addressline1]', TextFieldInteractor('Address Line 1'));
+  addressLine2 = scoped('[data-test-addressline2]', TextFieldInteractor('Address Line 2'));
+  stateRegion = scoped('[data-test-stateregion]', TextFieldInteractor('State/Prov/Region'));
+  zipCode = scoped('[data-test-zipcode]', TextFieldInteractor('Zip/Postal Code'));
+  country = scoped('[data-test-country]', TextFieldInteractor('Country'));
+  city = scoped('[data-test-city]', TextFieldInteractor('City'));
 });


### PR DESCRIPTION
React assumes DOM attributes with mixed case are react props and issues
a console warning about those it doesn't recognize:

> Warning: React does not recognize the `data-test-addressList-container`
> prop on a DOM element. If you intentionally want it to appear in the
> DOM as a custom attribute, spell it as lowercase `data-test-addresslist-container`
> instead. If you accidentally passed it from a parent component,
> remove it from the DOM element.

This must be merged after https://github.com/folio-org/stripes-testing/pull/171

Refs [UITEST-87](https://issues.folio.org/browse/UITEST-87), [STSMACOM-618](https://issues.folio.org/browse/STSMACOM-618)