### PR TITLE
More configurable makeQueryFunction

### DIFF
--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -27,7 +27,7 @@ import { removeNsKeys } from './nsQueryFunctions';
 //      escape (boolean): whether to escape quote and backslash values in the query (default: true)
 //      rightTrunc (boolean): whether to append '*' to query terms (default: true)
 //     For compatibility, a boolean value may be passed, and is used as the `escape` configuration value.
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, configOrEscape) {
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, configOrEscape = true) {
   const config = typeof configOrEscape === 'object' ?
     { rightTrunc: true, escape: true, ...configOrEscape } :
     { rightTrunc: true, escape: configOrEscape };

--- a/lib/SearchAndSort/makeQueryFunction.js
+++ b/lib/SearchAndSort/makeQueryFunction.js
@@ -23,8 +23,15 @@ import { removeNsKeys } from './nsQueryFunctions';
 //      2: fail if both query and filters and empty.
 //     For compatibility, false and true may be used for 0 and 1 respectively.
 // @nsParams object|string: namespace keys
-// @escape boolean whether to escape quote and backslash values in the query (default: true)
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, escape = true) {
+// @configOrEscape object|boolean: an object containing configuration parameters:
+//      escape (boolean): whether to escape quote and backslash values in the query (default: true)
+//      rightTrunc (boolean): whether to append '*' to query terms (default: true)
+//     For compatibility, a boolean value may be passed, and is used as the `escape` configuration value.
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, configOrEscape) {
+  const config = typeof configOrEscape === 'object' ?
+    { rightTrunc: true, escape: true, ...configOrEscape } :
+    { rightTrunc: true, escape: configOrEscape };
+
   return (queryParams, pathComponents, resourceValues, logger) => {
     const resourceQuery = removeNsKeys(resourceValues.query, nsParams);
     const nsQueryParams = removeNsKeys(queryParams, nsParams);
@@ -40,15 +47,15 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       return null;
     }
 
-    const escapeFx = escape ? escapeCqlValue : (s) => (s);
+    const escapeFx = config.escape ? escapeCqlValue : (s) => (s);
 
     let cql;
     if (query && qindex) {
       const t = qindex.split('/', 2);
       if (t.length === 1) {
-        cql = `${qindex}="${escapeFx(query)}*"`;
+        cql = `${qindex}="${escapeFx(query)}${config.rightTrunc ? '*' : ''}"`;
       } else {
-        cql = `${t[0]} =/${t[1]} "${escapeFx(query)}*"`;
+        cql = `${t[0]} =/${t[1]} "${escapeFx(query)}${config.rightTrunc ? '*' : ''}"`;
       }
     } else if (query) {
       const escapedQuery = { ...resourceQuery, ...{ query: escapeFx(get(resourceQuery, 'query', '')) } };

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -84,7 +84,9 @@ See ui-users' top-level component [`<Users.js>`](https://github.com/folio-org/ui
 
 Invoked as:
 
-	makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition)
+	makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams, config)
+
+(The last three of there parameters are all optional.)
 
 Makes and returns a function, suitable to be used as the `query` param of a stripes-connect resource configuration. The function is itself configured by five parameters, which will vary depending on the module that is using it, and will use these to determine how to interpret the query, filters and sort-specification in the application state. It is generally used as follows:
 ```
@@ -107,7 +109,7 @@ static manifest = Object.freeze({
 });
 ```
 
-The five parameters are:
+The six parameters are:
 
 * `findAll` -- a CQL string that can be used to find all records, for situations where no query or filters are specified and the application wants all records to be listed.
 * `queryTemplate` -- a CQL string into which the query and other data can be substituted, using the same syntax as [path substitution in stripes-connect](https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution): for example, `?{query}` interpolates the `query` parameter from the URL.
@@ -119,10 +121,18 @@ The five parameters are:
   * `2`: fail if both query and filters and empty.
 
   For backwards compatibility, `false` (or omitting the argument altogether) is equivalent to `0` , and `true` is equivalent to `1`.
+* `nsParams` -- namespace keys
+* `config` -- an object containing configuration parameters:
+  * `escape` (boolean): whether to escape quote and backslash values in the query [default: `true`]
+  * `rightTrunc` (boolean): whether to append `*` to query terms [default: `true`].
 
-  ## Components for filtering
+  For backslash compatibility, a boolean value may be passed instead of the config structure: this is used as the `escape` configuration value.
 
-  Please, pay attention, there is a set of components to be used for filtering inside SearchAndSort component. Each component represents a wrapper on existing form element component e.g. MultiSelect or renders a set of elements working like one filter e.g. CheckboxFilter. After change returns data in format: {name: <String>, values: <ArrayOfObjects>}, where name -- is a filter name and values -- filter values.
+
+
+## Components for filtering
+
+Please, pay attention, there is a set of components to be used for filtering inside SearchAndSort component. Each component represents a wrapper on existing form element component e.g. MultiSelect or renders a set of elements working like one filter e.g. CheckboxFilter. After change returns data in format: {name: <String>, values: <ArrayOfObjects>}, where name -- is a filter name and values -- filter values.
 
 
 ## Implementing filters


### PR DESCRIPTION
More configurable makeQueryFunction

The boolean `escape` parameter is replaced by a `config` object, which can contain multiple configuration options. These at present include:
* `escape` (boolean) — as before, specifies whether to escape quote and backslash values in the query [default: `true`]
* `rightTrunc` (boolean) — whether to append `*` to query terms [default: `true`].

And of course it will be easy to add other such entries later if we need them.

This version of the function is 100% backwards-compatible with the previous version: a boolean can be passed in place of the config object, and is interpreted as the value of `config.escape`. As before, this defaults to true if not specified.
