### PR TITLE
STSMACOM-735 Reset query index when there is none in the next selected segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## 8.0.2
+
+* Reset the previously selected query index when there is none in the next selected segment. Fixes STSMACOM-735.
+
 ## [8.0.1](https://github.com/folio-org/stripes-smart-components/tree/v8.0.1) (2023-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v8.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.0.2
 
 * Reset the previously selected query index when there is none in the next selected segment. Fixes STSMACOM-735.
+* Fix a page crash if `searchableIndexes` prop is missing. Fixes STSMACOM-735.
 
 ## [8.0.1](https://github.com/folio-org/stripes-smart-components/tree/v8.0.1) (2023-02-21)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v8.0.1)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -336,6 +336,7 @@ class SearchAndSort extends React.Component {
       location: {
         search
       },
+      searchableIndexes,
     } = props;
 
     const nextState = {};
@@ -355,7 +356,8 @@ class SearchAndSort extends React.Component {
       if (parsedQuery?.qindex) {
         nextState.locallyChangedQueryIndex = parsedQuery.qindex;
       } else {
-        nextState.locallyChangedQueryIndex = state.locallyChangedQueryIndex || '';
+        const hasSuchQueryIndexInSegment = searchableIndexes.some(({ value }) => value === state.locallyChangedQueryIndex);
+        nextState.locallyChangedQueryIndex = hasSuchQueryIndexInSegment ? state.locallyChangedQueryIndex : '';
       }
     }
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -355,9 +355,11 @@ class SearchAndSort extends React.Component {
       // if no 'qindex' parameter is present in window.location, keep or reset the local qIndex:
       if (parsedQuery?.qindex) {
         nextState.locallyChangedQueryIndex = parsedQuery.qindex;
-      } else {
+      } else if (searchableIndexes) {
         const hasSuchQueryIndexInSegment = searchableIndexes.some(({ value }) => value === state.locallyChangedQueryIndex);
         nextState.locallyChangedQueryIndex = hasSuchQueryIndexInSegment ? state.locallyChangedQueryIndex : '';
+      } else {
+        nextState.locallyChangedQueryIndex = state.locallyChangedQueryIndex || '';
       }
     }
 


### PR DESCRIPTION
* Reset the previously selected query index when there is none in the next selected segment.
* Fix a page crash if `searchableIndexes` prop is missing.

Refs STSMACOM-735