### PR TITLE
STSMACOM-707 retain locallyChangedSearchTerm when syncing to query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 7.4.0 IN PROGRESS
 
+* Fix bug with SearchAndSort not retaining search term when qindex changed. Refs STSMACOM-707.
+
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -343,19 +343,18 @@ class SearchAndSort extends React.Component {
       nextState.previousQueryString = search;
       const parsedQuery = queryString.parse(search);
 
-      // if update the local state of the search term to match the window location's query string.
-      if (parsedQuery?.query) {
+      // if the search hasn't been changed by the user,
+      // sync it to the query string...
+      if (!state.locallyChangedSearchTerm && parsedQuery?.query) {
         nextState.locallyChangedSearchTerm = parsedQuery.query;
-      } else {
-        nextState.locallyChangedSearchTerm = '';
       }
 
       // sync qindex...
-      // if no 'qindex' parameter is present in window.location, reset the local qIndex:
+      // if no 'qindex' parameter is present in window.location, keep or reset the local qIndex:
       if (parsedQuery?.qindex) {
         nextState.locallyChangedQueryIndex = parsedQuery.qindex;
       } else {
-        nextState.locallyChangedQueryIndex = '';
+        nextState.locallyChangedQueryIndex = state.locallyChangedQueryIndex || '';
       }
     }
 

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -48,7 +48,6 @@ describe('SearchAndSort Query Navigation', () => {
       />)
   });
 
-
   beforeEach(async function () {
     this.server.get('/samples', function ({ users }) {
       const res = users.all();
@@ -111,6 +110,19 @@ describe('SearchAndSort Query Navigation', () => {
     });
   });
 
+  describe('prefer local state values to emptying from query string', () => {
+    beforeEach(async () => {
+      await TextField().fillIn('test');
+    });
+
+    describe('changing the qindex', () => {
+      beforeEach(async () => {
+        await Bigtest.Select().choose('contributors');
+      });
+
+      it('retains the same search term in the text field', () => TextField().has({ value: 'test' }));
+    });
+  });
 
   describe('navigating to a qindex parameter', () => {
     beforeEach(async () => {


### PR DESCRIPTION
Problem:
If the user entered a search term and then modified the `qindex`, the search term would be lost or changed to whatever was currently in the query parameters.

Approach:
Check if there is a locally changed search term before syncing to the query parameter value.