### PR TITLE
STSMACOM-638 nicer test ergonomics

### DIFF
--- a/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
@@ -3,6 +3,7 @@ import {
   scoped,
   clickable,
   text,
+  isPresent
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
@@ -23,6 +24,6 @@ export default interactor(class NoteViewInteractor {
   noteType = text('[data-test-note-view-note-type]');
   noteTitle = text('[data-test-note-view-note-title]');
   metaSection = new MetaSectionInteractor();
-  emptyNoteType = scoped('[data-test-note-view-note-type]', NoValueInteractor);
-  emptyNoteTitle = scoped('[data-test-note-view-note-title]', NoValueInteractor);
+  hasEmptyNoteType = isPresent(`[data-test-note-view-note-type] ${NoValueInteractor.defaultScope}`);
+  hasEmptyNoteTitle = isPresent(`[data-test-note-view-note-title] ${NoValueInteractor.defaultScope}`);
 });

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
@@ -85,11 +85,11 @@ describe('NoteView', () => {
     });
 
     it('should display correct note type', () => {
-      expect(noteView.emptyNoteType.isPresent).to.be.true;
+      expect(noteView.hasEmptyNoteType).to.be.true;
     });
 
     it('should display correct note title', () => {
-      expect(noteView.emptyNoteTitle.isPresent).to.be.true;
+      expect(noteView.hasEmptyNoteTitle).to.be.true;
     });
   });
 


### PR DESCRIPTION
Nicer test ergonomics from the NoteView tests that I inadvertently missed in #1201. 

Refs [STSMACOM-638](https://issues.folio.org/browse/STSMACOM-638), [STCOM-936](https://issues.folio.org/browse/STCOM-936)[](https://github.com/zburke)
