### PR TITLE
STSMACOM-619 correctly specify LayoutHeader props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update internal state in SASQ when sort changes. Fixes STSMACOM-614.
 * Add preferred name to the Proxy Modal. Fixes STSMACOM-615.
 * Lint
+* Correctly specify `LayoutHeader` shape in `AddressEditGroup`. Refs STSMACOM-619.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/AddressFieldGroup/AddressView/AddressView.js
@@ -79,7 +79,7 @@ function AddressView(props) {
   }, this);
 
   const actions = [{
-    title: <FormattedMessage id="stripes-components.editThisAddress" />,
+    name: <FormattedMessage id="stripes-components.editThisAddress" />,
     icon: 'edit',
     handler: () => handleEdit(uiId)
   }];


### PR DESCRIPTION
Use the correct shape for the objects in the `actions` prop for
`LayoutHeader`. Discovered while reviewing _entirely_ unrelated changes
in #1163.

Refs [STSMACOM-619](https://issues.folio.org/browse/STSMACOM-619), [STCOM-914](https://issues.folio.org/browse/STCOM-914)