### PR TITLE
STSMACOM-750 Use correct proptype for 'expanded' prop for EditCustomFieldRecord

### DIFF
--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -57,7 +57,7 @@ const propTypes = {
   changeReduxFormField: PropTypes.func,
   columnCount: PropTypes.number,
   entityType: PropTypes.string.isRequired,
-  expanded: PropTypes.bool.isRequired,
+  expanded: PropTypes.bool,
   fieldComponent: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.func,


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-750

Removes the `isRequired` check from the `expanded` prop-type.

This is problematic because if the prop is just statically applied to appease the proptypes/clean the resulting console errors, the Accordion will be stuck in that non-interactive state - stuck open or closed.