### PR TITLE
STSMACOM-505 memory leak in EditCustomFieldsRecord

### DIFF
--- a/lib/CustomFields/utils/useCustomFieldsFetch.js
+++ b/lib/CustomFields/utils/useCustomFieldsFetch.js
@@ -27,8 +27,10 @@ const useCustomFieldsFetch = (okapi, backendModuleId, entityType) => {
           const { customFields: requestBody } = await response.json();
           const fieldsFilteredByEntityType = requestBody.filter(customField => customField.entityType === entityType);
 
-          setCustomFields(fieldsFilteredByEntityType);
-          setCustomFieldsLoaded(true);
+          if (isMounted) {
+            setCustomFields(fieldsFilteredByEntityType);
+            setCustomFieldsLoaded(true);
+          }
         } else {
           setCustomFieldsFetchFailed(true);
         }

--- a/lib/CustomFields/utils/useOptionsStatsFetch.js
+++ b/lib/CustomFields/utils/useOptionsStatsFetch.js
@@ -65,8 +65,10 @@ const useOptionsStatsFetch = (okapi, backendModuleId, customFields, entityType) 
             .filter(isOptionUsed)
             .reduce(optionsStatsReducer, {});
 
-          setOptionsStats(usedFieldOptions);
-          setOptionsStatsLoaded(true);
+          if (isMounted) {
+            setOptionsStats(usedFieldOptions);
+            setOptionsStatsLoaded(true);
+          }
         } else {
           setOptionsStatsFetchFailed(true);
         }

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -24,8 +24,10 @@ const useSectionTitleFetch = (okapi, moduleName) => {
         if (response.ok) {
           const { configs } = await response.json();
 
-          setSectionTitle({ ...configs[0] });
-          setSectionTitleLoaded(true);
+          if (isMounted) {
+            setSectionTitle({ ...configs[0] });
+            setSectionTitleLoaded(true);
+          }
         } else {
           setSectionTitleFetchFailed(true);
         }


### PR DESCRIPTION
## Description
The memory leak  was because of the async action(response transformation into json format) after component unmounted in next hooks:
- useCustomFieldsFetch.js
- useOptionsStatsFetch.js
- useSectionTitleFetch.js

## Issues
[STSMACOM-505](https://issues.folio.org/browse/STSMACOM-505)