### PR TITLE
STSMACOM-709: Disabled sorting after double click on the settings link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix bug with SearchAndSort not retaining search term when qindex changed. Refs STSMACOM-707.
 * Optimistic locking error appears when user adds more than 1 tag to "Holdings" record. Fixes STSMACOM-708.
+* Disabled sorting after double click on the settings link. Refs STSMACOM-709
 
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -61,7 +61,7 @@ class Settings extends Component {
     // links in a given section
     const navlinks = (section) => {
       const navItems = section.pages.map((p) => {
-        const search = props?.location?.search || '';
+        const search = props.location.search || '';
         const link = `${props.match.path}/${p.route}${search}`;
         if (props.location.pathname.startsWith(link)) {
           activeLink = link;

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -61,7 +61,8 @@ class Settings extends Component {
     // links in a given section
     const navlinks = (section) => {
       const navItems = section.pages.map((p) => {
-        const link = `${props.match.path}/${p.route}`;
+        const search = props?.location?.search || '';
+        const link = `${props.match.path}/${p.route}${search}`;
         if (props.location.pathname.startsWith(link)) {
           activeLink = link;
         }
@@ -132,6 +133,7 @@ Settings.propTypes = {
   ),
   location: PropTypes.shape({
     pathname: PropTypes.string,
+    search: PropTypes.string,
   }),
   match: PropTypes.shape({
     path: PropTypes.string.isRequired,


### PR DESCRIPTION
## Link
[STSMACOM-709](https://issues.folio.org/browse/STSMACOM-709)
[UIDATIMP-1321](https://issues.folio.org/browse/UIDATIMP-1321)

## Screenshots
### Before

https://user-images.githubusercontent.com/85172747/204260269-af72a0ae-4766-4083-8f0d-b77fde15fe3d.mp4


### After

https://user-images.githubusercontent.com/85172747/204260291-6f0cacf5-5ad0-4561-97a5-702d03f377b1.mp4


