### PR TITLE
STSMACOM-777: Don't reset filters after changing a search option.

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1149,14 +1149,11 @@ class SearchAndSort extends React.Component {
     const {
       advancedSearchIndex,
       extraParamsToReset,
-      location,
     } = this.props;
-    const selectedQindex = new URLSearchParams(location.search).get('qindex');
-
     const changeIndexEvent = { target: { value: advancedSearchIndex } };
     const changeSearchEvent = { target: { value: searchString } };
 
-    this.onChangeIndex(changeIndexEvent, { isAdvancedSearchModal: true });
+    this.onChangeIndex(changeIndexEvent);
     this.onChangeSearch(changeSearchEvent);
 
     this.setState({ isAdvancedSearchOpen: false });
@@ -1164,7 +1161,6 @@ class SearchAndSort extends React.Component {
     this.performSearch({
       query: searchString,
       qindex: advancedSearchIndex,
-      ...(selectedQindex !== advancedSearchIndex && { filters: '' }),
       ...extraParamsToReset,
     });
   };


### PR DESCRIPTION
## Purpose
Don't reset filters after changing a search option.

## Issue
[STSMACOM-777](https://issues.folio.org/browse/STSMACOM-777)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2256

## Screencast
in the related PR