### PR TITLE
STSMACOM-677: Search/Filter pane is not in a collapsed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.3.0 IN PROGRESS
 * Search term isn't persisted in SearchAndSort. Refs STSMACOM-671.
+* Search/Filter pane is not in a collapsed state. Refs STSMACOM-677.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -277,7 +277,7 @@ class SearchAndSort extends React.Component {
 
     this.state = {
       selectedItem: this.initiallySelectedRecord,
-      filterPaneIsVisible: !!storedFilterPaneState !== false ? storedFilterPaneState : true,
+      filterPaneIsVisible: storedFilterPaneState === null ? true : !!storedFilterPaneState,
       locallyChangedSearchTerm: '',
       locallyChangedQueryIndex: '',
     };

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -17,6 +17,7 @@ describe('SearchAndSort', () => {
 
   beforeEach(() => {
     onResetAllSpy.resetHistory();
+    window.localStorage.setItem('@folio/ui-dummy/filterPaneVisibility', true);
 
     mount(
       <ConnectedComponent
@@ -56,10 +57,6 @@ describe('SearchAndSort', () => {
   });
 
   describe('Filter Pane', () => {
-    beforeEach(async () => {
-      window.localStorage.setItem('@folio/ui-dummy/filterPaneVisibility', true);
-    });
-
     it('should be visible', () => {
       expect(searchAndSort.filterPane.isPresent).to.be.true;
     });


### PR DESCRIPTION
Fixed the issue, where `Search/Filter` pane is not in a collapsed state when we are on the **Data import/View all log** page AND collapse the `Search/Filter` pane by clicking the arrow at the top of the pane AND go to another app or Settings area and then return to **Data import/View all**.
The `Search/Filter` pane **being in a collapsed state should persist**
These changes also impact on **ui-inventory** and **ui-requests**
Link:
[STSMACOM-677](https://issues.folio.org/browse/STSMACOM-677)

https://user-images.githubusercontent.com/85172747/175303114-1c681704-3e2c-4971-a947-52f82f2d5df4.mp4
