### PR TITLE
STSMACOM-766 - disable edit button when user doesn't have permission to edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Expose `<EntryForm>` and `<EntrySelector>` components for reuse. Refs STSMACOM-759.
 * Expose expanded props of MetaSection through ViewMetaData component. Refs STSMACOM-752.
 * Update `locallyChangedSearchTerm` when `query` changes, but keep value when `qindex` changes. Fixes STSMACOM-758.
+* User Settings Permission sets: Disable editing for users with "Setting (Users): View all settings" permission. STSMACOM-766.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -222,7 +222,8 @@ class EntrySelector extends React.Component {
       parentResources,
       enableDetailsActionMenu,
       prohibitItemDelete,
-      nameKey
+      nameKey,
+      permissions,
     } = this.props;
 
     const {
@@ -231,6 +232,7 @@ class EntrySelector extends React.Component {
     } = this.state;
 
     const ComponentToRender = resourcePath ? ConnectedWrapper : detailComponent;
+    const disabled = !stripes.hasPerm(permissions.put);
 
     const lastMenu = (
       <PaneMenu>
@@ -240,6 +242,7 @@ class EntrySelector extends React.Component {
               <Button
                 onClick={() => this.props.onEdit(item)}
                 id="clickable-edit-item"
+                disabled={disabled}
                 aria-label={ariaLabel}
                 buttonStyle="primary"
                 marginBottom0

--- a/lib/EntryManager/tests/entry-manager-test.js
+++ b/lib/EntryManager/tests/entry-manager-test.js
@@ -176,6 +176,49 @@ describe('Entry Manager', () => {
     });
   });
 
+  describe('entry manager detail section with edit button disabled', () => {
+    setupApplication({
+      permissions: {
+        'test': false,
+        'module.ui-dummy.enabled': true,
+      },
+      stripesConfig: {
+        hasAllPerms: false,
+      }
+    });
+
+    beforeEach(() => {
+      mount(
+        <ConnectedComponent
+          nameKey="test"
+          paneTitle={paneTitle}
+          entryList={entryList}
+          entryLabel={entryLabel}
+          enableDetailsActionMenu={false}
+          parentMutator={
+            {
+              entries: {
+                POST: () => Promise.resolve()
+              }
+            }}
+          permissions={permissions}
+          detailComponent={detailComponent}
+          entryFormComponent={entryFormComponent}
+          prohibitItemDelete={prohibitItemDelete}
+        />
+      );
+    });
+
+    describe('item edit button to exist and be disabled', () => {
+      beforeEach(async () => {
+        await entryManagerInteractor.navTo(entryList[0].name);
+        await converge(() => EntryDetails().exists());
+      });
+
+      it('edit button should be disabled', () => Button({ text: 'Edit', disabled: true }).exists());
+    });
+  });
+
   describe('Test 422 error', () => {
     const resp422 = new Response();
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -32,6 +32,7 @@ export function setupApplication({
   scenarios,
   component = null,
   permissions = {},
+  stripesConfig
 } = {}) {
   const initialState = {
     discovery: {
@@ -45,6 +46,7 @@ export function setupApplication({
       serverType: 'miragejs',
       ...mirageOptions
     },
+    stripesConfig,
     scenarios,
     permissions,
     initialState,


### PR DESCRIPTION
## Purpose
User Settings Permission sets: Disable editing for users with "Setting (Users): View all settings" permission

## Approach
Disable 'Edit' button when user do not have permissions to edit.

**Note:** Added unit test to test new code. Refer to test result on screenshot 2 for the same. However, coverage seems to be zero. Coverage seems to be 100% locally.

## Screenshot
behavior with diku login
![image](https://github.com/folio-org/stripes-smart-components/assets/104053200/08f37c90-17f4-422e-ab47-92a1cf8bf954)

behavior with another user with permission "Settings (Users): Can view permission sets" **only**
![image](https://github.com/folio-org/stripes-smart-components/assets/104053200/03f7bd8e-5120-4af1-876d-018f72abf42c)

screenshot from bigtest
![image](https://github.com/folio-org/stripes-smart-components/assets/104053200/7bd337e8-1133-4282-a28a-d279c883b6b4)


## Refs
https://issues.folio.org/browse/STSMACOM-766