### PR TITLE
STSMACOM-719 Optimize `useColumnManager` to reduce redundant renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add `limit` query params to `ProxyManager` component. Refs STSMACOM-731.
 * Disabled action menu if user does not have any of the required permissions. Refs STSMACOM-736.
 * Reset the previously selected query index when there is none in the next selected segment. Fixes STSMACOM-735.
+* Optimize `useColumnManager` to reduce redundant renders. Refs STSMACOM-719.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/ColumnManager/useColumnManager.js
+++ b/lib/ColumnManager/useColumnManager.js
@@ -5,7 +5,7 @@ const useColumnManager = (prefix, columnMapping, persist) => {
   const storageKey = `${prefix}-storage`;
 
   // The column mapping object determines the default visible columns and order
-  const defaultColumnKeys = Object.keys(columnMapping);
+  const defaultColumnKeys = useMemo(() => Object.keys(columnMapping), [columnMapping]);
 
   const [visibleColumns, setVisibleColumns] = useState(() => {
     const stored = STORAGE.getItem(storageKey);


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STSMACOM-719

`useColumnManager` hook contains a variable that is a dependency in other hooks:
```
const defaultColumnKeys = Object.keys(columnMapping);
```
```
const orderedVisibleColumns = useMemo(() => {
    const visibleColumnsSet = new Set(visibleColumns);

    return defaultColumnKeys.filter(key => visibleColumnsSet.has(key));
}, [defaultColumnKeys, visibleColumns]);
```

Since each re-render creates a new array of keys, changing the value of the reference of this variable will entail a number of redundant renders of dependent components.

<details>
<summary>Preview</summary>

![chrome_fkyDsMObUQ](https://user-images.githubusercontent.com/88109087/224916730-ab2f1c50-b2ba-4f8b-bf3e-41f7885a8b0b.gif)

</details>

---

Memoization in this case is a more profitable operation than calling an additional rerender of an MCL with a hundred elements.

<details>
<summary>Preview</summary>

![chrome_FO7PSUc9iq](https://user-images.githubusercontent.com/88109087/224916697-b5a0ad98-a515-415f-be9e-4287ae8982b3.gif)

</details>

