### PR TITLE
STSMACOM-723 unpin @rehooks/local-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Expose MCL sticky column props through SearchAndSort. Refs STSMACOM-712.
 * PasswordValidationField swallows error messages from API queries. Refs STSMACOM-706.
 * *BREAKING*: `<SearchAndSort>` no longer accepts `paginationBoundaries`. Refs STSMACOM-717.
-* Upgrade `react-redux` to `v8`. Refs STSMACOM-721.
+* *BREAKING*: Upgrade `react-redux` to `v8`. Refs STSMACOM-721.
+* Unpin `@rehooks/local-storage` now that it's no longer broken. Refs STSMACOM-723.
 
 ## [7.3.0](https://github.com/folio-org/stripes-smart-components/tree/v7.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.2.0...v7.3.0)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "stylelint-junit-formatter": "^0.2.1"
   },
   "dependencies": {
-    "@rehooks/local-storage": "2.4.0",
+    "@rehooks/local-storage": "^2.4.4",
     "classnames": "^2.2.6",
     "final-form": "^4.18.2",
     "final-form-arrays": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,10 +1958,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
-"@rehooks/local-storage@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.0.tgz#fb884b2b657cad5f77aa6ab60bb3532f0e0725d2"
-  integrity sha512-LoXDbEHsuIckVgBsFAv8SuU/M7memjyfWut9Zf36TQXqqCHBRFv8bweg9PymQCa1aWIMjNrZQflFdo55FDlXYg==
+"@rehooks/local-storage@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.4.tgz#ccf40f60c2dcbab86dc88f9e3ea898d1fb8bea2d"
+  integrity sha512-zE+kfOkG59n/1UTxdmbwktIosclr67Nlbf2MzUJ9mNtCSypVscNHeD1qT6JCSo5Pjj8DO893IKWNLJqKKzDL/Q==
 
 "@restart/hooks@^0.3.25":
   version "0.3.27"


### PR DESCRIPTION
`@rehooks/local-storage` is no longer broken so we can once again depend on the latest version of it, allowing us to remove `resolutions` entries for it that are scattered about.

Refs [STSMACOM-723](https://issues.folio.org/browse/STSMACOM-723)