### PR TITLE
STSMACOM-626 Add the ability to override onNeedMore method and add missing props

### DIFF
--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -75,6 +75,11 @@ export default class StripesConnectedSource {
     // ... and stripes-connect notices this change and does the rest by magic
   }
 
+  fetchByQuery(query) {
+    this.mutator.resultOffset.replace(0);
+    this.mutator.query.replace({ query });
+  }
+
   // fetch by offset which is passed in as index.
   fetchOffset(index) {
     this.mutator.resultOffset.replace(index);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -164,7 +164,7 @@ class SearchAndSort extends React.Component {
     }),
     pageAmount: PropTypes.number,
     paginationBoundaries: PropTypes.bool,
-    pagingType: PropTypes.string, // only needed when GraphQL is used
+    pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
       query: PropTypes.shape({
@@ -204,8 +204,8 @@ class SearchAndSort extends React.Component {
     }).isRequired,
     path: PropTypes.string,
     queryFunction: PropTypes.func,
-    renderFilters: PropTypes.func, // collection to be exploded and passed on to the detail view
-    renderNavigation: PropTypes.func, // URL path to parse for detail views
+    renderFilters: PropTypes.func,
+    renderNavigation: PropTypes.func,
     resultCountIncrement: PropTypes.number.isRequired,
     resultCountMessageKey: PropTypes.string,
     resultRowFormatter: PropTypes.func,
@@ -217,8 +217,8 @@ class SearchAndSort extends React.Component {
     resultsOnNeedMore: PropTypes.func,
     resultsOnResetMarkedPosition: PropTypes.func,
     resultsVirtualize: PropTypes.bool,
-    searchableIndexes: PropTypes.arrayOf(PropTypes.object), // whether to auto-show the details record when a search returns a single row
-    searchableIndexesPlaceholder: PropTypes.string, // whether to auto-show the details record when a search returns a single row
+    searchableIndexes: PropTypes.arrayOf(PropTypes.object),
+    searchableIndexesPlaceholder: PropTypes.string,
     searchFieldButtonLabel: PropTypes.node,
     selectedIndex: PropTypes.string,
     showSingleResult: PropTypes.bool, // whether to auto-show the details record when a search returns a single row

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -151,7 +151,6 @@ class SearchAndSort extends React.Component {
     onCreate: PropTypes.func,
     onDismissDetail: PropTypes.func,
     onFilterChange: PropTypes.func,
-    onNeedMore: PropTypes.func,
     onResetAll: PropTypes.func,
     onSelectRow: PropTypes.func,
     packageInfo: PropTypes.shape({ // values pulled from the provider's package.json config object
@@ -164,8 +163,8 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
-    paginationEnabled: PropTypes.bool, // only needed when GraphQL is used
-    pagingType: PropTypes.string,
+    paginationBoundaries: PropTypes.bool,
+    pagingType: PropTypes.string, // only needed when GraphQL is used
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
       query: PropTypes.shape({
@@ -204,9 +203,9 @@ class SearchAndSort extends React.Component {
       resultCount: PropTypes.number,
     }).isRequired,
     path: PropTypes.string,
-    queryFunction: PropTypes.func, // collection to be exploded and passed on to the detail view
-    renderFilters: PropTypes.func, // URL path to parse for detail views
-    renderNavigation: PropTypes.func,
+    queryFunction: PropTypes.func,
+    renderFilters: PropTypes.func, // collection to be exploded and passed on to the detail view
+    renderNavigation: PropTypes.func, // URL path to parse for detail views
     resultCountIncrement: PropTypes.number.isRequired,
     resultCountMessageKey: PropTypes.string,
     resultRowFormatter: PropTypes.func,
@@ -215,6 +214,7 @@ class SearchAndSort extends React.Component {
     resultsFormatter: PropTypes.shape({}),
     resultsKey: PropTypes.string,
     resultsOnMarkPosition: PropTypes.func,
+    resultsOnNeedMore: PropTypes.func,
     resultsOnResetMarkedPosition: PropTypes.func,
     resultsVirtualize: PropTypes.bool,
     searchableIndexes: PropTypes.arrayOf(PropTypes.object), // whether to auto-show the details record when a search returns a single row
@@ -593,22 +593,19 @@ class SearchAndSort extends React.Component {
     }
   };
 
-  // вынести эту логику в родительский компонент
-  // добавить 2 пропса в компонент с пагинацией
-
   onNeedMore = (askAmount, index, firstIndex, direction) => {
     const {
       parentMutator: { resultOffset },
       stripes: { logger },
       resultCountIncrement,
-      onNeedMore
+      resultsOnNeedMore
     } = this.props;
     const source = makeConnectedSource(this.props, logger);
 
-    if (onNeedMore) {
+    if (resultsOnNeedMore) {
       const records = source.records();
 
-      onNeedMore({ records, source, direction, index, firstIndex, askAmount });
+      resultsOnNeedMore({ records, source, direction, index, firstIndex, askAmount });
     } else {
       // If module provides offset mutator and index parameter, opt-in to fetch by offset.
       if (resultOffset && index >= 0) {
@@ -1134,7 +1131,7 @@ class SearchAndSort extends React.Component {
       resultRowFormatter,
       hasRowClickHandlers,
       hideCount,
-      paginationEnabled
+      paginationBoundaries
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1192,7 +1189,7 @@ class SearchAndSort extends React.Component {
             itemToView={resultsCachedPosition}
             isSelected={resultRowIsSelected}
             hideCount={hideCount}
-            paginationEnabled={paginationEnabled}
+            paginationBoundaries={paginationBoundaries}
           />
         )}
       </FormattedMessage>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -118,7 +118,7 @@ class SearchAndSort extends React.Component {
     getHelperResourcePath: PropTypes.func,
     hasNewButton: PropTypes.bool,
     hasRowClickHandlers: PropTypes.bool,
-    hideCount: PropTypes.bool,
+    hidePageIndices: PropTypes.bool,
     history: PropTypes.shape({ // provided by withRouter
       push: PropTypes.func.isRequired,
     }).isRequired,
@@ -1130,7 +1130,7 @@ class SearchAndSort extends React.Component {
       resultsOnResetMarkedPosition,
       resultRowFormatter,
       hasRowClickHandlers,
-      hideCount,
+      hidePageIndices,
       paginationBoundaries
     } = this.props;
     const {
@@ -1188,7 +1188,7 @@ class SearchAndSort extends React.Component {
             onMarkReset={resultsOnResetMarkedPosition}
             itemToView={resultsCachedPosition}
             isSelected={resultRowIsSelected}
-            hideCount={hideCount}
+            hidePageIndices={hidePageIndices}
             paginationBoundaries={paginationBoundaries}
           />
         )}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -118,6 +118,7 @@ class SearchAndSort extends React.Component {
     getHelperResourcePath: PropTypes.func,
     hasNewButton: PropTypes.bool,
     hasRowClickHandlers: PropTypes.bool,
+    hideCount: PropTypes.bool,
     history: PropTypes.shape({ // provided by withRouter
       push: PropTypes.func.isRequired,
     }).isRequired,
@@ -150,6 +151,7 @@ class SearchAndSort extends React.Component {
     onCreate: PropTypes.func,
     onDismissDetail: PropTypes.func,
     onFilterChange: PropTypes.func,
+    onNeedMore: PropTypes.func,
     onResetAll: PropTypes.func,
     onSelectRow: PropTypes.func,
     packageInfo: PropTypes.shape({ // values pulled from the provider's package.json config object
@@ -162,6 +164,7 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
+    paginationEnabled: PropTypes.bool, // only needed when GraphQL is used
     pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
@@ -175,7 +178,7 @@ class SearchAndSort extends React.Component {
       resultOffset: PropTypes.shape({
         replace: PropTypes.func.isRequired,
       }),
-    }).isRequired, // only needed when GraphQL is used
+    }).isRequired,
     parentResources: PropTypes.shape({
       query: PropTypes.shape({
         filters: PropTypes.string,
@@ -201,11 +204,11 @@ class SearchAndSort extends React.Component {
       resultCount: PropTypes.number,
     }).isRequired,
     path: PropTypes.string,
-    queryFunction: PropTypes.func,
-    renderFilters: PropTypes.func,
+    queryFunction: PropTypes.func, // collection to be exploded and passed on to the detail view
+    renderFilters: PropTypes.func, // URL path to parse for detail views
     renderNavigation: PropTypes.func,
-    resultCountIncrement: PropTypes.number.isRequired, // collection to be exploded and passed on to the detail view
-    resultCountMessageKey: PropTypes.string, // URL path to parse for detail views
+    resultCountIncrement: PropTypes.number.isRequired,
+    resultCountMessageKey: PropTypes.string,
     resultRowFormatter: PropTypes.func,
     resultRowIsSelected: PropTypes.func,
     resultsCachedPosition: PropTypes.object,
@@ -214,12 +217,10 @@ class SearchAndSort extends React.Component {
     resultsOnMarkPosition: PropTypes.func,
     resultsOnResetMarkedPosition: PropTypes.func,
     resultsVirtualize: PropTypes.bool,
-    searchableIndexes: PropTypes.arrayOf(PropTypes.object),
-    searchableIndexesPlaceholder: PropTypes.string,
+    searchableIndexes: PropTypes.arrayOf(PropTypes.object), // whether to auto-show the details record when a search returns a single row
+    searchableIndexesPlaceholder: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     searchFieldButtonLabel: PropTypes.node,
     selectedIndex: PropTypes.string,
-    showSingleResult: PropTypes.bool, // whether to auto-show the details record when a search returns a single row    
-    selectedIndex: PropTypes.string, // whether to auto-show the details record when a search returns a single row
     showSingleResult: PropTypes.bool,
     sortableColumns: PropTypes.arrayOf(PropTypes.string),
     stripes: PropTypes.shape({
@@ -592,19 +593,29 @@ class SearchAndSort extends React.Component {
     }
   };
 
-  onNeedMore = (askAmount, index) => {
+  // вынести эту логику в родительский компонент
+  // добавить 2 пропса в компонент с пагинацией
+
+  onNeedMore = (askAmount, index, firstIndex, direction) => {
     const {
       parentMutator: { resultOffset },
       stripes: { logger },
       resultCountIncrement,
+      onNeedMore
     } = this.props;
     const source = makeConnectedSource(this.props, logger);
 
-    // If module provides offset mutator and index parameter, opt-in to fetch by offset.
-    if (resultOffset && index >= 0) {
-      source.fetchOffset(index);
+    if (onNeedMore) {
+      const records = source.records();
+
+      onNeedMore({ records, source, direction, index, firstIndex, askAmount });
     } else {
-      source.fetchMore(resultCountIncrement);
+      // If module provides offset mutator and index parameter, opt-in to fetch by offset.
+      if (resultOffset && index >= 0) {
+        source.fetchOffset(index);
+      } else {
+        source.fetchMore(resultCountIncrement);
+      }
     }
   };
 
@@ -1122,6 +1133,8 @@ class SearchAndSort extends React.Component {
       resultsOnResetMarkedPosition,
       resultRowFormatter,
       hasRowClickHandlers,
+      hideCount,
+      paginationEnabled
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1178,6 +1191,8 @@ class SearchAndSort extends React.Component {
             onMarkReset={resultsOnResetMarkedPosition}
             itemToView={resultsCachedPosition}
             isSelected={resultRowIsSelected}
+            hideCount={hideCount}
+            paginationEnabled={paginationEnabled}
           />
         )}
       </FormattedMessage>
@@ -1268,7 +1283,6 @@ class SearchAndSort extends React.Component {
         data-test-search-and-sort
       >
         <SRStatus ref={(ref) => { this.SRStatus = ref; }} />
-
         {/* Filter Pane */}
         {filterPaneIsVisible &&
           <Pane


### PR DESCRIPTION
In scope of 

https://issues.folio.org/browse/UIIN-1890
https://issues.folio.org/browse/UIIN-1897

issues,  we should be able to override the onNeedMore method and set new props for prev-next pagination.

Pagination was extended in https://issues.folio.org/browse/STCOM-923 