### PR TITLE
STSMACOM-735: Reset the previously selected query index when there is none in the next selected segment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.1.0 IN PROGRESS
 * Add `limit` query params to `ProxyManager` component. Refs STSMACOM-731.
+* Reset the previously selected query index when there is none in the next selected segment. Fixes STSMACOM-735.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -336,6 +336,7 @@ class SearchAndSort extends React.Component {
       location: {
         search
       },
+      searchableIndexes,
     } = props;
 
     const nextState = {};
@@ -355,7 +356,8 @@ class SearchAndSort extends React.Component {
       if (parsedQuery?.qindex) {
         nextState.locallyChangedQueryIndex = parsedQuery.qindex;
       } else {
-        nextState.locallyChangedQueryIndex = state.locallyChangedQueryIndex || '';
+        const hasSuchQueryIndexInSegment = searchableIndexes.some(({ value }) => value === state.locallyChangedQueryIndex);
+        nextState.locallyChangedQueryIndex = hasSuchQueryIndexInSegment ? state.locallyChangedQueryIndex : '';
       }
     }
 


### PR DESCRIPTION
## Description
When we make request with the query index `Title (all)` in the `Instance` segment and then switch to `Holdings` and make request here, but we don't have the `Title (all)` in the `Holdings` segment, we will see an [error](https://issues.folio.org/secure/attachment/58884/2023-03-09_15h31_41.mp4). Therefore, we need to check if the selected segment has previously picked the query index or not.
## Issues
[STSMACOM-735](https://issues.folio.org/browse/STSMACOM-735)
## Screencast

https://user-images.githubusercontent.com/77053927/224097687-198067ff-1c51-4218-8a8a-492decab032e.mp4

