### PR TITLE
STSMACOM-628 Settings : Move focus to second pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Introduce `useCustomFields` hook. Refs STSMACOM-622.
 * Add `paneTitleRef` prop to the `Settings` component. Refs STSMACOM-623.
 * Fix issue with EditableList crashing when a new item is added. Fixes STSMACOM-549.
+* Settings : Move focus to second pane. Refs STSMACOM-628
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -4,7 +4,18 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { isEqual, uniqueId, pickBy, noop } from 'lodash';
 
-import { Button, Callout, Col, ConfirmationModal, Modal, Pane, Paneset, Row, Loading } from '@folio/stripes-components';
+import {
+  Button,
+  Callout,
+  Col,
+  ConfirmationModal,
+  Modal,
+  Pane,
+  Paneset,
+  Row,
+  Loading,
+  getFirstFocusable
+} from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
@@ -307,6 +318,10 @@ class ControlledVocab extends React.Component {
     }
   }
 
+  handlePaneFocus({ paneRef }) {
+    getFirstFocusable(paneRef.current).focus();
+  }
+
   validate({ items }) {
     const { primaryField } = this.state;
 
@@ -410,7 +425,12 @@ class ControlledVocab extends React.Component {
 
     return (
       <Paneset id={this.id} {...dataProps}>
-        <Pane defaultWidth="fill" fluidContentWidth paneTitle={this.props.label}>
+        <Pane
+          defaultWidth="fill"
+          fluidContentWidth
+          paneTitle={this.props.label}
+          onMount={this.handlePaneFocus}
+        >
           {this.props.rowFilter}
           { hideList && this.props.listSuppressorText && <div>{this.props.listSuppressorText}</div> }
           { !hideList &&

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -19,7 +19,8 @@ import {
   PaneMenu,
   Paneset,
   ConfirmationModal,
-  Modal, getFirstFocusable,
+  Modal,
+  getFirstFocusable,
 } from '@folio/stripes-components';
 
 class EntrySelector extends React.Component {

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -19,7 +19,7 @@ import {
   PaneMenu,
   Paneset,
   ConfirmationModal,
-  Modal,
+  Modal, getFirstFocusable,
 } from '@folio/stripes-components';
 
 class EntrySelector extends React.Component {
@@ -209,6 +209,10 @@ class EntrySelector extends React.Component {
     this.changeDeleteState(false);
   }
 
+  handlePaneFocus = ({ paneRef }) => {
+    getFirstFocusable(paneRef.current).focus();
+  }
+
   renderDetail(item) {
     const {
       detailPaneTitle,
@@ -258,6 +262,7 @@ class EntrySelector extends React.Component {
         defaultWidth={paneWidth}
         dismissible
         onClose={this.onClose}
+        onMount={this.handlePaneFocus}
       >
         <ComponentToRender
           {...this.props}
@@ -355,7 +360,7 @@ class EntrySelector extends React.Component {
 
     return (
       <Paneset defaultWidth={paneSetWidth} data-test-entry-manager>
-        <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle}>
+        <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle} onMount={this.handlePaneFocus}>
           {this.props.rowFilter}
           <NavList>
             <NavListSection activeLink={this.activeLink(links)} className={contentData.length ? 'hasEntries' : ''}>

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -47,7 +47,7 @@ class Settings extends Component {
     });
   }
 
-  handlePaneFocus = (paneRef) => {
+  handlePaneFocus = ({ paneRef }) => {
     getFirstFocusable(paneRef.current).focus();
   }
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -8,6 +8,7 @@ import {
 import { withStripes } from '@folio/stripes-core';
 import NavListItem from '@folio/stripes-components/lib/NavListItem';
 import {
+  getFirstFocusable,
   NavList,
   NavListSection,
   Pane,
@@ -44,6 +45,10 @@ class Settings extends Component {
         }));
       this.routes = [...this.routes, ...sectionRoutes];
     });
+  }
+
+  handlePaneFocus = (paneRef) => {
+    getFirstFocusable(paneRef.current).focus();
   }
 
   render() {
@@ -88,6 +93,7 @@ class Settings extends Component {
           paneTitle={props.paneTitle || 'Module Settings'}
           firstMenu={<PaneBackLink to="/settings" />}
           paneTitleRef={props.paneTitleRef}
+          onMount={this.handlePaneFocus}
         >
           {this.sections.map((section, index) => {
             const {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-617

## Problem
In the current implementation, when you click on the link in the "settings" panel, the focus does not switch to the newly opened one. 

![current](https://issues.folio.org/secure/attachment/43487/fixed.gif)

## Solution
- Add an focus to first focusable element in Pane

![fixed](https://issues.folio.org/secure/attachment/43487/fixed.gif)