### PR TITLE
STSMACOM-741 Fix notes pop-up didn't appear in Checkout app when first checked out user didn't have notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix a page crush if searchableIndexes prop is missing. Fixes STSMACOM-735.
 * Fix an excessive Notes pop-ups. Fixes STSMACOM-738.
 * Accept override default column visibility in ColumnManager. Fixes STSMACOM-734.
+* Fix notes pop-up didn't appear in Checkout app when first checked out user didn't have notes. Fixes STSMACOM-741.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/Notes/NotePopupModal/NotePopupModal.js
+++ b/lib/Notes/NotePopupModal/NotePopupModal.js
@@ -102,6 +102,8 @@ const NotePopupModal = ({
   }, [popUpPropertyName]);
 
   const handleGetNotesRequest = useCallback((notes) => {
+    isNotesLoading.current = false;
+
     const userNotes = getPopupNotesFromNotes(notes);
 
     if (!userNotes.length) {


### PR DESCRIPTION
## Description
Reset `isNotesLoading` flag when handling load notes request

## Screenshots

https://user-images.githubusercontent.com/19309423/229775237-7db89272-f933-4873-a6cd-253b6695ad8e.mp4

## Issues
[STSMACOM-741](https://issues.folio.org/browse/STSMACOM-741)