### PR TITLE
STSMACOM-686 Support notes interface version 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add isCountHidden prop to SearchAndSort component. Refs STSMACOM-683.
 * Add an optional onSubmitSearch callback function to extend the form submission functionality. Fixes STSMACOM-682.
 * Accept `validateSearchOnSubmit` prop to prevent invalid searches. Refs STSMACOM-684.
+* Support `notes` interface version `3.0`. Refs STSMACOM-686.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "stripes": {
     "okapiInterfaces": {
-      "notes": "2.0",
+      "notes": "2.0 3.0",
       "tags": "1.0",
       "password-validator": "1.0"
     },


### PR DESCRIPTION
`mod-notes` module was updated with breaking changes to `/note-types` endpoint and updated interface version to `3.0`
However, these changes don't affect `/notes` endpoint so `stripes-smart-components` can safely use either `2.0` or `3.0`