### PR TITLE
STSMACOM-774 Provide the ability to handle the status change of the `<EditableListForm>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * *BREAKING* Upgrade `react` to `v18`. Refs STSMACOM-769.
 * Pass `labelInfo` prop to checkboxes in `<CheckboxFilter>`. Refs STSMACOM-773.
 * ControlledVocab "Last updated" display must be robust to sparse user data. Refs STSMACOM-756.
+* Provide the ability to handle the status change of the `<EditableListForm>`. Refs STSMACOM-774.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -228,9 +228,13 @@ class EditableListForm extends React.Component {
     return null;
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (this.props.shouldReinitialize && this.shouldUpdateStatus(prevProps.initialValues)) {
       this.setState({ status: buildStatusArray(this.props.initialValues.items) });
+    }
+
+    if (this.props.onStatusChange && !isEqual(prevState.status, this.state.status)) {
+      this.props.onStatusChange(prevState.status, this.state.status);
     }
   }
 

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -136,6 +136,10 @@ const propTypes = {
    */
   onUpdate: PropTypes.func,
   /**
+   * Callback when list status changed.
+   */
+  onStatusChange: PropTypes.func,
+  /**
    * boolean that shows if the form has been modified.
    */
   pristine: PropTypes.bool,

--- a/lib/EditableList/tests/EditableList-test.js
+++ b/lib/EditableList/tests/EditableList-test.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import { expect } from 'chai';
 import { describe, beforeEach, it } from 'mocha';
+import { spy } from 'sinon';
+
 import { EditableList as ELInteractor, EditableListRow, converge, TextField } from '@folio/stripes-testing';
 
 import TestForm from '../../../tests/TestForm';
 import { setupApplication, mount } from '../../../tests/helpers';
 import EditableList from '../EditableList';
+
+const onStatusChange = spy();
 
 describe('Editable List', () => {
   setupApplication();
@@ -15,6 +20,8 @@ describe('Editable List', () => {
   let deleteHandled = false;
 
   beforeEach(async () => {
+    onStatusChange.resetHistory();
+
     const contentData = [
       {
         id: '1',
@@ -39,6 +46,7 @@ describe('Editable List', () => {
           onUpdate={() => { updateHandled = true; }}
           onDelete={() => { deleteHandled = true; }}
           onCreate={() => { createHandled = true; }}
+          onStatusChange={onStatusChange}
         />
       </TestForm>
     ));
@@ -52,6 +60,10 @@ describe('Editable List', () => {
     });
 
     it('calls onDelete handler', () => converge(() => deleteHandled));
+
+    it('should not call status change handler', () => {
+      expect(onStatusChange.called).to.be.false;
+    });
   });
   describe('clicking the add button', () => {
     beforeEach(async () => {
@@ -62,12 +74,20 @@ describe('Editable List', () => {
 
     it('calls the update handler', () => converge(() => updateHandled));
 
+    it('should call status change handler', () => {
+      expect(onStatusChange.called).to.be.true;
+    });
+
     describe('canceling', () => {
       beforeEach(async () => {
         await EditableListRow().cancel();
       });
 
       it('removes the form', () => TextField().absent());
+
+      it('should call status change handler', () => {
+        expect(onStatusChange.called).to.be.true;
+      });
     });
 
     describe('saving', () => {


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STSMACOM-774
https://issues.folio.org/browse/UICONSET-112

The consortium manager requires the ability to handle the form's status (editing) change outside of the component to prevent some actions.

## Screencast

https://github.com/folio-org/stripes-smart-components/assets/88109087/7f22fded-77f2-4efb-8c69-494d43faced2

