### PR TITLE
STSMACOM-700 SearchAndSortQuery requires 2 clicks of the clear to successfully clear filters.

### DIFF
--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -204,10 +204,12 @@ class SearchAndSortQuery extends React.Component {
       if (props.location.search !== state.previousQuery) {
         nextState.previousQuery = props.location.search;
 
+        // we want the query state from location only, so we exclude the 'default' third parameters
+        // to getQueryStateSlice()
         const queryStateFromLocation = {
-          searchFields:  getQueryStateSlice(props.location.search, props.searchParamsMapping, props.initialSearchState),
-          filterFields: getQueryStateSlice(props.location.search, props.filterParamsMapping, props.initialFilterState),
-          sortFields:  getQueryStateSlice(props.location.search, props.sortParamsMapping, props.initialSortState),
+          searchFields:  getQueryStateSlice(props.location.search, props.searchParamsMapping),
+          filterFields: getQueryStateSlice(props.location.search, props.filterParamsMapping),
+          sortFields:  getQueryStateSlice(props.location.search, props.sortParamsMapping),
         };
 
         // sync up the queryState if a query change happened elsewhere - e.g. another component directly updates a query parameter

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
@@ -1,0 +1,147 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useOkapiKy } from '@folio/stripes-core';
+import { Button, SearchField, FilterGroups, MultiColumnList } from '@folio/stripes-components';
+import { useQuery } from 'react-query';
+import { useHistory, useLocation } from 'react-router';
+import SearchAndSortQuery from '../../SearchAndSortQuery';
+import QueryHarness from '../../../../tests/QueryHarness';
+import buildUrl from '../../buildUrl';
+
+const propTypes = {
+  testQindex: PropTypes.string,
+  testQindexLabel: PropTypes.node,
+  testQuery: PropTypes.string,
+  testQueryLabel: PropTypes.node,
+  testHomeRoute: PropTypes.string,
+};
+
+const SASQTestHarness = ({
+  testQuery = 'testquery',
+  testQindex = 'contributors',
+  testQindexLabel = 'nav-qindex',
+  testQueryLabel = 'nav-query',
+  ...SASQProps
+}) => {
+  const history = useHistory();
+  const location = useLocation();
+  const request = useOkapiKy();
+  const queryFromLocation = new URLSearchParams(location.search);
+  const { data } = useQuery(
+    ['dummy', queryFromLocation],
+    () => {
+      return request(buildUrl(location, queryFromLocation, 'samples'), queryFromLocation).json();
+    }, {
+    // don't fetch an empty query...
+      enabled: Object.keys(queryFromLocation).length > 0,
+    }
+  );
+
+  const filterConfig = [
+    {
+      label: 'Status',
+      name:'status',
+      values:[{
+        name: 'active',
+        displayName: 'active',
+      },
+      {
+        name: 'inactive',
+        displayName: 'inactive',
+      }
+      ],
+    }
+  ];
+
+  return (
+    <QueryHarness>
+      <SearchAndSortQuery
+        searchParamsMapping={{
+          query: (q) => ({ query: q }),
+          qindex: (q) => ({ qindex: q }),
+        }}
+        {...SASQProps}
+      >
+        {
+          ({
+            filterChanged,
+            searchChanged,
+            sortChanged,
+            getSearchHandlers,
+            searchValue,
+            onSubmitSearch,
+            getFilterHandlers,
+            onSort,
+            activeFilters,
+            resetAll,
+          }) => {
+            const groupFilters = {};
+            activeFilters.string.split(',').forEach(m => { groupFilters[m] = true; });
+            const resetDisabled = !(filterChanged || searchChanged);
+            return (
+              <>
+                <h3>SearchAndSortQuery Tests</h3>
+                <SearchField
+                  value={searchValue.query}
+                  name="query"
+                  onChange={getSearchHandlers().query}
+                  indexName="qindex"
+                  onChangeIndex={getSearchHandlers().query}
+                  searchableIndexes={
+                    [
+                      { label: 'all', value: 'all' },
+                      { label: 'contributors', value: 'contributors' },
+                      { label: 'title', value: 'title' }
+                    ]}
+                  selectedIndex={searchValue.qindex}
+                />
+                <Button
+                  disabled={resetDisabled}
+                  onChange={resetAll}
+                >
+                  Reset all
+                </Button>
+                <Button buttonStyle="primary" onClick={onSubmitSearch}>
+                  Search
+                </Button>
+                <Button
+                  onClick={() => { history.push(buildUrl(location, { qindex: testQindex }, '/dummy')); }}
+                >{testQindexLabel || 'navigate-qindex'}
+                </Button>
+                <Button
+                  onClick={() => { history.push(buildUrl(location, { query: testQuery }, '/dummy')); }}
+                >{testQueryLabel || 'navigate-query'}
+                </Button>
+                <Button
+                  disabled={!filterChanged}
+                  onClick={getFilterHandlers().clear}
+                >
+                  Clear Filters
+                </Button>
+                <FilterGroups
+                  config={filterConfig}
+                  filters={groupFilters}
+                  onChangeFilter={getFilterHandlers().checkbox}
+                  onClearFilter={getFilterHandlers().clearGroup}
+                />
+                <Button
+                  onClick={() => onSort('test')}
+                >
+                  Test Sort
+                </Button>
+                <h3 id="query-debug">
+                  search: {location.search}
+                </h3>
+                <span>testSort: {sortChanged}</span>
+                <MultiColumnList contentData={data} />
+              </>);
+          }
+        }
+      </SearchAndSortQuery>
+    </QueryHarness>
+  );
+};
+
+SASQTestHarness.propTypes = propTypes;
+
+export default SASQTestHarness;

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { describe, beforeEach, it } from 'mocha';
+import {
+  Bigtest,
+  Button,
+  TextField,
+  HTML,
+  including,
+  IconButton,
+  Checkbox,
+} from '@folio/stripes-testing';
+import { setupApplication } from '../../../../tests/helpers';
+import SASQTestHarness from './SASQTestHarness';
+
+describe('SearchAndSortQuery Navigation', () => {
+  setupApplication({
+    component: (
+      <SASQTestHarness
+        testQindex="contributors"
+        testQindexLabel="test-qindex-nav"
+        testQuery="testquery"
+        testQueryLabel="test-query-nav"
+      />)
+  });
+
+  beforeEach(async function () {
+    this.server.get('/samples', function ({ users }) {
+      const res = users.all();
+      return this.serialize(res, 'users');
+    });
+    await this.server.createList('user', 1000);
+  });
+
+  describe('Selecting a query index', () => {
+    beforeEach(async () => {
+      await Bigtest.Select().choose('contributors');
+    });
+
+    it('does not affect query', () => HTML({ id: 'query-debug' }).has({ text: 'search:' }));
+
+    describe('Clicking the search button', () => {
+      beforeEach(async () => {
+        await TextField().fillIn('test');
+        await Button('Search').click();
+      });
+
+      it('resetting the query', () => HTML({ id: 'query-debug' }).has({ text: including('qindex') }));
+
+      describe('Clicking the reset all', () => {
+        beforeEach(async () => {
+          await Button('Reset all').click();
+        });
+
+        it('removes the search from the query string', () => HTML({ id: 'query-debug' }).has({ text: 'search:' }));
+      });
+    });
+  });
+
+
+  describe('navigating to a qindex parameter', () => {
+    beforeEach(async () => {
+      await Button('test-qindex-nav').click();
+    });
+
+    it('syncs search index select accordingly', () => Bigtest.Select({ value: 'contributors' }).exists());
+  });
+
+  describe('navigating to a query parameter', () => {
+    beforeEach(async () => {
+      await Button('test-query-nav').click();
+    });
+
+    it('syncs search text field accordingly', () => TextField({ value: 'testquery' }).exists());
+  });
+
+  describe('testing initial query state', () => {
+    setupApplication({
+      component: (
+        <SASQTestHarness
+          testQindex="contributors"
+          testQindexLabel="test-qindex-nav"
+          testQuery="testquery"
+          testQueryLabel="test-query-nav"
+          initialSearchState={{ query: 'testSearch', qindex: 'title' }}
+          initialFilterState={{ status: ['active'] }}
+        />)
+    });
+
+    describe('rendering initial query state', () => {
+      it('renders the correct search field value', () => TextField({ value: 'testSearch' }).exists());
+      it('renders the correct qindex field value', () => Bigtest.Select({ value: 'title' }).exists());
+      it('includes all necessary query information in the query string', () => {
+        return HTML(including('?filters=status.active&qindex=title&query=testSearch')).exists();
+      });
+    });
+
+    describe('clicking the reset button on the filter group', () => {
+      beforeEach(async () => {
+        await IconButton({ icon: 'times-circle-solid' }).click();
+      });
+
+      it('clears default filters', () => {
+        return Checkbox('active').is({ checked: false });
+      });
+
+      it('removes the filter from the query string', () => {
+        return HTML(including('?qindex=title&query=testSearch')).exists();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/STSMACOM-700

Problem: The first click of the clear filters button would trigger an update to internal query state of SASQ, which updates the locatoin query as expected, but if `syncToLocationQuery`  is enabled, derived state will include the `initialFilterState` which will trump the now-empty values from the query when deriving the state. This isn't a problem with most existing SASQ implementations, as they don't make much use of the `initial*State` props.

*Approach:* Remove the initial query state prop from the `gDSFP` call since we only want to consider the location query itself when syncing to it.