### PR TITLE
STSMACOM-662 Add optional `persist` prop to <ColumnManager>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add pane id's to ControlledVocab and Settings Smart components. Refs STSMACOM-652.
 * Fix Accessibility problems for "Tag" component. Refs STSMACOM-448.
 * Un-pin axe-core from 4.3.3. Refs STSMACOM-546.
+* Add `persist` prop to <ColumnManager> to persist selection into subsequent sessions. Fixes STSMACOM-662.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/ColumnManager/ColumnManager.js
+++ b/lib/ColumnManager/ColumnManager.js
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
 import useColumnManager from './useColumnManager';
 import ColumnManagerMenu from './ColumnManagerMenu';
 
-const ColumnManager = ({ id, columnMapping, children, excludeKeys }) => {
+const ColumnManager = ({ id, columnMapping, children, excludeKeys, persist }) => {
   const prefixId = `column-manager-${id}`;
 
   const nonToggleableColumns = useRef(excludeKeys).current;
-  const { visibleColumns, toggleColumn } = useColumnManager(prefixId, columnMapping);
+  const { visibleColumns, toggleColumn } = useColumnManager(prefixId, columnMapping, persist);
 
   /**
    * Render columns menu section

--- a/lib/ColumnManager/readme.md
+++ b/lib/ColumnManager/readme.md
@@ -8,6 +8,8 @@ The UI for rendering a `<MenuSection>` with a set of checkboxes is passed down a
 
 The required ID passed to `<ColumnManager>` is used to persist the user's selected columns in sessionStorage.
 
+If the `persist` prop is present and true, then local storage is used instead of session storage, so that the set of selected columns persists into subsequent sessions.
+
 ## Basic Usage
 ```js
     import { ColumnManager } from '@stripes/folio/smart-components';
@@ -139,3 +141,4 @@ children | func | The render-prop function that will receive the relevant props 
 columnMapping | object | An object that maps keys to labels. The order of the keys will determine the default order of the columns. | | ☑️
 excludeKeys | array | Exclude some columns from being toggleable. These keys will be excluded from the columns menu UI. | |
 id | string | The unique ID is used to generate the storage key for persisting the visible columns in sessionStorage. The ID will also be used as a prefixed ID for any UI that is passed down to the render-prop function. | | ☑️
+persist | bool | If true, then the set of selected columns persists into subsequent sessions instead of being forgotten at the end of the present session | false |

--- a/lib/ColumnManager/useColumnManager.js
+++ b/lib/ColumnManager/useColumnManager.js
@@ -1,8 +1,7 @@
 import { useMemo, useState, useCallback } from 'react';
 
-const STORAGE = sessionStorage;
-
-const useColumnManager = (prefix, columnMapping) => {
+const useColumnManager = (prefix, columnMapping, persist) => {
+  const STORAGE = persist ? localStorage : sessionStorage;
   const storageKey = `${prefix}-storage`;
 
   // The column mapping object determines the default visible columns and order
@@ -33,7 +32,7 @@ const useColumnManager = (prefix, columnMapping) => {
 
       return nextVisibleColumns;
     });
-  }, [storageKey]);
+  }, [STORAGE, storageKey]);
 
   return {
     visibleColumns: orderedVisibleColumns,


### PR DESCRIPTION
If present and true, this persists the selection of columns into subsequent sessions.

Fixes STSMACOM-662.

(I can't wait around for the Grand Unified Theory in STCOR-601, I need to get this done ASAP and with minimal disruption.)