### PR TITLE
STSMACOM-647 include missing limit clause for campuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix issue when applying a date range filter clears other filters. Fixes STSMACOM-640.
 * Users pop -up note has slight overwrite in "Details:". Fixes STSMACOM-642.
 * Notes Accordion is Not Closed After Deleting a Note. Refs STSMACOM-645.
+* Retrieve up to 5k campuses in `<LocationModal>`, like other location-y things. Refs STSMACOM-647.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -115,7 +115,10 @@ export default class LocationModal extends React.Component {
 
     if (!institutionId) return;
 
-    const params = { query: `(institutionId=="${institutionId}") sortby name` };
+    const params = {
+      query: `(institutionId=="${institutionId}") sortby name`,
+      limit: '5000',
+    };
 
     this.props.mutator.campuses.GET({ params }).then((campuses) => {
       if (campuses.length !== 1) return;


### PR DESCRIPTION
Like other institutions, libraries, and locations, campuses also need a
`limit` clause in order to overwrite the default limit of 10.

Refs [STSMACOM-647](https://issues.folio.org/browse/STSMACOM-647)