### PR TITLE
STSMACOM-742 avoid experimental decorator syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix a page crush if searchableIndexes prop is missing. Fixes STSMACOM-735.
 * Fix an excessive Notes pop-ups. Fixes STSMACOM-738.
 * Accept override default column visibility in ColumnManager. Fixes STSMACOM-734.
+* Avoid experimental decorator syntax to enable `esbuild-loader` transpiler. Refs STSMACOM-742.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/Notes/NoteCreatePage/NoteCreatePage.js
+++ b/lib/Notes/NoteCreatePage/NoteCreatePage.js
@@ -15,7 +15,6 @@ import NoteForm from '../components/NoteForm';
 import { noteTypesCollectionShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 
-@stripesConnect
 class NoteCreatePage extends Component {
   static propTypes = {
     domain: PropTypes.string.isRequired,
@@ -175,4 +174,4 @@ class NoteCreatePage extends Component {
   }
 }
 
-export default NoteCreatePage;
+export default stripesConnect(NoteCreatePage);

--- a/lib/Notes/NoteEditPage/NoteEditPage.js
+++ b/lib/Notes/NoteEditPage/NoteEditPage.js
@@ -16,7 +16,6 @@ import { noteTypesCollectionShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 import { getMetadataPropsFromResponse } from '../utils';
 
-@stripesConnect
 class NoteEditPage extends Component {
   static propTypes = {
     domain: PropTypes.string.isRequired,
@@ -207,4 +206,4 @@ class NoteEditPage extends Component {
   }
 }
 
-export default NoteEditPage;
+export default stripesConnect(NoteEditPage);

--- a/lib/Notes/NoteViewPage/NoteViewPage.js
+++ b/lib/Notes/NoteViewPage/NoteViewPage.js
@@ -20,7 +20,6 @@ import NoteView from './components/NoteView';
 import { noteShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 
-@stripesConnect
 class NoteViewPage extends Component {
   static propTypes = {
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
@@ -312,4 +311,4 @@ class NoteViewPage extends Component {
   }
 }
 
-export default injectIntl(NoteViewPage);
+export default stripesConnect(injectIntl(NoteViewPage));

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -42,7 +42,7 @@ const searchQueryParams = {
   [notesColumnNames.TITLE_AND_DETAILS]: 'title',
   [notesColumnNames.TYPE]: 'noteType',
 };
-@stripesConnect
+
 class NotesSmartAccordion extends Component {
   static propTypes = {
     domainName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
@@ -403,4 +403,4 @@ class NotesSmartAccordion extends Component {
   }
 }
 
-export default withRouter(NotesSmartAccordion);
+export default stripesConnect(withRouter(NotesSmartAccordion));


### PR DESCRIPTION
Decorator syntax is still experimental and not all transpilers can handle it. In particular, `esbuild-loader` does not support it (https://github.com/evanw/esbuild/issues/104) and understandably doesn't plan to until the specification settles down. esbuild-loader offers a ~50% performance bump over babel-loader, and refactoring to stick with standard feels like a fair price to pay for that.

Refs [STSMACOM-742](https://issues.folio.org/browse/STSMACOM-742), [STRWEB-76](https://issues.folio.org/browse/STRWEB-76)