### PR TITLE
STSMACOM-640 Applying a date range filter clears other filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Tests must not inspect `<NoValue>`'s rendered state. Refs STSMACOM-638.
 * Do not push to history if the url didn't change in `<SearchAndSortQuery>`. Fixes STSMACOM-637.
 * Correctly specify `sortby` to the manifest for `<ControlledVocab>`. Fixes STSMACOM-639.
+* Fix issue when applying a date range filter clears other filters. Fixes STSMACOM-640.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -69,8 +69,11 @@ const getDateError = ({ errors, dateInvalid, dateMissing, type }) => {
     || (errors[dateMissing] && renderMissingDateError(DATE_TYPES[type]));
 };
 
-const areSelectedValuesEqual = (prev, next) => {
-  return JSON.stringify(prev.selectedValues) === JSON.stringify(next.selectedValues);
+const arePropsEqual = (prev, next) => {
+  return (
+    (prev.onChange === next.onChange) &&
+    (JSON.stringify(prev.selectedValues) === JSON.stringify(next.selectedValues))
+  );
 };
 
 const TheComponent = ({
@@ -90,7 +93,7 @@ const TheComponent = ({
   const setFocusRef = useSetRef(focusRef);
   const setFocusRefOnFocus = useSetRefOnFocus(focusRef);
 
-  const { errors, dateRangeValid, selectedValues: selectedValuesState } = filterValue;
+  const { errors, selectedValues: selectedValuesState } = filterValue;
   const { startDate, endDate } = selectedValuesState;
   const { wrongDatesOrder } = errors;
 
@@ -108,7 +111,16 @@ const TheComponent = ({
     type: 'END'
   });
 
-  const onApply = (event) => {
+  const applyFilter = React.useCallback(() => {
+    const filterString = makeFilterString(startDate, endDate);
+
+    onChange({
+      name,
+      values: [filterString]
+    });
+  }, [startDate, endDate, onChange, makeFilterString, name]);
+
+  const onApply = React.useCallback((event) => {
     if (event) event.preventDefault();
 
     const bothDatesEmpty = startDate === '' && endDate === '';
@@ -120,8 +132,10 @@ const TheComponent = ({
         ...prevState,
         ...validationData
       }));
+
+      if (validationData.dateRangeValid) applyFilter();
     }
-  };
+  }, [applyFilter, dateFormat, endDate, selectedValuesState, startDate]);
 
   const handleDateChange = (event, field) => {
     const date = event.target.value;
@@ -149,21 +163,6 @@ const TheComponent = ({
       onApply();
     }
   };
-
-  const applyFilter = React.useCallback(() => {
-    const filterString = makeFilterString(startDate, endDate);
-
-    onChange({
-      name,
-      values: [filterString]
-    });
-  }, [startDate, endDate, onChange, makeFilterString, name]);
-
-  React.useEffect(() => {
-    if (dateRangeValid) {
-      applyFilter();
-    }
-  }, [dateRangeValid, applyFilter]);
 
   React.useEffect(() => {
     setFilterValue({
@@ -228,7 +227,7 @@ TheComponent.propTypes = {
   }).isRequired,
 };
 
-const DateRangeFilter = memo(TheComponent, areSelectedValuesEqual);
+const DateRangeFilter = memo(TheComponent, arePropsEqual);
 DateRangeFilter.propTypes = TheComponent.propTypes;
 
 export default DateRangeFilter;


### PR DESCRIPTION
## Purpose:
https://issues.folio.org/browse/STSMACOM-640

`DateRangeFilter` component uses `React.memo` and check equality of only `selectedValues` prop. But we are passing a `onChange` callback to the `DateRangeFilter` component, which may depend on other parameters and, accordingly, the reference to the actual `onChange` callback may change. As a result, when the `applyFilter` function is called, `onChange` is used from the previous render, it causes problems in some applications.

## Approach:

- Check `onChange` prop equality on `React.memo` comparison function;
- Replace `applyFilter` function from `useEffect` hook to prevent infinite rerenders;