### PR TITLE
UIU-1990: Display the patron's name, in plain text

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -385,7 +385,8 @@ class ControlledVocab extends React.Component {
     if (record) {
       const { firstName, lastName } = record.personal;
       const name = firstName ? `${lastName}, ${firstName}` : lastName;
-      user = <Link to={`/users/view/${metadata.updatedByUserId}`}>{name}</Link>;
+      const { stripes } = this.props;
+      user = stripes.hasPerm('ui-users.view') ? <Link to={`/users/view/${metadata.updatedByUserId}`}>{name}</Link> : name;
     }
 
     return (


### PR DESCRIPTION
Story:
https://issues.folio.org/browse/UIU-1990

This pull is a complement of: https://github.com/folio-org/ui-users/pull/2142

Result:
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/7461514/168981128-6594e6e1-11c1-4472-b856-f005ae9bb85d.png">
