### PR TITLE
STSMACOM-676 Reset SearchAndSort query going back in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.3.0 IN PROGRESS
 * Search term isn't persisted in SearchAndSort. Refs STSMACOM-671.
+* Fix `<SearchAndSort>` query doesn't reset when clicking back in browser. Fixes STSMACOM-676.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -233,6 +233,7 @@ class SearchAndSort extends React.Component {
         log: PropTypes.func,
       }),
     }).isRequired,
+    syncQueryWithUrl: PropTypes.bool,
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     viewRecordComponent: PropTypes.func,
     viewRecordPathById: PropTypes.func,
@@ -254,6 +255,7 @@ class SearchAndSort extends React.Component {
     renderNavigation: noop,
     hasRowClickHandlers: true,
     selectedIndex: '',
+    syncQueryWithUrl: false,
     hasNewButton: true,
     resultRowIsSelected: ({ item, criteria }) => {
       if (criteria) {
@@ -312,6 +314,7 @@ class SearchAndSort extends React.Component {
       location: {
         search: currentSearch,
       },
+      syncQueryWithUrl,
     } = this.props;
     const oldState = makeConnectedSource(this.props, logger);
     const newState = makeConnectedSource(nextProps, logger);
@@ -365,7 +368,7 @@ class SearchAndSort extends React.Component {
       this.resetLocalQIndex(qindex);
     }
 
-    if (oldQuery !== newQuery) {
+    if (syncQueryWithUrl && oldQuery !== newQuery) {
       this.setState({ locallyChangedSearchTerm:  newQuery });
     }
   }

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -322,6 +322,8 @@ class SearchAndSort extends React.Component {
     } = nextProps;
     const { qindex, segment: nextSegment } = queryString.parse(search);
     const { segment: currSegment } = queryString.parse(currentSearch);
+    const oldQuery = this.queryParam('query', this.props);
+    const newQuery = this.queryParam('query', nextProps);
 
     // If the nominated mutation has finished, select the newly created record
     const oldStateForFinalSource = makeConnectedSource(this.props, logger, finishedResourceName);
@@ -361,6 +363,10 @@ class SearchAndSort extends React.Component {
 
     if (currSegment !== nextSegment) {
       this.resetLocalQIndex(qindex);
+    }
+
+    if (oldQuery !== newQuery) {
+      this.setState({ locallyChangedSearchTerm:  newQuery });
     }
   }
 
@@ -799,11 +805,11 @@ class SearchAndSort extends React.Component {
     this.transitionToParams(queryParams);
   }, 350);
 
-  queryParam(name) {
+  queryParam(name, props = this.props) {
     const {
       parentResources: { query },
       nsParams,
-    } = this.props;
+    } = props;
     const nsKey = getNsKey(name, nsParams);
 
     return get(query, nsKey);

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -55,6 +55,7 @@ viewRecordPerms | string | A comma-separated list of the permissions required in
 newRecordPerms | string | A comma-separated list of the permissions required in order to create a new record.
 disableRecordCreation | bool | If true, new record cannot be created. This is appropriate when one application is running embedded in another.
 parentResources | shape | The parent component's stripes-connect `resources` property, used to access the records of the relevant type. Must contain at least `records`, `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
+syncQueryWithUrl | bool | Will enable or disable syncing of `query` parameter in the url with search query input value.
 parentMutator | shape | The parent component's stripes-connect `mutator` property. Must contain at least `query` (the anointed resource used for navigation) and `resultCount` (a scalar used in infinite scrolling).
 nsParams | object or string | An object or string used to namespace search and sort parameters. More information can be found [here](https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md)
 notLoadedMessage | string | A message to show the user before a search has been submitted. Defaults to "Choose a filter or enter search query to show results".


### PR DESCRIPTION
## Description
Fix issue when `<SearchAndSort>` query doesn't return to old value, when you go back in browser history
Component's `locallyChangedSearchTerm` state value is prioritized over query parameter in url, so we need to update it when url value changes

## Screenshots

https://user-images.githubusercontent.com/19309423/174809563-e0ebd28f-f65e-4ed2-9583-70021aab912a.mp4


## Issues
[STSMACOM-676](https://issues.folio.org/browse/STSMACOM-676)