### PR TITLE
STSMACOM-671: Search term isn't persisted in SearchAndSort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-smart-components
 
+## 7.3.0 IN PROGRESS
+* Use query from props as initial value for SearchAndSort search input instead of local state. Refs STSMACOM-671.
+
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for stripes-smart-components
 
 ## 7.3.0 IN PROGRESS
-* Use query from props as initial value for SearchAndSort search input instead of local state. Refs STSMACOM-671.
+* Search term isn't persisted in SearchAndSort. Refs STSMACOM-671.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1065,9 +1065,7 @@ class SearchAndSort extends React.Component {
 
     const filters = filterState(this.queryParam('filters'));
     const query = this.queryParam('query') || '';
-    const searchTerm = (locallyChangedSearchTerm !== undefined)
-      ? locallyChangedSearchTerm
-      : query;
+    const searchTerm = locallyChangedSearchTerm || query;
     const queryIndex = locallyChangedQueryIndex || selectedIndex;
 
     return (


### PR DESCRIPTION
## Purpose
- In `ui-data-import`, We are saving `searchTerm` to `sessionStorage` and pass it to `<SearchAndSort />` as `query` property of `parentResources` prop. But the problem is that `search box` is getting its initial value from local state `locallyChangedSearchTerm`. The logic is comparing it with `undefined` which is always false because `locallyChangedSearchTerm` has initial value of `""` and never gets initial value from `props`.
- Also when refresh the page `searchTerm` will be lost but searched results are persisted because of url query string.
## Refs
- https://issues.folio.org/browse/STSMACOM-671