### PR TITLE
STSMACOM-622: Introduce useCustomFields hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update internal state in SASQ when sort changes. Fixes STSMACOM-614.
 * Add preferred name to the Proxy Modal. Fixes STSMACOM-615.
 * Lint
+* Introduce `useCustomFields` hook. Refs STSMACOM-622.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ export { default as ViewCustomFieldsSettings } from './lib/CustomFields/pages/Vi
 export { default as EditCustomFieldsSettings } from './lib/CustomFields/pages/EditCustomFieldsSettings';
 export { default as EditCustomFieldsRecord } from './lib/CustomFields/pages/EditCustomFieldsRecord';
 export { default as ViewCustomFieldsRecord } from './lib/CustomFields/pages/ViewCustomFieldsRecord';
+export { default as useCustomFields } from './lib/CustomFields/utils/useCustomFields';
 
 export * from './lib/ColumnManager';
 export * from './lib/utils';

--- a/lib/CustomFields/utils/index.js
+++ b/lib/CustomFields/utils/index.js
@@ -4,3 +4,4 @@ export { default as useLoadingErrorCallout } from './useLoadingErrorCallout';
 export { default as useSectionTitleFetch } from './useSectionTitleFetch';
 export { default as validateCustomFields } from './validateCustomFields';
 export { default as useOptionsStatsFetch } from './useOptionsStatsFetch';
+export { default as useCustomFields } from './useCustomFields';

--- a/lib/CustomFields/utils/useCustomFields.js
+++ b/lib/CustomFields/utils/useCustomFields.js
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+
+import { useStripes } from '@folio/stripes-core';
+
+import useCustomFieldsFetch from './useCustomFieldsFetch';
+import { selectModuleId } from '../selectors';
+
+/**
+ * A hook which loads custom fields for a given module and entity.
+ *
+ * @param {String} moduleName - used to set correct `x-okapi-module-id` header when making
+ * requests to `mod-custom-fields`.
+ * @param {String} entityType - used to filter custom files by particular entity type
+ *
+ * @return {array} - Return array in a format: [data, isLoading, error]
+ *
+ * Example usage:
+ *
+ * const [data, isLoading, error] = useCustomFields('users', 'user');
+ *
+*/
+const useCustomFields = (moduleName, entityType) => {
+  const { store: { getState }, okapi } = useStripes();
+  const state = getState();
+  const moduleId = useMemo(() => selectModuleId(state, moduleName), [state, moduleName]);
+  const {
+    customFields,
+    customFieldsLoaded,
+    customFieldsFetchFailed,
+  } = useCustomFieldsFetch(okapi, moduleId, entityType);
+
+  return [
+    customFields,
+    !customFieldsLoaded,
+    customFieldsFetchFailed,
+  ];
+};
+
+export default useCustomFields;


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-622

In order to accomplish the work described in  https://issues.folio.org/browse/UIU-2170 we need a way to fetch custom fields for a specific module. The retrieval of custom fields is a bit exotic since it attaches a special header to the request but the good news is that there are already helpers which can be utilized to create a reusable hook. This PR just does that.