### PR TITLE
Report error-messages when saving a record in <EntryManager>

### DIFF
--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -132,7 +132,7 @@ export default class EntryWrapper extends React.Component {
       errorMessage = response.errors[0].message;
     } else {
       const { message, statusText } = error;
-      errorMessage = message || statusText;
+      errorMessage = message || statusText || await error.text();
     }
 
     this.showSubmitErrorCallout(errorMessage);


### PR DESCRIPTION
Previously, if the back-end reported an error, it would never be extracted from the response body and an empty error toast would be displayed. Now we extract the response body and display that.