### PR TITLE
STSMACOM-744: Make `refreshRemote` prop optional in `Tags` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix an excessive Notes pop-ups. Fixes STSMACOM-738.
 * Accept override default column visibility in ColumnManager. Fixes STSMACOM-734.
 * Fix notes pop-up didn't appear in Checkout app when first checked out user didn't have notes. Fixes STSMACOM-741.
+* Make refreshRemote prop optional in Tags component. Refs STSMACOM-744.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -46,7 +46,7 @@ class Tags extends React.Component {
       tags: PropTypes.shape({ POST: PropTypes.func.isRequired }),
     }),
     onToggle: PropTypes.func,
-    refreshRemote: PropTypes.func.isRequired,
+    refreshRemote: PropTypes.func,
     resources: PropTypes.shape({
       entities: PropTypes.shape({
         isPending: PropTypes.bool,
@@ -73,7 +73,7 @@ class Tags extends React.Component {
     // `stripes-connect` is supposed to do it under the hood but there is a bug,
     // and therefore it is needed to do it manually.
     if (prevProps.link !== this.props.link) {
-      this.props.refreshRemote(this.props);
+      this.props?.refreshRemote(this.props);
     }
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-744