### PR TITLE
STSMACOM-620: Add additional prop in SearchAndSort

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -90,10 +90,7 @@ class SearchAndSort extends React.Component {
     columnWidths: PropTypes.object,
     createRecordPath: PropTypes.string,
     customPaneSub: PropTypes.node,
-    customPaneSubText: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element
-    ]),
+    customPaneSubText: PropTypes.node,
     detailProps: PropTypes.object,
     disableFilters: PropTypes.object,
     disableRecordCreation: PropTypes.bool,
@@ -215,7 +212,7 @@ class SearchAndSort extends React.Component {
     resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
-    searchFieldButtonLabel: PropTypes.string,
+    searchFieldButtonLabel: PropTypes.node,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
     sortableColumns: PropTypes.arrayOf(PropTypes.string),
@@ -1064,7 +1061,7 @@ class SearchAndSort extends React.Component {
           disabled={!searchTerm}
           data-test-search-and-sort-submit
         >
-          <FormattedMessage id={searchFieldButtonLabel || 'stripes-smart-components.search'} />
+          {searchFieldButtonLabel || <FormattedMessage id="stripes-smart-components.search" />}
         </Button>
         {this.renderResetButton()}
         {
@@ -1191,10 +1188,7 @@ class SearchAndSort extends React.Component {
             <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />
           )}
           {!isSourceLoaded && (
-            customPaneSubText ?
-              <FormattedMessage id={customPaneSubText} />
-              :
-              <FormattedMessage id="stripes-smart-components.searchCriteria" />
+            customPaneSubText || <FormattedMessage id="stripes-smart-components.searchCriteria" />
           )}
         </span>
         {customPaneSub && (

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -90,6 +90,7 @@ class SearchAndSort extends React.Component {
     columnWidths: PropTypes.object,
     createRecordPath: PropTypes.string,
     customPaneSub: PropTypes.node,
+    customPaneSubText: PropTypes.string,
     detailProps: PropTypes.object,
     disableFilters: PropTypes.object,
     disableRecordCreation: PropTypes.bool,
@@ -211,6 +212,7 @@ class SearchAndSort extends React.Component {
     resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
+    searchFiledButtonLabel: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
     sortableColumns: PropTypes.arrayOf(PropTypes.string),
@@ -1058,7 +1060,7 @@ class SearchAndSort extends React.Component {
           disabled={!searchTerm}
           data-test-search-and-sort-submit
         >
-          <FormattedMessage id="stripes-smart-components.search" />
+          <FormattedMessage id={this.props.searchFiledButtonLabel || 'stripes-smart-components.search'} />
         </Button>
         {this.renderResetButton()}
         {
@@ -1166,6 +1168,7 @@ class SearchAndSort extends React.Component {
     const {
       customPaneSub,
       resultCountMessageKey,
+      customPaneSubText,
     } = this.props;
 
     const messageKey = resultCountMessageKey || 'stripes-smart-components.searchResultsCountHeader';
@@ -1184,6 +1187,9 @@ class SearchAndSort extends React.Component {
             <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />
           )}
           {!isSourceLoaded && (
+            customPaneSubText?
+            <FormattedMessage id={customPaneSubText} />
+            :
             <FormattedMessage id="stripes-smart-components.searchCriteria" />
           )}
         </span>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -90,7 +90,10 @@ class SearchAndSort extends React.Component {
     columnWidths: PropTypes.object,
     createRecordPath: PropTypes.string,
     customPaneSub: PropTypes.node,
-    customPaneSubText: PropTypes.string,
+    customPaneSubText: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
+    ]),
     detailProps: PropTypes.object,
     disableFilters: PropTypes.object,
     disableRecordCreation: PropTypes.bool,
@@ -212,7 +215,7 @@ class SearchAndSort extends React.Component {
     resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object),
     searchableIndexesPlaceholder: PropTypes.string,
-    searchFiledButtonLabel: PropTypes.string,
+    searchFieldButtonLabel: PropTypes.string,
     selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
     sortableColumns: PropTypes.arrayOf(PropTypes.string),
@@ -1016,6 +1019,7 @@ class SearchAndSort extends React.Component {
       searchableIndexes,
       selectedIndex,
       autofocusSearchField,
+      searchFieldButtonLabel,
     } = this.props;
     const {
       locallyChangedSearchTerm,
@@ -1060,7 +1064,7 @@ class SearchAndSort extends React.Component {
           disabled={!searchTerm}
           data-test-search-and-sort-submit
         >
-          <FormattedMessage id={this.props.searchFiledButtonLabel || 'stripes-smart-components.search'} />
+          <FormattedMessage id={searchFieldButtonLabel || 'stripes-smart-components.search'} />
         </Button>
         {this.renderResetButton()}
         {
@@ -1187,10 +1191,10 @@ class SearchAndSort extends React.Component {
             <FormattedMessage id={messageKey} values={{ count: source.totalCount() }} />
           )}
           {!isSourceLoaded && (
-            customPaneSubText?
-            <FormattedMessage id={customPaneSubText} />
-            :
-            <FormattedMessage id="stripes-smart-components.searchCriteria" />
+            customPaneSubText ?
+              <FormattedMessage id={customPaneSubText} />
+              :
+              <FormattedMessage id="stripes-smart-components.searchCriteria" />
           )}
         </span>
         {customPaneSub && (

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -65,6 +65,8 @@ resultsOnMarkPosition | func | sets the `onMarkPosition` prop to the internally 
 resultsOnResetMarkedPosition | func | sets the `onMarkReset` prop to the internally rendered `<MultiColumnList>` component. It can be used to nullify the "position" object in application state. 
 resultsCachedPosition | position object |  sets the `ItemToView` prop of the internally rendered `<MultiColumnList>` component. It's in the shape of `{selector: string, clientTopOffset: number}`. This object is provided by the `resultsOnMarkPosition` prop.
 resultsKey | string | Sets a `key` prop on the internally rendered `<MultiColumnList>`. Changing this value will re-initialize the MCL. If necessary, this can be used to refresh the component so that it resets/readjusts to updates in data. This should be used sparingly as it can cause multiple re-renders of the list.
+customPaneSubText | node | A component that will be rendered in PaneSubHeader instead of default.
+searchFieldButtonLabel | node | A component that will be rendered inside the SearchField button instead of default.
 
 
 See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui-users/blob/master/Users.js) for an example of how to use `<SearchAndSort>`.


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-620

*Problem*

We need to have the ability to change paneSubTitle when props change and change the text in the button in SearchFiled. All that needs to be done in the scope of the Browse call numbers feature.

*Solution*

Simple add additional props in SearchAndSort components.