### PR TITLE
STSMACOM-704 Add props to ControlledVocab components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Refactor AddressList to avoid deprecated lifecycle methods. Refs STSMACOM-625.
 * Implement status reinitialization for `EditableListForm` component. Refs STSMACOM-699.
 * Fix SearchAndSortQuery bug - clear filters requires two clicks. Refs STSMACOM-700.
+* Add props to ControlledVocab components. Refs STSMACOM-704.
 
 ## [7.2.0](https://github.com/folio-org/stripes-smart-components/tree/v7.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.1.0...v7.2.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -161,6 +161,7 @@ class ControlledVocab extends React.Component {
     */
     validate: PropTypes.func,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
+    canCreate: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -192,6 +193,7 @@ class ControlledVocab extends React.Component {
     //  !{limitParam:-limit}
     // in the manifest above.
     actuatorType: 'rest',
+    canCreate: true
   };
 
   constructor(props) {
@@ -485,6 +487,7 @@ class ControlledVocab extends React.Component {
               // TODO: not sure why we need this OR if there are no groups
               // Seems to load this once before the groups data from the manifest
               // is pulled in. This still causes a JS warning, but not an error
+              canCreate={this.props.canCreate}
               contentData={rows}
               totalCount={rows.length}
               createButtonLabel={<FormattedMessage id="stripes-core.button.new" />}


### PR DESCRIPTION
For tickets:
https://issues.folio.org/browse/UITEN-225
https://issues.folio.org/browse/UITEN-226
https://issues.folio.org/browse/UITEN-227
https://issues.folio.org/browse/UITEN-228

It's required to hide/disable create button in "View only" mode.

Solution: add `canCreate` prop to `ControlledVocab.js` component.