### PR TITLE
STSMACOM-762 Fix rendering loop in <EntryManager>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Enhance `<EntryManager>` with optional `resourcePath` prop to fetch full record. Fixes STSMACOM-757.
 * Expose `<EntryForm>` and `<EntrySelector>` components for reuse. Refs STSMACOM-759.
 * Make `<EntryManager>`s `parseInitialValues` function work with correctly when `resourcePath` is defined. Document this previously undocumented prop and its converse, `onBeforeSave`. Fixes STSMACOM-761.
+* Fix intermittent rendering loop when using `<EntryManager>` with `parseInitialValues`. Fixes STSMACOM-762.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -22,6 +22,12 @@ import {
 } from '@folio/stripes-components';
 import ConnectedWrapper from './ConnectedWrapper';
 
+
+// We can't use useMemo in a class-based component, and I can't make _.memoize work
+// So we'll do this by hand
+let lastDetailComponent, lastDetailComponentWithParsing;
+
+
 class EntrySelector extends React.Component {
   static propTypes = {
     addButtonTitle: PropTypes.string,
@@ -232,10 +238,19 @@ class EntrySelector extends React.Component {
       prohibitDelete,
     } = this.state;
 
-    const DC = detailComponent; // Must start with a capital for JSX syntax to work
-    const detailComponentWithParsing = ({ initialValues, ...rest }) => (
-      <DC initialValues={parseInitialValues(initialValues)} {...rest} />
-    );
+    let detailComponentWithParsing;
+    if (detailComponent === lastDetailComponent) {
+      console.log('re-using existing DetailComponentWithParsing');
+      detailComponentWithParsing = lastDetailComponentWithParsing;
+    } else {
+      console.log('*** making new DetailComponentWithParsing');
+      const DC = detailComponent; // Must start with a capital for JSX syntax to work
+      detailComponentWithParsing = ({ initialValues, ...rest }) => (
+        <DC initialValues={parseInitialValues(initialValues)} {...rest} />
+      );
+      lastDetailComponent = detailComponent;
+      lastDetailComponentWithParsing = detailComponentWithParsing;
+    }
     const ComponentToRender = resourcePath ? ConnectedWrapper : detailComponentWithParsing;
 
     const lastMenu = (

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -25,7 +25,8 @@ import ConnectedWrapper from './ConnectedWrapper';
 
 // We can't use useMemo in a class-based component, and I can't make _.memoize work
 // So we'll do this by hand
-let lastDetailComponent, lastDetailComponentWithParsing;
+let lastDetailComponent;
+let lastDetailComponentWithParsing;
 
 
 class EntrySelector extends React.Component {
@@ -240,10 +241,8 @@ class EntrySelector extends React.Component {
 
     let detailComponentWithParsing;
     if (detailComponent === lastDetailComponent) {
-      console.log('re-using existing DetailComponentWithParsing');
       detailComponentWithParsing = lastDetailComponentWithParsing;
     } else {
-      console.log('*** making new DetailComponentWithParsing');
       const DC = detailComponent; // Must start with a capital for JSX syntax to work
       detailComponentWithParsing = ({ initialValues, ...rest }) => (
         <DC initialValues={parseInitialValues(initialValues)} {...rest} />

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -18,6 +18,12 @@ import EntryForm from './EntryForm';
 import EntrySelector from './EntrySelector';
 import ConnectedWrapper from './ConnectedWrapper';
 
+
+// We can't use useMemo in a class-based component, and I can't make _.memoize work
+// So we'll do this by hand
+let lastEntryFormComponent, lastEntryFormComponentWithParsing;
+
+
 export default class EntryWrapper extends React.Component {
   static manifest = Object.freeze({
     query: { initialValue: {} },
@@ -246,9 +252,18 @@ export default class EntryWrapper extends React.Component {
     );
 
     const EntryFormComponent = (this.props.entryFormComponent) ? this.props.entryFormComponent : EntryForm;
-    const EntryFormComponentWithParsing = ({ initialValues: iv, ...rest }) => (
-      <EntryFormComponent initialValues={parseInitialValues(iv)} {...rest} />
-    );
+    let EntryFormComponentWithParsing;
+    if (EntryFormComponent === lastEntryFormComponent) {
+      console.log('re-using existing EntryFormComponentWithParsing');
+      EntryFormComponentWithParsing = lastEntryFormComponentWithParsing;
+    } else {
+      console.log('*** making new EntryFormComponentWithParsing');
+      EntryFormComponentWithParsing = ({ initialValues: iv, ...rest }) => (
+        <EntryFormComponent initialValues={parseInitialValues(iv)} {...rest} />
+      );
+      lastEntryFormComponent = EntryFormComponent;
+      lastEntryFormComponentWithParsing = EntryFormComponentWithParsing;
+    }
     const ComponentToRender = resourcePath ? ConnectedWrapper : EntryFormComponentWithParsing;
 
     return (

--- a/lib/EntryManager/EntryWrapper.js
+++ b/lib/EntryManager/EntryWrapper.js
@@ -21,7 +21,8 @@ import ConnectedWrapper from './ConnectedWrapper';
 
 // We can't use useMemo in a class-based component, and I can't make _.memoize work
 // So we'll do this by hand
-let lastEntryFormComponent, lastEntryFormComponentWithParsing;
+let lastEntryFormComponent;
+let lastEntryFormComponentWithParsing;
 
 
 export default class EntryWrapper extends React.Component {
@@ -254,10 +255,8 @@ export default class EntryWrapper extends React.Component {
     const EntryFormComponent = (this.props.entryFormComponent) ? this.props.entryFormComponent : EntryForm;
     let EntryFormComponentWithParsing;
     if (EntryFormComponent === lastEntryFormComponent) {
-      console.log('re-using existing EntryFormComponentWithParsing');
       EntryFormComponentWithParsing = lastEntryFormComponentWithParsing;
     } else {
-      console.log('*** making new EntryFormComponentWithParsing');
       EntryFormComponentWithParsing = ({ initialValues: iv, ...rest }) => (
         <EntryFormComponent initialValues={parseInitialValues(iv)} {...rest} />
       );


### PR DESCRIPTION
This PR fixes an intermittently manifesting rendering loop which occurs in `<EntryManager>` under some circumstances, but not in others — I have not been able to determine what the trigger is.

The fix is to memoize the creation of the components that apply parsing to the values in the record to be viewed or edited. I can't use `useMemo` for this, as the components in question are class-based rather than functional; and I couldn't get loadash's `_.memoize` to work at all. So rather than continue flogging that horse, I just did it by hand.

Fixes STSMACOM-762.