### PR TITLE
STSMACOM-779: Add possible to pass paneTitleRef from SearchAndSort to Pane that already support paneTitleRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Provide missing dependencies (`uuid`). Refs STSMACOM-776.
 * Do not reset advanced search filters if the advanced search option is already selected. Fixes STSMACOM-777.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STSMACOM-780.
+* Add possible to pass `paneTitleRef` from `SearchAndSort` to `Pane` that already support `paneTitleRef`. Refs STSMACOM-779.
 
 ## [8.0.0](https://github.com/folio-org/stripes-smart-components/tree/v8.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v7.3.0...v8.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -103,6 +103,7 @@ class SearchAndSort extends React.Component {
     browseOnly: PropTypes.bool,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,
+    paneTitleRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     columnManagerProps: PropTypes.object,
     columnMapping: PropTypes.object,
     columnWidths: PropTypes.object,
@@ -1429,7 +1430,8 @@ class SearchAndSort extends React.Component {
       columnMapping,
       namespace,
       viewRecordPathById,
-      createRecordPath
+      createRecordPath,
+      paneTitleRef,
     } = this.props;
     const { filterPaneIsVisible } = this.state;
 
@@ -1439,6 +1441,7 @@ class SearchAndSort extends React.Component {
     const renderResultsPane = ({ visibleColumns, ...columnManagerRenderProps }) => (
       <Pane
         id="pane-results"
+        paneTitleRef={paneTitleRef}
         padContent={false}
         defaultWidth="fill"
         actionMenu={this.getActionMenu(columnManagerRenderProps)}


### PR DESCRIPTION
## Purpose
Add possible to pass paneTitleRef from SearchAndSort to Pane that already support paneTitleRef

## Refs
https://issues.folio.org/browse/STSMACOM-779