### PR TITLE
STSMACOM-546: Un-pin axe-core from 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Retrieve up to 5k campuses in `<LocationModal>`, like other location-y things. Refs STSMACOM-647.
 * Add pane id's to ControlledVocab and Settings Smart components. Refs STSMACOM-652.
 * Fix Accessibility problems for "Tag" component. Refs STSMACOM-448.
+* Un-pin axe-core from 4.3.3. Refs STSMACOM-546.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@folio/stripes-testing": "^4.2.0",
     "@folio/stripes-util": "^5.1.0",
     "@formatjs/cli": "^4.2.20",
-    "axe-core": "4.3.3",
+    "axe-core": "4.3.5",
     "chai": "^4.2.0",
     "core-js": "^3.6.5",
     "eslint": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@folio/stripes-testing": "^4.2.0",
     "@folio/stripes-util": "^5.1.0",
     "@formatjs/cli": "^4.2.20",
-    "axe-core": "4.3.5",
+    "axe-core": "^4.3.5",
     "chai": "^4.2.0",
     "core-js": "^3.6.5",
     "eslint": "^6.2.1",


### PR DESCRIPTION
## Description
Un-pin axe-core from "4.3.3", moving back to "^4.3.5".

## Issues
[STSMACOM-546](https://issues.folio.org/browse/STSMACOM-546)

