### PR TITLE
STSMACOM-669: Enable nonInteractiveHeaders prop to be passed to MCL via SearchAndSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 * Add pagingCanGoNext and pagingCanGoPrevious props to SearchAndSort component. Refs STSMACOM-665.
 * ControlledVocab - optimistic locking. Refs STSMACOM-668.
 * All notes on a user record set to pop up should pop up, not just the first. Refs STSMACOM-667.
-
+* Enable nonInteractiveHeaders prop to be passed to MCL via SearchAndSort component. Refs STSMACOM-669.
+g
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * ControlledVocab - optimistic locking. Refs STSMACOM-668.
 * All notes on a user record set to pop up should pop up, not just the first. Refs STSMACOM-667.
 * Enable nonInteractiveHeaders prop to be passed to MCL via SearchAndSort component. Refs STSMACOM-669.
-g
+
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -142,6 +142,7 @@ class SearchAndSort extends React.Component {
     newRecordInitialValues: PropTypes.object,
     newRecordPerms: PropTypes.string,
     notLoadedMessage: PropTypes.element,
+    nonInteractiveHeaders: PropTypes.arrayOf(PropTypes.string),
     nsParams: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
@@ -1123,6 +1124,7 @@ class SearchAndSort extends React.Component {
 
   renderResultsList(source, visibleColumns) {
     const {
+      nonInteractiveHeaders,
       columnMapping,
       columnWidths,
       resultsFormatter,
@@ -1175,6 +1177,7 @@ class SearchAndSort extends React.Component {
             key={resultsKey}
             id={`list-${moduleName}`}
             ariaLabel={ariaLabel}
+            nonInteractiveHeaders={nonInteractiveHeaders}
             totalCount={count}
             contentData={records}
             selectedRow={selectedItem}


### PR DESCRIPTION
## Purpose
To enhance accessibility 

##  Refs
[UIDATIMP-1162](https://issues.folio.org/browse/UIDATIMP-1162)
[STSMACOM-669](https://issues.folio.org/browse/STSMACOM-669)
