### PR TITLE
STSMACOM-661 Search results with a single hit should automatically open the detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add pane id's to ControlledVocab and Settings Smart components. Refs STSMACOM-652.
 * Fix Accessibility problems for "Tag" component. Refs STSMACOM-448.
 * Un-pin axe-core from 4.3.3. Refs STSMACOM-546.
+* Search results with a single hit should automatically open the detail view. Fixes STSMACOM-661.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -343,8 +343,7 @@ class SearchAndSort extends React.Component {
     // If there's a single hit, open the detail pane
     if (nextProps.showSingleResult &&
       newState.totalCount() === 1 &&
-      (this.lastNonNullReaultCount > 1 || 
-      (oldState.records()[0] !== newState.records()[0]))) {
+      (this.lastNonNullReaultCount > 1 || (oldState.records()[0] !== newState.records()[0]))) {
       this.onSelectRow(null, newState.records()[0]);
     }
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -340,9 +340,11 @@ class SearchAndSort extends React.Component {
     }
 
     // if the results list is winnowed down to a single record, display the record.
+    // If there's a single hit, open the detail pane
     if (nextProps.showSingleResult &&
       newState.totalCount() === 1 &&
-      this.lastNonNullReaultCount > 1) {
+      (this.lastNonNullReaultCount > 1 || 
+      (oldState.records()[0] !== newState.records()[0]))) {
       this.onSelectRow(null, newState.records()[0]);
     }
 


### PR DESCRIPTION
## Description
Search results with a single hit should automatically open the detail view

## Approach
Added a condition which will open the detail view when there's a single hit

## Issue
[STSMACOM-661](https://issues.folio.org/browse/STSMACOM-661)

## Screenshot
https://user-images.githubusercontent.com/101391438/166885084-fa398fca-734b-4c98-9603-66950948b7ff.mp4