### PR TITLE
STSMACOM-670 Unable to scroll to action buttons in <EditableListForm> on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add pagingCanGoNext and pagingCanGoPrevious props to SearchAndSort component. Refs STSMACOM-665.
 * ControlledVocab - optimistic locking. Refs STSMACOM-668.
 * All notes on a user record set to pop up should pop up, not just the first. Refs STSMACOM-667.
+* Unable to scroll to action buttons in `<EditableListForm>` on small screens. Refs STSMACOM-670.
 
 ## [7.1.0](https://github.com/folio-org/stripes-smart-components/tree/v7.1.0) (2022-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.0.0...v7.1.0)

--- a/lib/EditableList/EditableList.css
+++ b/lib/EditableList/EditableList.css
@@ -9,6 +9,10 @@
   margin-bottom: 15px;
 }
 
+.mclRowContainer {
+  width: fit-content;
+}
+
 .editListRow {
   display: flex;
   max-width: 100%;

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -643,7 +643,7 @@ class EditableListForm extends React.Component {
               rowProps={{ fields }}
               formatter={cellFormatters}
               columnWidths={this.getColumnWidths()}
-              rowContainerClass={css.mclRowContainer}
+              getRowContainerClass={(defaultClass) => `${defaultClass} ${css.mclRowContainer}`}
               isEmptyMessage={this.props.isEmptyMessage}
               headerRowClass={css.editListHeaders}
               id={`editList-${this.testingId}`}

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -425,6 +425,7 @@ class EditableListForm extends React.Component {
   };
 
   ItemFormatter = ({
+    rowClass,
     rowIndex,
     rowData,
     cells,
@@ -468,6 +469,7 @@ class EditableListForm extends React.Component {
         fieldComponents={fieldComponents}
         widths={columnWidths}
         cells={cells}
+        rowClass={rowClass}
         {...rowProps}
       />
     );
@@ -641,6 +643,7 @@ class EditableListForm extends React.Component {
               rowProps={{ fields }}
               formatter={cellFormatters}
               columnWidths={this.getColumnWidths()}
+              rowContainerClass={css.mclRowContainer}
               isEmptyMessage={this.props.isEmptyMessage}
               headerRowClass={css.editListHeaders}
               id={`editList-${this.testingId}`}

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -77,10 +77,10 @@ const ItemEdit = ({
   return (
     <div
       className={classnames(
-        rowClass,
         css.editListRow,
         css.baselineListRow,
-        { [css.isOdd]: !(rowIndex % 2) }
+        { [css.isOdd]: !(rowIndex % 2) },
+        rowClass,
       )}
       aria-rowindex={rowIndex + 2}
     >

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -25,6 +25,7 @@ const ItemEdit = ({
   cells,
   autoFocus,
   FieldComponent,
+  rowClass,
 }) => {
   const fields = visibleFields.map((name, fieldIndex) => {
     if (readOnlyFields.indexOf(name) === -1) {
@@ -76,6 +77,7 @@ const ItemEdit = ({
   return (
     <div
       className={classnames(
+        rowClass,
         css.editListRow,
         css.baselineListRow,
         { [css.isOdd]: !(rowIndex % 2) }
@@ -102,6 +104,7 @@ ItemEdit.propTypes = {
   FieldComponent: PropTypes.object,
   fieldComponents: PropTypes.object,
   readOnlyFields: PropTypes.arrayOf(PropTypes.string),
+  rowClass: PropTypes.string,
   rowIndex: PropTypes.number.isRequired,
   visibleFields: PropTypes.arrayOf(PropTypes.string),
   widths: PropTypes.object,

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -3,9 +3,10 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import css from './EditableList.css';
 
-const ItemView = ({ cells, rowIndex }) => (
+const ItemView = ({ cells, rowClass, rowIndex }) => (
   <div
     className={classnames(
+      rowClass,
       css.editListRow,
       { [css.isOdd]: !(rowIndex % 2) }
     )}
@@ -17,6 +18,7 @@ const ItemView = ({ cells, rowIndex }) => (
 
 ItemView.propTypes = {
   cells: PropTypes.arrayOf(PropTypes.object).isRequired,
+  rowClass: PropTypes.string,
   rowIndex: PropTypes.number.isRequired,
 };
 

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -6,9 +6,9 @@ import css from './EditableList.css';
 const ItemView = ({ cells, rowClass, rowIndex }) => (
   <div
     className={classnames(
-      rowClass,
       css.editListRow,
-      { [css.isOdd]: !(rowIndex % 2) }
+      { [css.isOdd]: !(rowIndex % 2) },
+      rowClass,
     )}
     aria-rowindex={rowIndex + 2}
   >

--- a/lib/ViewMetaData/tests/ViewMetaData-test.js
+++ b/lib/ViewMetaData/tests/ViewMetaData-test.js
@@ -108,8 +108,8 @@ describe('ViewMetaData', () => {
     it('Given system-id, system-user details display',
       () => metaSection.has({ createdByText: including('Source: SYSTEM, USER') }));
 
-    it('Given user-id, automated-process details display instead',
-      () => metaSection.has({ updatedByText: including('Source: Automated process') }));
+    it('Given user-id, unknown-user details display instead',
+      () => metaSection.has({ updatedByText: including('Source: Unknown user') }));
 
     it('Given user-id, details are not linked to a user profile',
       () => metaSection.has({ updatedByLink: undefined }));


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STSMACOM-670

At the moment, the `<EditableListForm >` component has a number of problems related to displaying on small screens:
- When changing the "isEditing" state of a row, it becomes difficult or even impossible to get to the desired action button. 
- When scrolling, column headers do not move with their respective columns.

How it looks now:
![chrome_XEhC6dxmXP](https://user-images.githubusercontent.com/88109087/173052759-0bfa1751-98bf-4354-93cc-15bacca1ca2d.gif)

How it looks after changes:
![chrome_M4kxKOJt2I](https://user-images.githubusercontent.com/88109087/173052879-e999dede-9457-41a7-8b23-1a3f7d145786.gif)

NB: Requires https://github.com/folio-org/stripes-components/pull/1820 first

---

<details>
  <summary>Places, where "EditableListForm" used:</summary>'

 **Settings**:
  - Agreements:
    - Supplementary property pick list setup
      - Pick lists
      - Pick lists values
  - Circulation:
    - Requests:
      - Request cancellation reasons
  - Courses:
    - Terms
    - Course Types
    - Cource Departments
    - Processing Statuses
    - Copyright Statuses
  - Data import:
    - Other
      - MARC field protection
  - eHoldings:
    - Access status types
  - Finance:
    - Fund types
    - Expense classes
  - INN-Reach:
    - INN-Reach locations
  - Inventory:
    - Instances:
      - Alternative title types
      - Classification identifier types
      - Contributor types
      - Formats
      - Instance note types
      - Instance status types
      - Modes of issuance
      - Nature of content
      - Resource identifier types
      - Resource types
    - Holdings:
      - Holdings note types
      - Holdings sources
      - Holdings types
      - ILL policy
    - Items:
      - Item note types
      - Loan types
      - Material types
    - Instances, Holdings, Items:
      - Statistical code types
      - URL relationship
    - Holdings, Items:
      - Call number types
  - Invoices:
    - Vouchers:
      - Batch groups
  - Licenses:
    - License term pick list setup:
      - Pick lists
      - Pick list values
  - Notes:
    - General
  - Orders:
    - General:
      - Closing purchase order reasons
      - Acquisition methods
    - PO number:
      - Prefixes
      - Suffixes
  - Organizations:
    - Categories
    - Types
  - Remote storage:
    - Accession tables
  - Tenant:
    - General:
      - Addresses
    - Location setup:
      - Institutions
      - Campuses
      - Libraries
  - General:
    - Patron groups
    - Address Types
    - Departments
  - Fee/fine:
    - Owners
    - Manual charges
    - Waive reasons
    - Payment methods
    - Refund reasons
    - Transfer accounts
  
</details>

---

