### PR TITLE
STSMACOM-720: Update <ConfigManager> to work with mod-settings (Small fix)

### DIFF
--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -105,7 +105,7 @@ class ConfigManager extends React.Component {
 
   getInitialValues() {
     const { resources, moduleName, configName, getInitialValues } = this.props;
-    const settings = (resources.settings || {}).records[0][moduleName ? 'configs' : 'items'] || [];
+    const settings = resources.settings?.records?.[0][moduleName ? 'configs' : 'items'] || [];
 
     if (getInitialValues) {
       return getInitialValues(settings);


### PR DESCRIPTION
fix: Nullish coalescing

Added null coalescing back to component (also brought previous null safety in line for code consistency)

refs STSMACOM-720

Coversation on the previous PR: https://github.com/folio-org/stripes-smart-components/pull/1313#issuecomment-1415522670