### PR TITLE
STSMACOM-645: Notes Accordion is Not Closed After Deleting a Note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly specify `sortby` to the manifest for `<ControlledVocab>`. Fixes STSMACOM-639.
 * Fix issue when applying a date range filter clears other filters. Fixes STSMACOM-640.
 * Users pop -up note has slight overwrite in "Details:". Fixes STSMACOM-642.
+* Notes Accordion is Not Closed After Deleting a Note. Refs STSMACOM-645.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
+++ b/lib/Notes/NotesSmartAccordion/tests/interactors/notes-accordion.js
@@ -19,6 +19,7 @@ import { isEmpty } from 'lodash';
   newButtonDisplayed = isPresent('[data-test-notes-accordion-new-button]');
   clickAssignButton = clickable('[data-test-notes-accordion-assign-button]');
   clickNewButton = clickable('[data-test-notes-accordion-new-button]');
+  toggleAccordion = clickable('[class^="defaultCollapseButton--"]');
 
   newButton = new Button('[data-test-notes-accordion-new-button]');
   assignButton = new Button('[data-test-notes-accordion-assign-button]');


### PR DESCRIPTION
## Description
Added toggleAccordion method to NotesAccordion 

## Issues
[STSMACOM-645](https://issues.folio.org/browse/STSMACOM-645)
