### PR TITLE
STSMACOM-637: Do not push to history if the url did not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.2.0 IN PROGRESS
 
 * Additional bump to `<LocationModal>` location query limits to 5000. Fixes STSMACOM-629.
+* Do not push to history if the url didn't change in `<SearchAndSortQuery>`. Fixes STSMACOM-637.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -17,8 +17,14 @@ import {
 import buildUrl from './buildUrl';
 
 const locationQuerySetter = ({ location, history, nsValues }) => {
+  const { pathname, search } = location;
   const url = buildUrl(location, nsValues);
-  history.push(url);
+
+  // Do not push to history if the url didn't change
+  // https://issues.folio.org/browse/STSMACOM-637
+  if (`${pathname}${search}` !== url) {
+    history.push(url);
+  }
 };
 
 const locationQueryGetter = ({ location }) => {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-637

I noticed this bug when working on lazy loading. The ui-courses would just go into an infinite loop and keep re-rendering and reloading all resources. This happens because `SearchAndSortQuery` execs `history.push` for the same url as the current location url.