### PR TITLE
STSMACOM-639 correctly provide default sortby value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Additional bump to `<LocationModal>` location query limits to 5000. Fixes STSMACOM-629.
 * Tests must not inspect `<NoValue>`'s rendered state. Refs STSMACOM-638.
 * Do not push to history if the url didn't change in `<SearchAndSortQuery>`. Fixes STSMACOM-637.
+* Correctly specify `sortby` to the manifest for `<ControlledVocab>`. Fixes STSMACOM-639.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -35,7 +35,7 @@ class ControlledVocab extends React.Component {
         path: '!{baseUrl}/%{activeRecord.id}',
       },
       GET: {
-        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby}&!{limitParam:-limit}=2000'
+        path: '!{baseUrl}?query=cql.allRecords=1 sortby !{sortby:-name}&!{limitParam:-limit}=2000'
       }
     },
     // Only used when actuatorType="refdata"
@@ -158,12 +158,12 @@ class ControlledVocab extends React.Component {
     },
     preCreateHook: (row) => row,
     preUpdateHook: (row) => row,
-    sortby: 'name',
     validate: () => ({}),
     clientGeneratePk: true,
     editable: true,
     // We would like to use
     //  limitParam: 'limit'
+    //  sortby: 'name',
     // here, but that doesn't work as defaultProps are not visible to
     // react-redux. As a result, they don't show up for substitution
     // in a stripes-connect manifest, which is why we hardwire the


### PR DESCRIPTION
As noted by helpful comments from @miketaylor in this file, react-redux
does not receive defaultProps values, and hence can't pass them onto
stripes-connect for substitution in a manifest. T

The situation we ended up in was that our default value was being
ignored, causing evaluation of the manifest to fail and thus the query
would never fire.

CC: @andrewish

Refs [STSMACOM-639](https://issues.folio.org/browse/STSMACOM-639)