### PR TITLE
STSMACOM-759 Expose `<EntryForm>` and `<EntrySelector>` components for reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove `isRequired` check from `expanded` prop on EditCustomFieldsRecord. Refs STSMACOM-750.
 * Unlock `locallyChangedSearchTerm` sync with `query` parameter. Fixes STSMACOM-754.
 * Enhance `<EntryManager>` with optional `resourcePath` prop to fetch full record. Fixes STSMACOM-757.
+* Expose `<EntryForm>` and `<EntrySelector>` components for reuse. Refs STSMACOM-759.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ export { default as ControlledVocab } from './lib/ControlledVocab';
 export { default as EditableList } from './lib/EditableList';
 
 export { default as EntryManager } from './lib/EntryManager';
+export { default as EntryForm } from './lib/EntryManager/EntryForm';
+export { default as EntrySelector } from './lib/EntryManager/EntrySelector';
 
 export { default as LocationLookup } from './lib/LocationLookup';
 export { default as LocationSelection } from './lib/LocationSelection';

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -93,7 +93,7 @@ class Settings extends Component {
         <Pane
           defaultWidth={props.navPaneWidth}
           paneTitle={props.paneTitle || 'Module Settings'}
-          firstMenu={<PaneBackLink to="/settings" />}
+          firstMenu={<PaneBackLink to={props.paneBackLink} />}
           paneTitleRef={this.paneTitleRef}
           onMount={this.handlePaneFocus}
           id="app-settings-nav-pane"
@@ -147,6 +147,7 @@ Settings.propTypes = {
       route: PropTypes.string.isRequired,
     }),
   ),
+  paneBackLink: PropTypes.string,
   paneTitle: PropTypes.node,
   paneTitleRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   sections: PropTypes.arrayOf(
@@ -170,6 +171,7 @@ Settings.propTypes = {
 
 Settings.defaultProps = {
   navPaneWidth: '30%',
+  paneBackLink: '/settings',
 };
 
 export default withStripes(Settings);


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-759

In order to implement consortium-related components, it would be useful not to write all from scratch, but use existing ones.