### PR TITLE
STSMACOM-519: EditableList: `actions` column title should be capitalized and translated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-smart-components
 
 ## 7.2.0 IN PROGRESS
+* EditableList: `actions` column title should be capitalized and translated. Refs STSMACOM-519.
 * Add aria-label for checkboxes in <ChangeDueDateDialog> component. Refs STSMACOM-636.
 * Additional bump to `<LocationModal>` location query limits to 5000. Fixes STSMACOM-629.
 * Tests must not inspect `<NoValue>`'s rendered state. Refs STSMACOM-638.

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -199,6 +199,7 @@ class EditableListForm extends React.Component {
     this.getColumnWidths = this.getColumnWidths.bind(this);
     this.getVisibleColumns = this.getVisibleColumns.bind(this);
     this.getReadOnlyColumns = this.getReadOnlyColumns.bind(this);
+    this.getColumnMapping = this.getColumnMapping.bind(this);
 
     if (this.props.id) {
       this.testingId = this.props.id;
@@ -372,6 +373,19 @@ class EditableListForm extends React.Component {
     }
 
     return visibleFields;
+  }
+
+  getColumnMapping() {
+    const {
+      editable,
+      columnMapping,
+    } = this.props;
+
+    if (editable) {
+      columnMapping['actions'] = <FormattedMessage id="stripes-smart-components.actions" />
+    }
+
+    return columnMapping;
   }
 
   getReadOnlyColumns() {
@@ -611,6 +625,7 @@ class EditableListForm extends React.Component {
           <Col xs={12}>
             <MultiColumnList
               {...this.props}
+              columnMapping={this.getColumnMapping()}
               visibleColumns={this.getVisibleColumns()}
               rowUpdater={this.rowUpdater}
               contentData={contentData}

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -381,11 +381,13 @@ class EditableListForm extends React.Component {
       columnMapping,
     } = this.props;
 
+    const map = { ...columnMapping };
+
     if (editable) {
-      columnMapping.actions = <FormattedMessage id="stripes-smart-components.actions" />;
+      map.actions = <FormattedMessage id="stripes-smart-components.actions" />;
     }
 
-    return columnMapping;
+    return map;
   }
 
   getReadOnlyColumns() {

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -382,7 +382,7 @@ class EditableListForm extends React.Component {
     } = this.props;
 
     if (editable) {
-      columnMapping['actions'] = <FormattedMessage id="stripes-smart-components.actions" />
+      columnMapping.actions = <FormattedMessage id="stripes-smart-components.actions" />;
     }
 
     return columnMapping;

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -173,6 +173,7 @@
   "notes.displayAsPopup.checkout": "Check out app",
   "notes.displayAsPopup.users": "Users app",
   "status": "Status",
+  "actions": "Actions",
   "assigned": "Assigned",
   "unassigned": "Unassigned",
   "notes.deleteNote": "Delete note",


### PR DESCRIPTION
# Purpose 
Added translation for 'Actions' column.

# Refs
[STSMACOM-519](https://issues.folio.org/browse/STSMACOM-519)

# Screenshot

<img width="1385" alt="Снимок экрана 2022-05-11 в 11 18 02" src="https://user-images.githubusercontent.com/15856488/167835278-1484ecb1-5cf7-41fd-9888-05b730ca9024.png">

