### PR TITLE
STSMACOM-776 provide missing dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Pass `labelInfo` prop to checkboxes in `<CheckboxFilter>`. Refs STSMACOM-773.
 * ControlledVocab "Last updated" display must be robust to sparse user data. Refs STSMACOM-756.
 * Provide the ability to handle the status change of the `<EditableListForm>`. Refs STSMACOM-774.
+* Provide missing dependencies (`uuid`). Refs STSMACOM-776.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -95,9 +95,8 @@
     "react-query": "^3.9.8",
     "react-quill": "^1.3.5",
     "react-router-prop-types": "^1.0.4",
-    "react-transition-group": "^2.4.0",
-    "react-virtualized-auto-sizer": "^1.0.2",
-    "redux-form": "^8.3.0"
+    "redux-form": "^8.3.0",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "@folio/stripes-components": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10048,7 +10048,7 @@ react-transform-catch-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/react-transform-catch-errors/-/react-transform-catch-errors-1.0.2.tgz#1b4d4a76e97271896fc16fe3086c793ec88a9eeb"
   integrity sha512-FCeTXLTpRM8wMrwAlYVoEI+HXUFYEJLKdmf9zd5YtH1yc2Dq81JL1YMr0eHeUe699CCTezG4CfEB5D9RpmovEw==
 
-react-transition-group@^2.2.1, react-transition-group@^2.4.0:
+react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==


### PR DESCRIPTION
Provide missing dependencies:
* `uuid`

Omit unused dependencies:
* `react-transition-group`
* `react-virtualized-auto-sizer`

Refs [STSMACOM-776](https://issues.folio.org/browse/STSMACOM-776)