### PR TITLE
STSMACOM-549 UI-Users bombs out when adding new loan owner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Lint
 * Introduce `useCustomFields` hook. Refs STSMACOM-622.
 * Add `paneTitleRef` prop to the `Settings` component. Refs STSMACOM-623.
+* Fix issue with EditableList crashing when a new item is added. Fixes STSMACOM-549.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -55,6 +55,10 @@ const propTypes = {
    */
   columnWidths: PropTypes.object,
   /**
+   * Collection of items to render.
+   */
+  contentData: PropTypes.arrayOf(PropTypes.object),
+  /**
    * Label for the 'Add' button
    */
   createButtonLabel: PropTypes.node,
@@ -174,13 +178,15 @@ const defaultProps = {
   validate: noop,
 };
 
+const buildStatusArray = (items = []) => items.map(() => ({ editing: false, error: false }));
+
 class EditableListForm extends React.Component {
   constructor(props) {
     super(props);
 
     let status = [];
     if (props.initialValues) {
-      status = this.buildStatusArray(props.initialValues.items);
+      status = buildStatusArray(props.initialValues.items);
     }
 
     this.state = {
@@ -191,7 +197,6 @@ class EditableListForm extends React.Component {
 
     this.RenderItems = this.RenderItems.bind(this);
     this.setError = this.setError.bind(this);
-    this.buildStatusArray = this.buildStatusArray.bind(this);
     this.getColumnWidths = this.getColumnWidths.bind(this);
     this.getVisibleColumns = this.getVisibleColumns.bind(this);
     this.getReadOnlyColumns = this.getReadOnlyColumns.bind(this);
@@ -205,16 +210,14 @@ class EditableListForm extends React.Component {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.initialValues, nextProps.initialValues)) {
-      this.setState({
-        status: this.buildStatusArray(nextProps.initialValues.items),
-      });
+  static getDerivedStateFromProps(props, state) {
+    if (!state.status) {
+      return {
+        status: buildStatusArray(props.initialValues.items)
+      };
     }
-  }
 
-  buildStatusArray(items) {
-    return items.map(() => ({ editing: false, error: false }));
+    return null;
   }
 
   onAdd(fields) {
@@ -225,7 +228,7 @@ class EditableListForm extends React.Component {
     this.setState((curState) => {
       const newState = cloneDeep(curState);
       if (newState.status.length === 0 && fields.length > 0) {
-        newState.status = this.buildStatusArray();
+        newState.status = buildStatusArray();
         newState.creating = true;
       }
       newState.status.unshift({ editing: true, error: false });
@@ -386,13 +389,10 @@ class EditableListForm extends React.Component {
   }
 
   toggleEdit(index) {
-    if (this.state.status.length === 0) {
-      this.buildStatusArray();
-    }
     this.setState((curState) => {
       const newState = cloneDeep(curState);
       if (newState.status.length === 0) {
-        newState.status = this.buildStatusArray();
+        newState.status = buildStatusArray(this.props.contentData);
       }
       newState.status[index].editing = !newState.status[index].editing;
       newState.lastAction = new Date().getTime();

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -210,6 +210,7 @@ class EditableListForm extends React.Component {
     }
   }
 
+  // needed for instances where initialValues arrive AFTER initialization.
   static getDerivedStateFromProps(props, state) {
     if (!state.status) {
       return {
@@ -391,7 +392,7 @@ class EditableListForm extends React.Component {
   toggleEdit(index) {
     this.setState((curState) => {
       const newState = cloneDeep(curState);
-      if (newState.status.length === 0) {
+      if (!newState.status[index]) {
         newState.status = buildStatusArray(this.props.contentData);
       }
       newState.status[index].editing = !newState.status[index].editing;


### PR DESCRIPTION
### Pro'lem: 
If no initial values were provided, the lifecycle for syncing items would bomb out since `isEqual` doesn't do well at handling `undefined` parameters (just returns false in those cases) and so the underlying logic would attempt to access a property of the undefined value.

### Refresher: 
`EditableList` uses an internal array to track the editing state of items that has to be kept in sync with its props.

### Approach:
Sure, we could have just done a check for the existence of `props.initialValues` and called it a day... but no, them UNSAFE lifecycles gotta go. Moved the `buildStatusArray` function outside of the component, set up the old gDSFP function to handle async initial values, and made sure to sync things appropriately when items were edited, re-building the status array where necessary.

2 birds with one stone: fix the bug, remove a deprecated lifecycle.

Tests look good, interaction seems good. Hopefully no other stones show up....