### PR TITLE
STSMACOM-785 - add default parameters to onSubmit, submitAll internal handlers

### DIFF
--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -249,7 +249,7 @@ class SearchAndSortQuery extends React.Component {
   componentDidMount() {
     if (this.props.setQueryOnMount ||
       (this.props.syncToLocationSearch && Object.keys(this.state.searchFields).length > 0)) {
-      this.onSubmitAll(false);
+      this.onSubmitAll(false, 'init.reset');
     }
   }
 
@@ -346,10 +346,10 @@ class SearchAndSortQuery extends React.Component {
     });
   }
 
-  onSubmitAll = (dbounce = true) => {
+  onSubmitAll = (dbounce = true, changeType = 'all.submit') => {
     this.internalSetState(
       {},
-      'all.submit',
+      changeType,
       [
         (s) => {
           const filterParams = this.props.filtersToParams(s.filterFields);
@@ -363,7 +363,7 @@ class SearchAndSortQuery extends React.Component {
     );
   }
 
-  onSubmitSearch = (e) => {
+  onSubmitSearch = (e, changeType = 'search.submit') => {
     if (e) {
       e.preventDefault();
       e.stopPropagation();
@@ -371,7 +371,7 @@ class SearchAndSortQuery extends React.Component {
 
     this.internalSetState(
       {}, // Don't actually change state at all here, just trigger changeType
-      'search.submit',
+      changeType,
       [
         (s) => this.debouncedCallQuerySetter(s.searchFields),
       ]
@@ -397,7 +397,7 @@ class SearchAndSortQuery extends React.Component {
   };
 
   onResetSearch = (submit = true) => {
-    const submitCallback = submit ? () => { this.onSubmitSearch(); } : noop;
+    const submitCallback = submit ? () => { this.onSubmitSearch(false, 'search.before-reset'); } : noop;
     const { searchChangeCallback } = this.props;
     // this.log('action', 'cleared search');
     this.internalSetState(


### PR DESCRIPTION
[this commit](https://github.com/folio-org/stripes-smart-components/commit/d197a0) added some necessary event handling and `changeType`s to SASQ internals, but it did not account for leftover `changeType` that may have been depended upon by app code.

If SASQ has `setQueryOnMount = true` or an `initialSearchState` applied, a `submitAll()` is carried out when the component mounts. State is initialized with an `init.reset` changeType. Previously, the submitAll() call had no `changeType` applied, so `init.reset` remained - and thus, the expectant code was built.

This code adds the `changeType` as a default parameter for the methods that we would expect, with overridden `changeType`s applied for those situational cases where `submitAll()` and `submitSearch` are called - that is, at mount time, given the previously mentioned props, and upon a user-triggered reset.

