### PR TITLE
STSMACOM-642 Users pop -up note has slight overwrite in "Details:"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Do not push to history if the url didn't change in `<SearchAndSortQuery>`. Fixes STSMACOM-637.
 * Correctly specify `sortby` to the manifest for `<ControlledVocab>`. Fixes STSMACOM-639.
 * Fix issue when applying a date range filter clears other filters. Fixes STSMACOM-640.
+* Users pop -up note has slight overwrite in "Details:". Fixes STSMACOM-642.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/Notes/NotePopupModal/NotePopupModal.css
+++ b/lib/Notes/NotePopupModal/NotePopupModal.css
@@ -2,3 +2,7 @@
 .note-popup-details-label {
   margin-bottom: -14px;
 }
+
+.note-details-container {
+  padding: 15px 0;
+}

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -145,8 +145,8 @@ const NotePopupModal = ({
       <p className={styles['note-popup-details-label']}>
         <strong><FormattedMessage id="stripes-smart-components.details" />: </strong>
       </p>
-      <span
-        className="ql-editor"
+      <div
+        className={`ql-editor ${styles['note-details-container']}`}
         data-test-note-popup-modal-content
         dangerouslySetInnerHTML={popupContentHTML} // eslint-disable-line react/no-danger
       />

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.css
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.css
@@ -2,3 +2,7 @@
   margin: 0 auto;
   max-width: 50rem;
 }
+
+.note-details-container {
+  padding: 0;
+}

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -271,7 +271,7 @@ export default class NoteView extends Component {
                       label={<FormattedMessage id="stripes-smart-components.details" />}
                     >
                       <div
-                        className="editor-preview ql-editor"
+                        className={`editor-preview ql-editor ${styles['note-details-container']}`}
                         data-test-note-view-note-details
                         dangerouslySetInnerHTML={noteContentMarkup}
                       />

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -134,7 +134,7 @@ class NotesList extends React.Component {
           <div>
             <strong><FormattedMessage id="stripes-smart-components.details" />: </strong>
             {/* eslint-disable-next-line react/no-danger */}
-            <span data-test-note-details dangerouslySetInnerHTML={{ __html: htmlString }} />
+            <div data-test-note-details dangerouslySetInnerHTML={{ __html: htmlString }} />
           </div>
         );
 


### PR DESCRIPTION
Purpose: https://issues.folio.org/browse/STSMACOM-642
Approach: `<div>` usage instead of `<span>` for note details container, add rigth paddings.
Screenshot:
<img width="1667" alt="Screenshot 2022-03-24 at 14 31 46" src="https://user-images.githubusercontent.com/43407139/159909787-a23abbcb-fa9a-4055-8b10-827fcc819613.png">