### PR TITLE
Support `iface` condition in <Settings> entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 IN PROGRESS
 
+* Entries passed into the `<Settings>` component can have an `iface` element specifying an interface that must be present in order for the settings page to be enabled (analogous to the `perm` element).
+
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -40,6 +40,7 @@ class Settings extends Component {
     this.sections.forEach(section => {
       const sectionRoutes = section.pages
         .filter(p => !p.perm || stripes.hasPerm(p.perm))
+        .filter(p => !p.iface || stripes.hasInterface(p.iface))
         .map(page => ({
           page,
           component: stripes.connect(page.component, { dataKey: page.route }),
@@ -166,6 +167,7 @@ Settings.propTypes = {
   stripes: PropTypes.shape({
     connect: PropTypes.func.isRequired,
     hasPerm: PropTypes.func.isRequired,
+    hasInterface: PropTypes.func.isRequired,
   }).isRequired,
 };
 

--- a/lib/Settings/readme.md
+++ b/lib/Settings/readme.md
@@ -31,6 +31,7 @@ The following properties are supported:
   * `label`: the human-readable label that, when clicked on, links to the specified route.
   * `component`: the component that is rendered at the specified route.
   * `perm`: if specified, the name of a permission which the current user must have in order to access the page; if the user lacks the permission, then the link is not provided. (If omitted, then no permission check is performed for the sub-page.)
+  * `iface`: if specified, the name of an interface which the system must implement in order to access the page; if the interface is not present, then the link is not provided. (If omitted, then no interface check is performed for the sub-page.)
 * `sections`: an array of section objects. Each member of the list is an object with the following members:
   * `label`: the human-readable label that, when clicked on, links to the specified route.
   * `pages`: which has the same form as the `pages` prop


### PR DESCRIPTION
Entries passed into the `<Settings>` component can have an `iface` element specifying an interface that must be present in order for the settings page to be enabled (analogous to the `perm` element).

*Background*

I'm working on a bug (UITEN-266) that would be easier to fix if this change were in place, I'm trying to rush it through in time for me to use it now, but it seems like this is a facility that `<Settings>` ought to provide.

What do y'all think?