### PR TITLE
STSMACOM-775: Search And Sort Query - fire queryStateReducer events on search submit

### DIFF
--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -347,27 +347,20 @@ class SearchAndSortQuery extends React.Component {
   }
 
   onSubmitAll = (dbounce = true) => {
-    const {
-      searchFields,
-      filterFields,
-      sortFields
-    } = this.state;
-
-    // convert filters to params (similar to this.applyFilters())
-    const filterParams = this.props.filtersToParams(filterFields);
-
-    const params = { ...searchFields, ...filterParams, ...sortFields };
-
     this.internalSetState(
-      {}, // Don't actually change state at all here, just trigger changeType
+      {},
       'all.submit',
-    );
+      [
+        (s) => {
+          const filterParams = this.props.filtersToParams(s.filterFields);
+          const params = { ...s.searchFields, ...filterParams, ...s.sortFields };
 
-    if (dbounce) {
-      this.debouncedCallQuerySetter(params);
-    } else {
-      this.callQuerySetter(params);
-    }
+          if (dbounce) {
+            this.debouncedCallQuerySetter(params);
+          } else { this.callQuerySetter(params); }
+        }
+      ]
+    );
   }
 
   onSubmitSearch = (e) => {
@@ -379,9 +372,10 @@ class SearchAndSortQuery extends React.Component {
     this.internalSetState(
       {}, // Don't actually change state at all here, just trigger changeType
       'search.submit',
+      [
+        (s) => this.callQuerySetter(s.searchFields),
+      ]
     );
-
-    this.debouncedCallQuerySetter(this.state.searchFields);
   };
 
   // eslint-disable-next-line react/sort-comp

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -373,7 +373,7 @@ class SearchAndSortQuery extends React.Component {
       {}, // Don't actually change state at all here, just trigger changeType
       'search.submit',
       [
-        (s) => this.callQuerySetter(s.searchFields),
+        (s) => this.debouncedCallQuerySetter(s.searchFields),
       ]
     );
   };

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -358,6 +358,11 @@ class SearchAndSortQuery extends React.Component {
 
     const params = { ...searchFields, ...filterParams, ...sortFields };
 
+    this.internalSetState(
+      {}, // Don't actually change state at all here, just trigger changeType
+      'all.submit',
+    );
+
     if (dbounce) {
       this.debouncedCallQuerySetter(params);
     } else {
@@ -370,6 +375,11 @@ class SearchAndSortQuery extends React.Component {
       e.preventDefault();
       e.stopPropagation();
     }
+
+    this.internalSetState(
+      {}, // Don't actually change state at all here, just trigger changeType
+      'search.submit',
+    );
 
     this.debouncedCallQuerySetter(this.state.searchFields);
   };

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
@@ -97,7 +97,7 @@ const SASQTestHarness = ({
                 />
                 <Button
                   disabled={resetDisabled}
-                  onChange={resetAll}
+                  onClick={resetAll}
                 >
                   Reset all
                 </Button>

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
@@ -20,6 +20,7 @@ describe('SearchAndSortQuery Navigation', () => {
         testQindexLabel="test-qindex-nav"
         testQuery="testquery"
         testQueryLabel="test-query-nav"
+        initialSearchState={{ query: '', qindex: '' }}
       />)
   });
 


### PR DESCRIPTION
feat: Add SASQ event for search submit and all submit

Added internalSetState call for submit all and submit search, which does not change internal state itself, but fires an event that queryStateReducer can use to trigger changes from those events

refs: https://issues.folio.org/browse/STSMACOM-775