### PR TITLE
STSMACOM-777: Do not reset advanced search filters if the advanced search option is already selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * ControlledVocab "Last updated" display must be robust to sparse user data. Refs STSMACOM-756.
 * Provide the ability to handle the status change of the `<EditableListForm>`. Refs STSMACOM-774.
 * Provide missing dependencies (`uuid`). Refs STSMACOM-776.
+* Do not reset advanced search filters if the advanced search option is already selected. Fixes STSMACOM-777.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1149,7 +1149,9 @@ class SearchAndSort extends React.Component {
     const {
       advancedSearchIndex,
       extraParamsToReset,
+      location,
     } = this.props;
+    const selectedQindex = new URLSearchParams(location.search).get('qindex');
 
     const changeIndexEvent = { target: { value: advancedSearchIndex } };
     const changeSearchEvent = { target: { value: searchString } };
@@ -1162,6 +1164,7 @@ class SearchAndSort extends React.Component {
     this.performSearch({
       query: searchString,
       qindex: advancedSearchIndex,
+      ...(selectedQindex !== advancedSearchIndex && { filters: '' }),
       ...extraParamsToReset,
     });
   };


### PR DESCRIPTION
## Purpose
Filters shouldn't be reset when the advanced search option is already selected.

## Issue
[STSMACOM-777](https://issues.folio.org/browse/STSMACOM-777)
## Related PRs
https://github.com/folio-org/ui-inventory/pull/2255

