### PR TITLE
STSMACOM-773 Pass `labelInfo` prop to checkboxes in `<CheckboxFilter>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Propagate sort fields while applying filters too. Refs. STSMACOM-770.
 * Add `<AdvancedSearch>` to `<SearchAndSort>` component. Refs STSMACOM-767.
 * *BREAKING* Upgrade `react` to `v18`. Refs STSMACOM-769.
+* Pass `labelInfo` prop to checkboxes in `<CheckboxFilter>`. Refs STSMACOM-773.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
+++ b/lib/SearchAndSort/components/CheckboxFilter/CheckboxFilter.js
@@ -46,7 +46,7 @@ export default class CheckboxFilter extends React.Component {
     } = this.props;
 
     return (
-      dataOptions.map(({ value, label, disabled, readOnly }) => {
+      dataOptions.map(({ value, label, disabled, readOnly, labelInfo }) => {
         const name = typeof label === 'string' ? label : value;
         return (
           <Checkbox
@@ -55,6 +55,7 @@ export default class CheckboxFilter extends React.Component {
             data-test-checkbox-filter-data-option={value}
             key={value}
             label={label}
+            labelInfo={labelInfo}
             name={name}
             disabled={disabled}
             readOnly={readOnly}


### PR DESCRIPTION
## Desciprtion
 Pass `labelInfo` prop to checkboxes in `<CheckboxFilter>`. This can be used with facets that need to render facet counts

## Issues
[STSMACOM-773](https://issues.folio.org/browse/STSMACOM-773)