### PR TITLE
STSMACOM-758 Update `locallyChangedSearchTerm` when `query` changes, but keep value when `qindex` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove `isRequired` check from `expanded` prop on EditCustomFieldsRecord. Refs STSMACOM-750.
 * Unlock `locallyChangedSearchTerm` sync with `query` parameter. Fixes STSMACOM-754.
 * Enhance `<EntryManager>` with optional `resourcePath` prop to fetch full record. Fixes STSMACOM-757.
+* Update `locallyChangedSearchTerm` when `query` changes, but keep value when `qindex` changes. Fixes STSMACOM-758.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -346,7 +346,7 @@ class SearchAndSort extends React.Component {
 
       // if the search hasn't been changed by the user,
       // sync it to the query string...
-      if (!state.locallyChangedSearchTerm && parsedQuery?.query) {
+      if (parsedQuery?.query !== queryString.parse(state.previousQueryString)?.query) {
         nextState.locallyChangedSearchTerm = parsedQuery.query;
       }
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -136,6 +136,7 @@ class SearchAndSort extends React.Component {
     }).isRequired,
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
+    initiallySelectedRecord: PropTypes.string,
     isCountHidden: PropTypes.bool,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
@@ -436,10 +437,13 @@ class SearchAndSort extends React.Component {
   }
 
   get initiallySelectedRecord() {
-    const { location: { pathname } } = this.props;
+    const {
+      location: { pathname },
+      initiallySelectedRecord,
+    } = this.props;
 
     const match = pathname.match(/^\/.*\/view\/(.*)$/);
-    const recordId = match && match[1];
+    const recordId = (match && match[1]) || initiallySelectedRecord;
 
     return { id: recordId };
   }


### PR DESCRIPTION
## Description
Update `locallyChangedSearchTerm` when `query` changes, but keep value when `qindex` changes
This can happen when user is switching between Search modes, and there are saved `query` values for previous searches

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/ba58b0e9-3a00-473d-8ac6-dcc22aa81e7a



## Issues
[STSMACOM-758](https://issues.folio.org/browse/STSMACOM-758)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2177