### PR TITLE
STSMACOM-629: Bump location query limits to 5000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Change focus on ConfigManager mount. Refs STSMACOM-631.
 * Accessibility: Document has multiple static elements with the same ID attribute. Refs STSMACOM-630.
 * Settings : Move focus to second pane. Refs STSMACOM-628
+* Bump `<LocationModal>` location query limits to 5000. Fixes STSMACOM-629.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -128,7 +128,7 @@ export default class LocationModal extends React.Component {
   fetchInstitutions() {
     const params = {
       query: 'cql.allRecords=1 sortby name',
-      limit: '1000',
+      limit: '5000',
     };
 
     this.props.mutator.institutions.reset();
@@ -153,7 +153,7 @@ export default class LocationModal extends React.Component {
 
     const params = {
       query: `(campusId=="${campusId}") sortby name`,
-      limit: '1000',
+      limit: '5000',
     };
 
     this.props.mutator.libraries.GET({ params }).then((libraries) => {
@@ -172,7 +172,7 @@ export default class LocationModal extends React.Component {
 
     const params = {
       query: `(libraryId=="${libraryId}") sortby name`,
-      limit: '1000',
+      limit: '5000',
     };
 
     this.props.mutator.locations.GET({ params }).then((locations) => {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-629

Believe it or not, some library systems have more than 2,000 libraries. Let's hope there aren't any with more than 5,000. This is the "dead-simple/deal-with-it-later fix", as Zak put it.