### PR TITLE
STSMACOM-513 refactor away from react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add `paneTitleRef` prop to the `Settings` component. Refs STSMACOM-623.
 * Fix issue with EditableList crashing when a new item is added. Fixes STSMACOM-549.
 * Settings : Move focus to second pane. Refs STSMACOM-628
+* Refactor from `react-intl-safe-html` to `react-intl`. Refs STSMACOM-513.
 
 ## [7.0.0](https://github.com/folio-org/stripes-smart-components/tree/v7.0.0) (2021-09-27)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v6.1.0...v7.0.0)

--- a/lib/ChangeDueDateDialog/ChangeDueDate.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDate.js
@@ -5,7 +5,6 @@ import { FormattedMessage } from 'react-intl';
 import moment from 'moment-timezone';
 
 import { Button, Icon, Layout } from '@folio/stripes-components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import DueDatePicker from './DueDatePicker';
 import LoanList from './LoanList';
@@ -260,7 +259,7 @@ class ChangeDueDate extends React.Component {
       <div>
         <p role="alert">
           { loans.length > 1 ?
-            <SafeHTMLMessage
+            <FormattedMessage
               id="stripes-smart-components.cddd.itemsSelected"
               values={{ count: numSelectedLoans }}
             /> : null

--- a/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
+++ b/lib/ChangeDueDateDialog/ChangeDueDateSuccess.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button, Icon, Layout } from '@folio/stripes-components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import LoanList from './LoanList';
 
@@ -46,7 +45,7 @@ class ChangeDueDateSuccess extends React.Component {
         { numFailed > 0 ?
           <p role="alert">
             <Icon size="medium" icon="check-circle" status="success" />
-            <SafeHTMLMessage
+            <FormattedMessage
               id="stripes-smart-components.cddd.changeSucceededWithFailures"
               values={{
                 succeeded: numSucceeded,
@@ -56,7 +55,7 @@ class ChangeDueDateSuccess extends React.Component {
           </p> :
           <p role="alert">
             <Icon size="medium" icon="check-circle" status="success" />
-            <SafeHTMLMessage
+            <FormattedMessage
               id="stripes-smart-components.cddd.changeSucceededWithCount"
               values={{ succeeded: numSucceeded }}
             />

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -16,7 +16,6 @@ import {
   Loading,
   getFirstFocusable
 } from '@folio/stripes-components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import EditableList from '../EditableList';
 import css from './ControlledVocab.css';
@@ -305,7 +304,7 @@ class ControlledVocab extends React.Component {
   showDeletionSuccessCallout(item) {
     if (this.callout) {
       const message = (
-        <SafeHTMLMessage
+        <FormattedMessage
           id="stripes-smart-components.cv.termDeleted"
           values={{
             type: this.props.labelSingular,
@@ -410,7 +409,7 @@ class ControlledVocab extends React.Component {
     const term = this.state.selectedItem[this.state.primaryField];
 
     const modalMessage = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-smart-components.cv.termWillBeDeleted"
         values={{ type, term }}
       />

--- a/lib/CustomFields/components/CustomFieldsForm/components/DeleteModal/DeleteModal.js
+++ b/lib/CustomFields/components/CustomFieldsForm/components/DeleteModal/DeleteModal.js
@@ -10,8 +10,6 @@ import {
   Layout,
 } from '@folio/stripes-components';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
-
 const propTypes = {
   fetchUsageStatistics: PropTypes.func.isRequired,
   fieldsToDelete: PropTypes.arrayOf(PropTypes.shape({
@@ -86,7 +84,7 @@ const DeleteModal = ({
 
   const renderDeleteList = () => usageStatistics.map(({ name, count, fieldId }) => (
     <div key={fieldId} data-test-custom-field-delete-warning>
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-smart-components.customFields.delete.warning"
         values={{
           fieldName: name,
@@ -117,7 +115,7 @@ const DeleteModal = ({
             key={`${fieldId}_${optionData.value}`}
             data-test-custom-field-option-delete-warning
           >
-            <SafeHTMLMessage
+            <FormattedMessage
               id="stripes-smart-components.customFields.option.delete.warning"
               values={{
                 fieldName,

--- a/lib/EntryManager/EntryForm.js
+++ b/lib/EntryManager/EntryForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { Button, ConfirmationModal, Pane, PaneMenu, Paneset } from '@folio/stripes-components';
 import stripesForm from '@folio/stripes-form';
 
@@ -122,7 +121,7 @@ class EntryForm extends React.Component {
       }
     }
     const message = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-core.label.confirmDeleteEntry"
         values={{
           name: selectedEntry[this.props.nameKey] || <FormattedMessage id="stripes-core.untitled" />,

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -7,7 +7,6 @@ import {
 } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { IfPermission } from '@folio/stripes-core';
 import {
   Button,
@@ -282,7 +281,7 @@ class EntrySelector extends React.Component {
             />
           )}
           message={(
-            <SafeHTMLMessage
+            <FormattedMessage
               id="stripes-core.label.confirmDeleteEntry"
               values={{
                 name: item[nameKey] || <FormattedMessage id="stripes-core.untitled" />,

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { omit } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
@@ -173,7 +172,7 @@ export default class EntryWrapper extends React.Component {
     }
 
     const message = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-smart-components.success.message"
         values={{
           entry: this.props.entryLabel,

--- a/lib/Notes/NoteViewPage/NoteViewPage.js
+++ b/lib/Notes/NoteViewPage/NoteViewPage.js
@@ -7,7 +7,6 @@ import {
 import { Redirect } from 'react-router';
 import { get, cloneDeep } from 'lodash';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   stripesConnect,
   TitleManager,
@@ -147,7 +146,7 @@ class NoteViewPage extends Component {
     return (
       <>
         <span data-test-delete-confirmation-message>
-          <SafeHTMLMessage
+          <FormattedMessage
             id="stripes-smart-components.notes.delete.confirm.message"
             values={{ title, resourcesNumber: links.length }}
           />
@@ -160,7 +159,7 @@ class NoteViewPage extends Component {
     const { title } = this.state.note;
 
     return (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="stripes-smart-components.notes.unassign.confirm.message"
         values={{ title }}
       />

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "stylelint-junit-formatter": "^0.2.1"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.0.0",
     "@rehooks/local-storage": "2.4.0",
     "classnames": "^2.2.6",
     "final-form": "^4.18.2",


### PR DESCRIPTION
`<SafeHTMLMessage>` is no longer necessary as `<FormattedMessage>` knows
all its tricks for handling HTML.

Refs [STSMACOM-513](https://issues.folio.org/browse/STSMACOM-513), [STRIPES-754](https://issues.folio.org/browse/STRIPES-754)