### PR TITLE
STSMACOM-665 Add pagingCanGoNext and pagingCanGoPrevious props to SearchAndSort component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Search results with a single hit should automatically open the detail view. Fixes STSMACOM-661.
 * Add `persist` prop to <ColumnManager> to persist selection into subsequent sessions. Fixes STSMACOM-662.
 * Update CI image to NodeJS 16. Refs STSMACOM-664.
+* Add pagingCanGoNext and pagingCanGoPrevious props to SearchAndSort component. Refs STSMACOM-665.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import {
   Link,
   Route,
@@ -164,7 +165,7 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
-    paginationBoundaries: PropTypes.bool,
+    paginationBoundaries: deprecated(PropTypes.bool), //  will be removed in next major release. Use pagingCanGoPrevious and pagingCanGoNext instead.
     pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -164,6 +164,7 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
+    paginationBoundaries: PropTypes.bool,
     pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
@@ -1141,7 +1142,8 @@ class SearchAndSort extends React.Component {
       hasRowClickHandlers,
       hidePageIndices,
       pagingCanGoPrevious,
-      pagingCanGoNext
+      pagingCanGoNext,
+      paginationBoundaries
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1201,6 +1203,7 @@ class SearchAndSort extends React.Component {
             hidePageIndices={hidePageIndices}
             pagingCanGoNext={pagingCanGoNext}
             pagingCanGoPrevious={pagingCanGoPrevious}
+            paginationBoundaries={paginationBoundaries}
           />
         )}
       </FormattedMessage>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -84,6 +84,8 @@ class SearchAndSort extends React.Component {
     autofocusSearchField: PropTypes.bool,
     basePath: PropTypes.string,
     browseOnly: PropTypes.bool,
+    pagingCanGoNext: PropTypes.bool,
+    pagingCanGoPrevious: PropTypes.bool,
     columnManagerProps: PropTypes.object,
     columnMapping: PropTypes.object,
     columnWidths: PropTypes.object,
@@ -162,7 +164,6 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
-    paginationBoundaries: PropTypes.bool,
     pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
@@ -1139,7 +1140,8 @@ class SearchAndSort extends React.Component {
       resultRowFormatter,
       hasRowClickHandlers,
       hidePageIndices,
-      paginationBoundaries
+      pagingCanGoPrevious,
+      pagingCanGoNext
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -1197,7 +1199,8 @@ class SearchAndSort extends React.Component {
             itemToView={resultsCachedPosition}
             isSelected={resultRowIsSelected}
             hidePageIndices={hidePageIndices}
-            paginationBoundaries={paginationBoundaries}
+            pagingCanGoNext={pagingCanGoNext}
+            pagingCanGoPrevious={pagingCanGoPrevious}
           />
         )}
       </FormattedMessage>


### PR DESCRIPTION
Add pagingCanGoNext and pagingCanGoPrevious props to SearchAndSort component instead of paginationBoundaries.
This will allow us to disable pagination buttons separately, and not all at once