### PR TITLE
STSMACOM-706 PasswordValidationField swallows error messages from API queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Optimistic locking error appears when user adds more than 1 tag to "Holdings" record. Fixes STSMACOM-708.
 * Disabled sorting after double click on the settings link. Refs STSMACOM-709
 * Expose MCL sticky column props through SearchAndSort. Refs STSMACOM-712.
+* PasswordValidationField swallows error messages from API queries. Refs STSMACOM-706.
 
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)

--- a/lib/PasswordValidationField/PasswordValidationField.js
+++ b/lib/PasswordValidationField/PasswordValidationField.js
@@ -23,7 +23,7 @@ class PasswordValidationField extends React.Component {
   static manifest = Object.freeze({
     validators: {
       type: 'okapi',
-      path: 'tenant/rules?query=(type=RegExp and state=Enabled)',
+      path: 'tenant/rules',
       throwErrors: false,
       fetch: false,
       accumulate: true,


### PR DESCRIPTION
## Purpose
This PR relates to [STSMACOM-706](https://issues.folio.org/browse/STSMACOM-706)
## Approach
The query was removed as it was invalid and not used by BE