### PR TITLE
Upgrade entry manager tests

### DIFF
--- a/lib/EntryManager/tests/entry-manager-test.js
+++ b/lib/EntryManager/tests/entry-manager-test.js
@@ -1,10 +1,19 @@
 import React from 'react';
 import { expect } from 'chai';
-import { beforeEach, describe, it } from '@bigtest/mocha';
+import { beforeEach, describe, it } from 'mocha';
 import { Response } from 'miragejs';
+import {
+  EntryManager as Interactor,
+  NavList,
+  EntryForm,
+  Callout,
+  EntryDetails,
+  Button,
+  Modal,
+  converge,
+} from '@folio/stripes-testing';
 import { mount, setupApplication } from '../../../tests/helpers';
 
-import EntryManagerInteractor from './interactor';
 import {
   ConnectedComponent,
   paneTitle,
@@ -16,7 +25,7 @@ import {
   entryLabel,
 } from './constants';
 
-const entryManagerInteractor = new EntryManagerInteractor();
+const entryManagerInteractor = Interactor();
 
 function mountErr(response) {
   mount(
@@ -66,90 +75,65 @@ describe('Entry Manager', () => {
     });
 
     describe('EntryManager', () => {
-      it('should be presented', () => {
-        expect(entryManagerInteractor.isPresent).to.be.true;
-      });
+      it('should be presented', () => entryManagerInteractor.exists());
 
       describe('nav list', () => {
-        it('should be presented', () => {
-          expect(entryManagerInteractor.navList.isPresent).to.be.true;
-        });
+        it('should be presented', () => NavList().exists());
 
-        it('should have proper amount of items', () => {
-          expect(entryManagerInteractor.navList.items().length).to.equal(entryList.length);
-        });
+        it('should have proper amount of items', () => NavList().has({ count: entryList.length }));
 
         describe('add new item', () => {
           beforeEach(async () => {
-            await entryManagerInteractor.newItemButton.click();
+            await entryManagerInteractor.createEntry();
           });
 
-          it('entry form should be presented', () => {
-            expect(entryManagerInteractor.entryForm.isPresent).to.be.true;
-          });
+          it('entry form should be presented', () => EntryForm().exists());
 
           describe('error callout', () => {
             beforeEach(async () => {
-              await entryManagerInteractor.entryForm.entryFormSave();
+              await EntryForm().save();
             });
 
-            it('callout should be shown', () => {
-              expect(entryManagerInteractor.calloutElement.isPresent).to.be.true;
-            });
+            it('callout should be shown', () => Callout().exists());
           });
         });
 
         describe('first item select', () => {
           beforeEach(async () => {
-            await entryManagerInteractor.navList.items(0).click();
-            await entryManagerInteractor.detailsSection.whenLoaded();
+            await entryManagerInteractor.navTo(entryList[0].name);
+            await converge(() => EntryDetails().exists());
           });
 
           describe('details section', () => {
-            it('should be presented', () => {
-              expect(entryManagerInteractor.detailsSection.isPresent).to.be.true;
-            });
-
-            it('actions bbutton should be presented', () => {
-              expect(entryManagerInteractor.detailsSection.actionsButton.isPresent).to.be.true;
-            });
+            it('actions button should be presented', () => Button('Actions').exists());
 
             describe('actions dropdown', () => {
               describe('item edit', () => {
                 beforeEach(async () => {
-                  await entryManagerInteractor.detailsSection.actionsButton.click();
-                  await entryManagerInteractor.detailsSection.actionsDropdown.whenDeleteLoaded();
-                  await entryManagerInteractor.detailsSection.actionsDropdown.edit.click();
+                  await Button('Actions').click();
+                  await Button('Edit').click();
                 });
 
-                it('entry form should be presented', () => {
-                  expect(entryManagerInteractor.entryForm.isPresent).to.be.true;
-                });
+                it('entry form should be presented', () => EntryForm().exists());
               });
 
               describe('item duplication', () => {
                 beforeEach(async () => {
-                  await entryManagerInteractor.detailsSection.actionsButton.click();
-                  await entryManagerInteractor.detailsSection.actionsDropdown.whenDeleteLoaded();
-                  await entryManagerInteractor.detailsSection.actionsDropdown.duplicate.click();
+                  await Button('Actions').click();
+                  await Button('Duplicate').click();
                 });
 
-                it('entry form should be presented', () => {
-                  expect(entryManagerInteractor.entryForm.isPresent).to.be.true;
-                });
+                it('entry form should be presented', () => EntryForm().exists());
               });
             });
 
             describe('item deletion prohibit modal', () => {
               beforeEach(async () => {
-                await entryManagerInteractor.detailsSection.actionsButton.click();
-                await entryManagerInteractor.detailsSection.actionsDropdown.whenDeleteLoaded();
-                await entryManagerInteractor.detailsSection.actionsDropdown.delete.click();
+                await Button('Actions').click();
+                await Button('Delete').click();
               });
 
-              it('should not be presented', () => {
-                expect(entryManagerInteractor.isProhibitDeleteModalOpen).to.be.false;
-              });
+              it('should not be presented', () => Modal('Delete entryLabel').exists());
             });
           });
         });
@@ -184,14 +168,12 @@ describe('Entry Manager', () => {
 
     describe('item edit button click', () => {
       beforeEach(async () => {
-        await entryManagerInteractor.navList.items(0).click();
-        await entryManagerInteractor.detailsSection.whenLoaded();
-        await entryManagerInteractor.detailsSection.editItemButton.click();
+        await entryManagerInteractor.navTo(entryList[0].name);
+        await converge(() => EntryDetails().exists());
+        await Button('Edit').click();
       });
 
-      it('entry form should be presented', () => {
-        expect(entryManagerInteractor.entryForm.isPresent).to.be.true;
-      });
+      it('entry form should be presented', () => EntryForm().exists());
     });
   });
 
@@ -210,23 +192,17 @@ describe('Entry Manager', () => {
     setupApplication({ scenarios: ['entry-manager-dublication-error'] });
     beforeEach(async () => {
       mountErr(resp422);
-      await entryManagerInteractor.newItemButton.click();
+      await entryManagerInteractor.createEntry();
     });
 
     describe('error callout', () => {
       beforeEach(async () => {
-        await entryManagerInteractor.entryForm.entryFormSave();
+        await EntryForm().save();
       });
 
-      it('callout should be shown', () => {
-        expect(entryManagerInteractor.calloutElement.isPresent).to.be.true;
-      });
+      it('callout should be shown', () => Callout().exists());
 
-      it('callout should display error message', () => {
-        const { errorMessage } = entryManagerInteractor.calloutElement;
-
-        expect(errorMessage).to.equal('Cannot create entity; name is not unique');
-      });
+      it('callout should display error message', () => Callout('Cannot create entity; name is not unique').exists());
     });
   });
 
@@ -238,23 +214,17 @@ describe('Entry Manager', () => {
     setupApplication({ scenarios: ['controlled-vocab-default-error'] });
     beforeEach(async () => {
       mountErr(resp400);
-      await entryManagerInteractor.newItemButton.click();
+      await entryManagerInteractor.createEntry();
     });
 
     describe('error callout', () => {
       beforeEach(async () => {
-        await entryManagerInteractor.entryForm.entryFormSave();
+        await EntryForm().save();
       });
 
-      it('callout should be shown', () => {
-        expect(entryManagerInteractor.calloutElement.isPresent).to.be.true;
-      });
+      it('callout should be shown', () => Callout().exists());
 
-      it('callout should display error message', () => {
-        const { errorMessage } = entryManagerInteractor.calloutElement;
-
-        expect(errorMessage).to.equal('400 Bad Request');
-      });
+      it('callout should display error message', () => Callout('400 Bad Request').exists());
     });
   });
 });

--- a/lib/EntryManager/tests/entry-manager-test.js
+++ b/lib/EntryManager/tests/entry-manager-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { Response } from 'miragejs';
 import {


### PR DESCRIPTION
Upgrading these to new interactors exported from `@folio/stripes-testing`.

I can imagine that we could find a way to *still make an entry manager interactor work for those entry manager that are rolled from scratch at the ui-module level...
A nav list, a button, callout are mostly the built-in interactors that are needed, along with some special ones to cover your `[data-test-whatever]` (or possibly better) containing elements.

Require a merge request on stripes-testing.