### PR TITLE
`<EntryManager>`: `parseInitialValues` prop works with `resourcePath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove `isRequired` check from `expanded` prop on EditCustomFieldsRecord. Refs STSMACOM-750.
 * Unlock `locallyChangedSearchTerm` sync with `query` parameter. Fixes STSMACOM-754.
 * Enhance `<EntryManager>` with optional `resourcePath` prop to fetch full record. Fixes STSMACOM-757.
+* Make `<EntryManager>`s `parseInitialValues` function work with correctly when `resourcePath` is defined. Document this previously undocumented prop and its converse, `onBeforeSave`. Fixes STSMACOM-761.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -58,6 +58,7 @@ class EntrySelector extends React.Component {
     paneWidth: PropTypes.string.isRequired,
     parentMutator: PropTypes.object.isRequired,
     parentResources: PropTypes.object,
+    parseInitialValues: PropTypes.func.isRequired,
     resourcePath: PropTypes.string,
     permissions: PropTypes.object,
     prohibitItemDelete: PropTypes.shape({
@@ -218,6 +219,7 @@ class EntrySelector extends React.Component {
       detailComponent,
       parentMutator,
       resourcePath,
+      parseInitialValues,
       editable,
       parentResources,
       enableDetailsActionMenu,
@@ -230,7 +232,11 @@ class EntrySelector extends React.Component {
       prohibitDelete,
     } = this.state;
 
-    const ComponentToRender = resourcePath ? ConnectedWrapper : detailComponent;
+    const DC = detailComponent; // Must start with a capital for JSX syntax to work
+    const detailComponentWithParsing = ({ initialValues, ...rest }) => (
+      <DC initialValues={parseInitialValues(initialValues)} {...rest} />
+    );
+    const ComponentToRender = resourcePath ? ConnectedWrapper : detailComponentWithParsing;
 
     const lastMenu = (
       <PaneMenu>
@@ -268,7 +274,7 @@ class EntrySelector extends React.Component {
           initialValues={item}
           parentMutator={parentMutator}
           resourcePath={this.props.resourcePath}
-          underlyingComponent={detailComponent}
+          underlyingComponent={detailComponentWithParsing}
         />
         <ConfirmationModal
           id="delete-item-confirmation"

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -63,6 +63,7 @@ export default class EntryWrapper extends React.Component {
   };
 
   static defaultProps = {
+    parseInitialValues: entry => entry,
     onBeforeSave: entry => entry
   };
 
@@ -220,11 +221,7 @@ export default class EntryWrapper extends React.Component {
     const selectedItem = (selectedId && !adding)
       ? find(entryList, entry => entry.id === selectedId) : defaultEntry;
 
-    let initialValues = cloning ? omit(selectedItem, 'id') : selectedItem;
-
-    if (parseInitialValues) {
-      initialValues = parseInitialValues(initialValues);
-    }
+    const initialValues = cloning ? omit(selectedItem, 'id') : selectedItem;
 
     const container = document.getElementById('ModuleContainer');
 
@@ -249,7 +246,10 @@ export default class EntryWrapper extends React.Component {
     );
 
     const EntryFormComponent = (this.props.entryFormComponent) ? this.props.entryFormComponent : EntryForm;
-    const ComponentToRender = resourcePath ? ConnectedWrapper : EntryFormComponent;
+    const EntryFormComponentWithParsing = ({ initialValues: iv, ...rest }) => (
+      <EntryFormComponent initialValues={parseInitialValues(iv)} {...rest} />
+    );
+    const ComponentToRender = resourcePath ? ConnectedWrapper : EntryFormComponentWithParsing;
 
     return (
       <EntrySelector
@@ -278,6 +278,7 @@ export default class EntryWrapper extends React.Component {
               <ComponentToRender
                 {...this.props}
                 initialValues={initialValues}
+                parseInitialValues={parseInitialValues}
                 cloning={cloning}
                 onSave={this.onSave}
                 onCancel={this.onCancel}
@@ -288,7 +289,7 @@ export default class EntryWrapper extends React.Component {
                 deleteDisabled={this.props.deleteDisabled ? this.props.deleteDisabled : () => (false)}
                 deleteDisabledMessage={this.props.deleteDisabledMessage || ''}
                 resourcePath={this.props.resourcePath}
-                underlyingComponent={EntryFormComponent}
+                underlyingComponent={EntryFormComponentWithParsing}
               />
             </Layer>
           )}

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -278,7 +278,6 @@ export default class EntryWrapper extends React.Component {
               <ComponentToRender
                 {...this.props}
                 initialValues={initialValues}
-                parseInitialValues={parseInitialValues}
                 cloning={cloning}
                 onSave={this.onSave}
                 onCancel={this.onCancel}

--- a/lib/EntryManager/readme.md
+++ b/lib/EntryManager/readme.md
@@ -32,6 +32,8 @@ isEntryInUse | function | An optional function which allows or prohibit item del
 prohibitItemDelete | object with keys `close`, `label`, `message` | An optional object which provides a possibility to customize label, message and submit button of `prohibitDelete` modal with relevant object properties. 
 enableDetailsActionMenu | bool | If present and true, replaces the **Edit** button at top right of full records with an action menu offering **Duplicate**, **Edit** and **Delete**.
 resourcePath | string | An optional string specifying the path to a resource from which full records can be obtained. See below.
+parseInitialValues | function | A function which accepts a record as loaded and returns a potentially modified version of that record suitable for display and editing. **Note.** the record must not be modified in place, but a modified copy of it returned.
+onBeforeSave | function | The converse of `parseInitialValues`: a function which accepts a record that has been edited in the entry form, and returns a potentially modified version of that record suitable for writing back to the WSAPI. **Note.** the record must not be modified in place, but a modified copy of it returned.
 
 ## Summary records
 


### PR DESCRIPTION
The `parseInitialValues` function is now applied correctly when
`resourcePath` is defined (see STSMACOM-757) so that full records are
loaded from a WSAPI.

Previously, the transformation would be applied to the brief version
of the record before the full record was loaded, so that fields that
occur only in the full version of the record were not transformed.

Also, I have documented these previously undocumented props.

Fixes STSMACOM-761.
