### PR TITLE
STSMACOM-679:  Mark initialValues as immutable in LocationForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.3.0 IN PROGRESS
 * Search term isn't persisted in SearchAndSort. Refs STSMACOM-671.
 * Search/Filter pane is not in a collapsed state. Refs STSMACOM-677.
+* Mark `initialValues` as immutable in `<LocationForm>`. Fixes STSMACOM-679.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -34,7 +34,6 @@ const LocationForm = ({
   };
 
   const curValues = getCurrentValues();
-
   const institutionOpts = institutions.map(inst => ({ label: inst.name, value: inst.id }));
   const campusOpts = campuses.map(campus => ({ label: campus.name, value: campus.id }));
   const libraryOpts = libraries.map(library => ({ label: library.name, value: library.id }));

--- a/lib/LocationLookup/LocationForm.js
+++ b/lib/LocationLookup/LocationForm.js
@@ -34,6 +34,7 @@ const LocationForm = ({
   };
 
   const curValues = getCurrentValues();
+
   const institutionOpts = institutions.map(inst => ({ label: inst.name, value: inst.id }));
   const campusOpts = campuses.map(campus => ({ label: campus.name, value: campus.id }));
   const libraryOpts = libraries.map(library => ({ label: library.name, value: library.id }));
@@ -144,4 +145,9 @@ export default stripesForm({
   form: 'locationForm',
   navigationCheck: false,
   enableReinitialize: true,
+  // Passing modified initialValues does not re-render the form
+  // even when enableReinitialize is set to true.
+  // This seems like a bug in redux-form:
+  // https://github.com/redux-form/redux-form/issues/2572
+  immutableProps: ['initialValues'],
 })(LocationForm);

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -189,7 +189,6 @@ export default class LocationModal extends React.Component {
 
   render() {
     const { resources, isTemporaryLocation, ...rest } = this.props;
-    const { campusId, libraryId, locationId, institutionId } = this.state;
     const institutions = (resources.institutions || {}).records || [];
     const campuses = (resources.campuses || {}).records || [];
     const libraries = (resources.libraries || {}).records || [];
@@ -212,7 +211,7 @@ export default class LocationModal extends React.Component {
         dismissible
       >
         <LocationForm
-          initialValues={{ campusId, libraryId, locationId, institutionId }}
+          initialValues={this.state}
           institutions={institutions}
           campuses={campuses}
           libraries={libraries}

--- a/lib/LocationLookup/LocationModal.js
+++ b/lib/LocationLookup/LocationModal.js
@@ -189,6 +189,8 @@ export default class LocationModal extends React.Component {
 
   render() {
     const { resources, isTemporaryLocation, ...rest } = this.props;
+    const { campusId, libraryId, locationId, institutionId } = this.state;
+    const initialValues = { campusId, libraryId, locationId, institutionId };
     const institutions = (resources.institutions || {}).records || [];
     const campuses = (resources.campuses || {}).records || [];
     const libraries = (resources.libraries || {}).records || [];
@@ -211,7 +213,7 @@ export default class LocationModal extends React.Component {
         dismissible
       >
         <LocationForm
-          initialValues={this.state}
+          initialValues={initialValues}
           institutions={institutions}
           campuses={campuses}
           libraries={libraries}


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-679

Even though initial values change, the form is not re-rendered. This should be happening with `enableReinitialize` set to `true`.

This looks like a legit issue in redux-form:

https://github.com/redux-form/redux-form/issues/2572#issuecomment-754261512

The correct way to fix it would be to get rid of the redux-form and replace it with the final-form (which we should do in the future).