### PR TITLE
UIU-2611 - All notes on a user record set to pop up should pop up, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Search results with a single hit should automatically open the detail view. Fixes STSMACOM-661.
 * Add `persist` prop to <ColumnManager> to persist selection into subsequent sessions. Fixes STSMACOM-662.
 * Update CI image to NodeJS 16. Refs STSMACOM-664.
+* All notes on a user record set to pop up should pop up, not just the first. Refs UIU-2611.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -119,9 +119,10 @@ const NotePopupModal = ({
     }
   }, [entityId, handleGetNotesRequest, popupNote, mutator.NotePopupModal_assignedNotes]);
 
-  const incrementNoteIdx = () => {
-    setCurrentPopUpNoteIdx(prev => prev + 1);
-    setPopupNote(userPopUpNotes[currentPopUpNoteIdx + 1]);
+  const incrementNoteIdx = (idx) => {
+    setCurrentPopUpNoteIdx(idx);
+    setPopupNote(userPopUpNotes[idx]);
+    mutator.popupNote.update({ id: userPopUpNotes[idx].id });
     setIsOpen(true);
   };
 
@@ -135,7 +136,7 @@ const NotePopupModal = ({
       })
       .then(() => {
         if (currentPopUpNoteIdx + 1 < userPopUpNotes.length) {
-          incrementNoteIdx();
+          incrementNoteIdx(currentPopUpNoteIdx + 1);
         }
       });
   };
@@ -143,7 +144,7 @@ const NotePopupModal = ({
   const onClose = () => {
     setIsOpen(false);
     if (currentPopUpNoteIdx + 1 < userPopUpNotes.length) {
-      incrementNoteIdx();
+      incrementNoteIdx(currentPopUpNoteIdx + 1);
     }
   };
 

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -86,25 +86,29 @@ const NotePopupModal = ({
   label,
 }) => {
   const stripes = useStripes();
+  const [userPopUpNotes, setUserPopUpNotes] = useState([]);
+  const [currentPopUpNoteIdx, setCurrentPopUpNoteIdx] = useState(null);
   const [popupNote, setPopupNote] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
   const isNotesLoading = useRef(false);
 
-  const getPopupNoteFromNotes = useCallback((notes) => {
-    return notes.find(note => !!note[popUpPropertyName]);
+  const getPopupNotesFromNotes = useCallback((notes) => {
+    return notes.filter(note => !!note[popUpPropertyName]);
   }, [popUpPropertyName]);
 
   const handleGetNotesRequest = useCallback((notes) => {
-    const note = getPopupNoteFromNotes(notes);
+    const userNotes = getPopupNotesFromNotes(notes);
 
-    if (!note) {
+    if (!userNotes.length) {
       return;
     }
 
-    setPopupNote(note);
-    mutator.popupNote.update({ id: note.id });
+    setUserPopUpNotes(userNotes);
+    setCurrentPopUpNoteIdx(0);
+    setPopupNote(userNotes[0]);
+    mutator.popupNote.update({ id: userNotes[0].id });
     setIsOpen(true);
-  }, [mutator.popupNote, getPopupNoteFromNotes]);
+  }, [mutator.popupNote, getPopupNotesFromNotes]);
 
   useEffect(() => {
     if (!popupNote && entityId && !isNotesLoading.current) {
@@ -115,6 +119,12 @@ const NotePopupModal = ({
     }
   }, [entityId, handleGetNotesRequest, popupNote, mutator.NotePopupModal_assignedNotes]);
 
+  const incrementNoteIdx = () => {
+    setCurrentPopUpNoteIdx(prev => prev + 1);
+    setPopupNote(userPopUpNotes[currentPopUpNoteIdx + 1]);
+    setIsOpen(true);
+  };
+
   const onDelete = () => {
     mutator.note.DELETE({
       id: popupNote.id,
@@ -122,11 +132,19 @@ const NotePopupModal = ({
       .then(() => {
         setIsOpen(false);
         EventEmitter.dispatch(eventType.DELETE_NOTE);
+      })
+      .then(() => {
+        if (currentPopUpNoteIdx + 1 < userPopUpNotes.length) {
+          incrementNoteIdx();
+        }
       });
   };
 
   const onClose = () => {
     setIsOpen(false);
+    if (currentPopUpNoteIdx + 1 < userPopUpNotes.length) {
+      incrementNoteIdx();
+    }
   };
 
   const hideDelete = !stripes.hasPerm('ui-notes.item.delete');


### PR DESCRIPTION
## Purpose
Issue: All notes on a user record set to pop up should pop up, not just the first
https://issues.folio.org/browse/UIU-2611

##Result
![a6bOeHKJTi](https://user-images.githubusercontent.com/104053200/171434622-20a8e65a-71ac-4952-9b30-d47c4fe7f3a8.gif)
