### PR TITLE
STSMACOM-638 tests must not inspect NoValue's DOM structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.2.0 IN PROGRESS
 
 * Additional bump to `<LocationModal>` location query limits to 5000. Fixes STSMACOM-629.
+* Tests must not inspect `<NoValue>`'s rendered state. Refs STSMACOM-638.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -20,6 +20,9 @@ describe('ViewCustomFieldsRecord', () => {
   const onToggle = sinon.spy();
 
   const renderComponent = (props = {}) => {
+    // note the default scenario has five fields, one for each type,
+    // but only four values are present here, so the TEXTBOX_LONG
+    // field (textarea-1) will be rendered on the view-page via NoValue.
     return mount(
       <ViewCustomFieldsRecord
         accordionId="some-accordion-id"
@@ -59,7 +62,7 @@ describe('ViewCustomFieldsRecord', () => {
     expect(a11yResults.violations).to.be.empty;
   });
 
-  it('should display corrent number of fields', () => {
+  it('should display current number of fields', () => {
     expect(viewCustomFields.fields().length).to.equal(5);
   });
 
@@ -68,7 +71,7 @@ describe('ViewCustomFieldsRecord', () => {
   });
 
   it('should display dash for fields without a value', () => {
-    expect(viewCustomFields.fields(1).value).to.equal('-');
+    expect(viewCustomFields.fields(1).hasNoValue.isPresent).to.be.true;
   });
 
   it('should show multiple value for multiselect with several values', () => {

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -71,7 +71,7 @@ describe('ViewCustomFieldsRecord', () => {
   });
 
   it('should display dash for fields without a value', () => {
-    expect(viewCustomFields.fields(1).hasNoValue.isPresent).to.be.true;
+    expect(viewCustomFields.fields(1).hasNoValue).to.be.true;
   });
 
   it('should show multiple value for multiselect with several values', () => {

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
@@ -3,7 +3,6 @@ import {
   text,
   collection,
   isPresent,
-  scoped
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
@@ -15,7 +14,7 @@ export default interactor(class ViewCustomFieldsRecord {
   fields = collection('[data-test-col-custom-field]', {
     label: text('[class^='),
     value: text('[data-test-kv-value]'),
-    hasNoValue: scoped('[data-test-kv-value]', NoValueInteractor),
+    hasNoValue: isPresent(`[data-test-kv-value] ${NoValueInteractor.defaultScope}`),
   });
 
   whenFieldsAreVisible() {

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
@@ -7,7 +7,7 @@ import {
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
-import { NoValueInteractor } from '@folio/stripes-components/lib/NoValue/tests/interactor';
+import NoValueInteractor from '@folio/stripes-components/lib/NoValue/tests/interactor';
 
 export default interactor(class ViewCustomFieldsRecord {
   accordion = new AccordionInteractor('#some-accordion-id');

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/interactor.js
@@ -3,9 +3,11 @@ import {
   text,
   collection,
   isPresent,
+  scoped
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+import { NoValueInteractor } from '@folio/stripes-components/lib/NoValue/tests/interactor';
 
 export default interactor(class ViewCustomFieldsRecord {
   accordion = new AccordionInteractor('#some-accordion-id');
@@ -13,6 +15,7 @@ export default interactor(class ViewCustomFieldsRecord {
   fields = collection('[data-test-col-custom-field]', {
     label: text('[class^='),
     value: text('[data-test-kv-value]'),
+    hasNoValue: scoped('[data-test-kv-value]', NoValueInteractor),
   });
 
   whenFieldsAreVisible() {

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
@@ -7,6 +7,7 @@ import {
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 import MetaSectionInteractor from '@folio/stripes-components/lib/MetaSection/tests/interactor';
+import NoValueInteractor from '@folio/stripes-components/lib/NoValue/tests/interactor';
 
 import ReferredRecordInteractor from '../../../../components/ReferredRecord/tests/interactor';
 
@@ -22,4 +23,6 @@ export default interactor(class NoteViewInteractor {
   noteType = text('[data-test-note-view-note-type]');
   noteTitle = text('[data-test-note-view-note-title]');
   metaSection = new MetaSectionInteractor();
+  emptyNoteType = scoped('[data-test-note-view-note-type]', NoValueInteractor);
+  emptyNoteTitle = scoped('[data-test-note-view-note-title]', NoValueInteractor);
 });

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
@@ -85,11 +85,11 @@ describe('NoteView', () => {
     });
 
     it('should display correct note type', () => {
-      expect(noteView.noteType).to.equal('-');
+      expect(noteView.emptyNoteType.isPresent).to.be.true;
     });
 
     it('should display correct note title', () => {
-      expect(noteView.noteTitle).to.equal('-');
+      expect(noteView.emptyNoteTitle.isPresent).to.be.true;
     });
   });
 


### PR DESCRIPTION
How a component renders in the DOM is considered private and thus is
subject to change without warning. Nonetheless, some tests inspected
the DOM to assess whether a `<NoValue>` component had been rendered, and
when its internal state changed these tests began to fail.

Assess the presence of `<NoValue>` via its interactor.

Refs [STSMACOM-638](https://issues.folio.org/browse/STSMACOM-638), [STCOM-936](https://issues.folio.org/browse/STCOM-936)