### PR TITLE
STSMACOM-735: Fix a page crush if `searchableIndexes` prop is missing. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Disabled action menu if user does not have any of the required permissions. Refs STSMACOM-736.
 * Reset the previously selected query index when there is none in the next selected segment. Fixes STSMACOM-735.
 * Optimize `useColumnManager` to reduce redundant renders. Refs STSMACOM-719.
+* Fix a page crush if searchableIndexes prop is missing. Fixes STSMACOM-735.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -355,9 +355,11 @@ class SearchAndSort extends React.Component {
       // if no 'qindex' parameter is present in window.location, keep or reset the local qIndex:
       if (parsedQuery?.qindex) {
         nextState.locallyChangedQueryIndex = parsedQuery.qindex;
-      } else {
+      } else if (searchableIndexes) {
         const hasSuchQueryIndexInSegment = searchableIndexes.some(({ value }) => value === state.locallyChangedQueryIndex);
         nextState.locallyChangedQueryIndex = hasSuchQueryIndexInSegment ? state.locallyChangedQueryIndex : '';
+      } else {
+        nextState.locallyChangedQueryIndex = state.locallyChangedQueryIndex || '';
       }
     }
 


### PR DESCRIPTION
## Purpose
Fix a page crush if `searchableIndexes` prop is missing. This is related to the previous [PR](https://github.com/folio-org/stripes-smart-components/pull/1328).
## Issue
[STSMACOM-735](https://issues.folio.org/browse/STSMACOM-735)