### PR TITLE
STSMACOM-770 - propagate sort fields while applying filters too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 * Expose `<EntryForm>` and `<EntrySelector>` components for reuse. Refs STSMACOM-759.
 * Expose expanded props of MetaSection through ViewMetaData component. Refs STSMACOM-752.
 * Update `locallyChangedSearchTerm` when `query` changes, but keep value when `qindex` changes. Fixes STSMACOM-758.
-* User Settings Permission sets: Disable editing for users with "Setting (Users): View all settings" permission. STSMACOM-766.
+* User Settings Permission sets: Disable editing for users with "Setting (Users): View all settings" permission. Refs STSMACOM-766.
+* Propagate sort fields while applying filters too. Refs. STSMACOM-770.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -613,9 +613,9 @@ class SearchAndSortQuery extends React.Component {
     // packs it into an object with a "filters" key.
     // This behavior is overridden with the filtersToParams prop.
     const paramObject = this.props.filtersToParams(activeFilters);
-    const { searchFields } = this.state;
+    const { searchFields, sortFields } = this.state;
 
-    this.callQuerySetter({ ...searchFields, ...paramObject });
+    this.callQuerySetter({ ...searchFields, ...paramObject, ...sortFields });
   }
 
   getActiveFilterState = () => {


### PR DESCRIPTION
## Purpose
users are not sorted by display-name

## Approach
Propagate sort fields too (along with search fields and filter parameters). This will provide correct ns values to querySetter provided via props.

NOTE: Locally coverage is showing 100%. CI script is probably buggy now. I have observed the same in couple of the earlier PRs.

## Screenshots

<img width="960" alt="image" src="https://github.com/folio-org/stripes-smart-components/assets/104053200/5e39b4b7-6601-45c2-ab54-f97b4194be4d">

<img width="960" alt="image" src="https://github.com/folio-org/stripes-smart-components/assets/104053200/eb402e6a-8d20-49fa-b31d-31364784d4e5">

<img width="601" alt="image" src="https://github.com/folio-org/stripes-smart-components/assets/104053200/19b37ad3-85f2-4dc1-8d95-07d343821f90">

screencast - https://issues.folio.org/secure/attachment/64170/image-2023-07-11-12-04-56-189.png

## Refs
https://issues.folio.org/browse/STSMACOM-770