### PR TITLE
Optional `resourcePath` prop for `<EntryManager>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Pass proper `count` value to screen reader message in SearchAndSort. Refs STSMACOM-718.
 * Remove `isRequired` check from `expanded` prop on EditCustomFieldsRecord. Refs STSMACOM-750.
 * Unlock `locallyChangedSearchTerm` sync with `query` parameter. Fixes STSMACOM-754.
+* Enhance `<EntryManager>` with optional `resourcePath` prop to fetch full record. Fixes STSMACOM-757.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/EntryManager/ConnectedDetail.js
+++ b/lib/EntryManager/ConnectedDetail.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useOkapiKy } from '@folio/stripes/core';
+import { Loading } from '@folio/stripes/components';
+
+function ConnectedDetail({ resourcePath, initialValues, underlyingComponent, ...rest }) {
+  const okapiKy = useOkapiKy();
+  const [record, setRecord] = useState();
+  const [loading, setLoading] = useState(false);
+
+  if (!record) {
+    if (!loading) {
+      setLoading(true);
+      okapiKy(`${resourcePath}/${initialValues.id}`)
+        .then(res => res.json().then(rec => {
+          setRecord(rec);
+          setLoading(false);
+        }));
+    }
+    return <Loading />;
+  }
+
+  const Component = underlyingComponent;
+  return <Component initialValues={record} {...rest} />;
+}
+
+ConnectedDetail.propTypes = {
+  resourcePath: PropTypes.string.isRequired,
+  initialValues: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  underlyingComponent: PropTypes.func, // React component
+};
+
+export default ConnectedDetail;

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useOkapiKy } from '@folio/stripes/core';
 import { Loading } from '@folio/stripes/components';
 
-function ConnectedDetail({ resourcePath, initialValues, underlyingComponent, ...rest }) {
+function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ...rest }) {
   const okapiKy = useOkapiKy();
   const [record, setRecord] = useState();
   const [loading, setLoading] = useState(false);
@@ -24,7 +24,7 @@ function ConnectedDetail({ resourcePath, initialValues, underlyingComponent, ...
   return <Component initialValues={record} {...rest} />;
 }
 
-ConnectedDetail.propTypes = {
+ConnectedWrapper.propTypes = {
   resourcePath: PropTypes.string.isRequired,
   initialValues: PropTypes.shape({
     id: PropTypes.string.isRequired,
@@ -32,4 +32,4 @@ ConnectedDetail.propTypes = {
   underlyingComponent: PropTypes.func, // React component
 };
 
-export default ConnectedDetail;
+export default ConnectedWrapper;

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -7,6 +7,13 @@ function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ..
   const okapiKy = useOkapiKy();
   const [record, setRecord] = useState();
   const [loading, setLoading] = useState(false);
+  const Component = underlyingComponent;
+
+  console.log('initialValues =', initialValues);
+  if (!initialValues.id) {
+    // Creating a new record: pass through
+    return <Component initialValues={initialValues} {...rest} />;
+  }
 
   if (!record) {
     if (!loading) {
@@ -20,14 +27,13 @@ function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ..
     return <Loading />;
   }
 
-  const Component = underlyingComponent;
   return <Component initialValues={record} {...rest} />;
 }
 
 ConnectedWrapper.propTypes = {
   resourcePath: PropTypes.string.isRequired,
   initialValues: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+    id: PropTypes.string,
   }).isRequired,
   underlyingComponent: PropTypes.func, // React component
 };

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useOkapiKy } from '@folio/stripes/core';
 import { Loading } from '@folio/stripes/components';
@@ -6,26 +6,35 @@ import { Loading } from '@folio/stripes/components';
 function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ...rest }) {
   const okapiKy = useOkapiKy();
   const [record, setRecord] = useState();
-  const [loading, setLoading] = useState(false);
   const Component = underlyingComponent;
+
+  console.log('in ConnectedWrapper, id =', initialValues.id);
+  useEffect(() => {
+    console.log(' useEffect', [initialValues.id, okapiKy, resourcePath]);
+    if (initialValues.id) {
+      console.log(`  fetching from ${resourcePath}/${initialValues.id}`);
+      okapiKy(`${resourcePath}/${initialValues.id}`)
+        .then(res => res.json().then(rec => {
+          console.log(`   got record with name ${rec.name}`);
+          setRecord(rec);
+        }));
+    }
+    // If `okpaiKy` is included in the dependency list, the effect fires on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialValues.id, resourcePath]);
 
   if (!initialValues.id) {
     // Creating a new record: pass through
+    console.log(' no ID, creating new record');
     return <Component initialValues={initialValues} {...rest} />;
   }
 
   if (!record) {
-    if (!loading) {
-      setLoading(true);
-      okapiKy(`${resourcePath}/${initialValues.id}`)
-        .then(res => res.json().then(rec => {
-          setRecord(rec);
-          setLoading(false);
-        }));
-    }
+    console.log(' no record yet, showing spinner');
     return <Loading />;
   }
 
+  console.log(' got record yet, showing underlying component');
   return <Component initialValues={record} {...rest} />;
 }
 

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -9,7 +9,6 @@ function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ..
   const [loading, setLoading] = useState(false);
   const Component = underlyingComponent;
 
-  console.log('initialValues =', initialValues);
   if (!initialValues.id) {
     // Creating a new record: pass through
     return <Component initialValues={initialValues} {...rest} />;

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useOkapiKy } from '@folio/stripes/core';
-import { Loading } from '@folio/stripes/components';
+import { useOkapiKy } from '@folio/stripes-core';
+import { Loading } from '@folio/stripes-components';
 
 function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ...rest }) {
   const okapiKy = useOkapiKy();

--- a/lib/EntryManager/ConnectedWrapper.js
+++ b/lib/EntryManager/ConnectedWrapper.js
@@ -8,14 +8,10 @@ function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ..
   const [record, setRecord] = useState();
   const Component = underlyingComponent;
 
-  console.log('in ConnectedWrapper, id =', initialValues.id);
   useEffect(() => {
-    console.log(' useEffect', [initialValues.id, okapiKy, resourcePath]);
     if (initialValues.id) {
-      console.log(`  fetching from ${resourcePath}/${initialValues.id}`);
       okapiKy(`${resourcePath}/${initialValues.id}`)
         .then(res => res.json().then(rec => {
-          console.log(`   got record with name ${rec.name}`);
           setRecord(rec);
         }));
     }
@@ -25,16 +21,13 @@ function ConnectedWrapper({ resourcePath, initialValues, underlyingComponent, ..
 
   if (!initialValues.id) {
     // Creating a new record: pass through
-    console.log(' no ID, creating new record');
     return <Component initialValues={initialValues} {...rest} />;
   }
 
   if (!record) {
-    console.log(' no record yet, showing spinner');
     return <Loading />;
   }
 
-  console.log(' got record yet, showing underlying component');
   return <Component initialValues={record} {...rest} />;
 }
 

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -20,6 +20,7 @@ import {
   ConfirmationModal,
   Modal,
 } from '@folio/stripes-components';
+import ConnectedDetail from './ConnectedDetail';
 
 class EntrySelector extends React.Component {
   static propTypes = {
@@ -57,6 +58,7 @@ class EntrySelector extends React.Component {
     paneWidth: PropTypes.string.isRequired,
     parentMutator: PropTypes.object.isRequired,
     parentResources: PropTypes.object,
+    resourcePath: PropTypes.string,
     permissions: PropTypes.object,
     prohibitItemDelete: PropTypes.shape({
       close: PropTypes.oneOfType([
@@ -215,6 +217,7 @@ class EntrySelector extends React.Component {
       paneWidth,
       detailComponent,
       parentMutator,
+      resourcePath,
       editable,
       parentResources,
       enableDetailsActionMenu,
@@ -227,7 +230,7 @@ class EntrySelector extends React.Component {
       prohibitDelete,
     } = this.state;
 
-    const ComponentToRender = detailComponent;
+    const ComponentToRender = resourcePath ? ConnectedDetail : detailComponent;
 
     const lastMenu = (
       <PaneMenu>
@@ -264,6 +267,8 @@ class EntrySelector extends React.Component {
           parentResources={parentResources}
           initialValues={item}
           parentMutator={parentMutator}
+          resourcePath={this.props.resourcePath}
+          underlyingComponent={detailComponent}
         />
         <ConfirmationModal
           id="delete-item-confirmation"

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -20,7 +20,7 @@ import {
   ConfirmationModal,
   Modal,
 } from '@folio/stripes-components';
-import ConnectedDetail from './ConnectedDetail';
+import ConnectedWrapper from './ConnectedWrapper';
 
 class EntrySelector extends React.Component {
   static propTypes = {
@@ -230,7 +230,7 @@ class EntrySelector extends React.Component {
       prohibitDelete,
     } = this.state;
 
-    const ComponentToRender = resourcePath ? ConnectedDetail : detailComponent;
+    const ComponentToRender = resourcePath ? ConnectedWrapper : detailComponent;
 
     const lastMenu = (
       <PaneMenu>

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -16,7 +16,7 @@ import find from 'lodash/find';
 
 import EntryForm from './EntryForm';
 import EntrySelector from './EntrySelector';
-import ConnectedDetail from './ConnectedDetail';
+import ConnectedWrapper from './ConnectedWrapper';
 
 export default class EntryWrapper extends React.Component {
   static manifest = Object.freeze({
@@ -249,7 +249,7 @@ export default class EntryWrapper extends React.Component {
     );
 
     const EntryFormComponent = (this.props.entryFormComponent) ? this.props.entryFormComponent : EntryForm;
-    const ComponentToRender = resourcePath ? ConnectedDetail : EntryFormComponent;
+    const ComponentToRender = resourcePath ? ConnectedWrapper : EntryFormComponent;
 
     return (
       <EntrySelector

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -49,6 +49,7 @@ export default class EntryWrapper extends React.Component {
     nameKey: PropTypes.string.isRequired,
     onBeforeSave: PropTypes.func,
     paneTitle: PropTypes.node.isRequired,
+    resourcePath: PropTypes.string,
     parentMutator: PropTypes.object,
     parseInitialValues: PropTypes.func,
     permissions: PropTypes.shape({
@@ -257,6 +258,7 @@ export default class EntryWrapper extends React.Component {
         onRemove={this.onRemove}
         detailComponent={this.props.detailComponent}
         contentData={entryList}
+        resourcePath={this.props.resourcePath}
         parentMutator={this.props.parentMutator}
         paneTitle={this.props.paneTitle}
         detailPaneTitle={selectedItem ? selectedItem[nameKey] : entryLabel}

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -16,6 +16,7 @@ import find from 'lodash/find';
 
 import EntryForm from './EntryForm';
 import EntrySelector from './EntrySelector';
+import ConnectedDetail from './ConnectedDetail';
 
 export default class EntryWrapper extends React.Component {
   static manifest = Object.freeze({
@@ -206,6 +207,7 @@ export default class EntryWrapper extends React.Component {
       permissions,
       entryLabel,
       parseInitialValues,
+      resourcePath,
       nameKey
     } = this.props;
     const { selectedId } = this.state;
@@ -247,6 +249,7 @@ export default class EntryWrapper extends React.Component {
     );
 
     const EntryFormComponent = (this.props.entryFormComponent) ? this.props.entryFormComponent : EntryForm;
+    const ComponentToRender = resourcePath ? ConnectedDetail : EntryFormComponent;
 
     return (
       <EntrySelector
@@ -272,7 +275,7 @@ export default class EntryWrapper extends React.Component {
               contentLabel={contentLabel}
               container={container}
             >
-              <EntryFormComponent
+              <ComponentToRender
                 {...this.props}
                 initialValues={initialValues}
                 cloning={cloning}
@@ -284,6 +287,8 @@ export default class EntryWrapper extends React.Component {
                 asyncValidate={this.props.asyncValidate}
                 deleteDisabled={this.props.deleteDisabled ? this.props.deleteDisabled : () => (false)}
                 deleteDisabledMessage={this.props.deleteDisabledMessage || ''}
+                resourcePath={this.props.resourcePath}
+                underlyingComponent={EntryFormComponent}
               />
             </Layer>
           )}

--- a/lib/EntryManager/readme.md
+++ b/lib/EntryManager/readme.md
@@ -30,3 +30,11 @@ addMenu | component | An optional component which can be used to override defaul
 parseInitialValues | function | An optional function which can be used to parse initialValues object
 isEntryInUse | function | An optional function which allows or prohibit item deletion. It takes an item id and returns a boolean value. 
 prohibitItemDelete | object with keys `close`, `label`, `message` | An optional object which provides a possibility to customize label, message and submit button of `prohibitDelete` modal with relevant object properties. 
+resourcePath | string | An optional string specifying the path to a resource from which full records can be obtained. See below.
+
+## Summary records
+
+The `<EntryList>` component was created on the assumption that the records it manages are returned in full when a list is requested: so, for example, the list of records returned from `/path/to/endpoint` are each the same shape as the individual ones obtained by ID at paths like `/path/to/endpoint/12335`. This pattern is generally followed by most web-service endpoints provided by most FOLIO modules.
+
+Some modules, however, return a list of summary records (for example, just ID and title), so that it's necessary to fetch each full record separately by ID. When `<EntryList>` is used to manage records on such an endpoint, the path to that service should be passed in as the `resourcePath` prop. When this is done, the full record is fetched each time a user views or edits a record.
+


### PR DESCRIPTION
The `<EntryList>` component was created on the assumption that the records it manages are returned in full when a list is requested: so, for example, the list of records returned from `/path/to/endpoint` are each the same shape as the individual ones obtained by ID at paths like `/path/to/endpoint/12335`. This pattern is generally followed by most web-service endpoints provided by most FOLIO modules.

Some modules, however, return a list of summary records (for example, just ID and title), so that it's necessary to fetch each full record separately by ID. When `<EntryList>` is used to manage records on such an endpoint, the path to that service should be passed in as the `resourcePath` prop. When this is done, the full record is fetched each time a user views or edits a record.

This is required by:
* https://issues.folio.org/browse/UIHAADM-7
* https://issues.folio.org/browse/UIHAADM-8
* https://issues.folio.org/browse/UIHAADM-9
