### PR TITLE
STSMACOM-705: Mark addressType as require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Refactor AddressList to avoid deprecated lifecycle methods. Refs STSMACOM-625.
 * Implement status reinitialization for `EditableListForm` component. Refs STSMACOM-699.
 * Fix SearchAndSortQuery bug - clear filters requires two clicks. Refs STSMACOM-700.
+* Mark `addressType` as required. Fixes STSMACOM-705.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -164,6 +164,7 @@ class EmbeddedAddressForm extends React.Component {
                 component={mergedFieldComponents[fieldName].component}
                 {...mergedFieldComponents[fieldName].props}
                 dataOptions={list}
+                required
               />
             );
           } else {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-705

Based on the work in https://issues.folio.org/browse/MODUSERS-212 `addressType` is now a required field.

This PR marks it as a required field.