### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for stripes-smart-components
 
-## 7.4.0 IN PROGRESS
+## 8.0.0 IN PROGRESS
 
 * Fix bug with SearchAndSort not retaining search term when qindex changed. Refs STSMACOM-707.
 * Optimistic locking error appears when user adds more than 1 tag to "Holdings" record. Fixes STSMACOM-708.
 * Disabled sorting after double click on the settings link. Refs STSMACOM-709
 * Expose MCL sticky column props through SearchAndSort. Refs STSMACOM-712.
 * PasswordValidationField swallows error messages from API queries. Refs STSMACOM-706.
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
 
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-smart-components",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "Connected Stripes components",
   "repository": "folio-org/stripes-smart-components",
   "sideEffects": [
@@ -63,7 +63,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",
-    "react-redux": "^7.2.0",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STRIPES-834.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.