### PR TITLE
STSMACOM-717 SearchAndSort no longer accepts paginationBoundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Disabled sorting after double click on the settings link. Refs STSMACOM-709
 * Expose MCL sticky column props through SearchAndSort. Refs STSMACOM-712.
 * PasswordValidationField swallows error messages from API queries. Refs STSMACOM-706.
+* *BREAKING*: `<SearchAndSort>` no longer accepts `paginationBoundaries`. Refs STSMACOM-717.
 
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -179,7 +179,6 @@ class SearchAndSort extends React.Component {
       }).isRequired,
     }),
     pageAmount: PropTypes.number,
-    paginationBoundaries: deprecated(PropTypes.bool), //  will be removed in next major release. Use pagingCanGoPrevious and pagingCanGoNext instead.
     pagingType: PropTypes.string,
     parentData: PropTypes.object,
     parentMutator: PropTypes.shape({
@@ -1181,7 +1180,6 @@ class SearchAndSort extends React.Component {
       hidePageIndices,
       pagingCanGoPrevious,
       pagingCanGoNext,
-      paginationBoundaries,
       resultsStickyFirstColumn,
       resultsStickyLastColumn,
     } = this.props;
@@ -1243,7 +1241,6 @@ class SearchAndSort extends React.Component {
             hidePageIndices={hidePageIndices}
             pagingCanGoNext={pagingCanGoNext}
             pagingCanGoPrevious={pagingCanGoPrevious}
-            paginationBoundaries={paginationBoundaries}
             stickyFirstColumn={resultsStickyFirstColumn}
             stickyLastColumn={resultsStickyLastColumn}
           />


### PR DESCRIPTION
`<SearchAndSort>` no longer accepts `paginationBoundaries`, a long-deprecated prop that it passed along to `<MCL>`, where it was also deprecated and where, finally in v11, it is being removed.

Refs [STSMACOM-717](https://issues.folio.org/browse/STSMACOM-717), [STCOM-1067](https://issues.folio.org/browse/STCOM-1067)