### PR TITLE
STSMACOM-786  Added `inputType` prop to `<SearchAndSort>` component to support both input and textarea search boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 IN PROGRESS
 
+* Added `inputType` prop to `<SearchAndSort>` component to support both input and textarea search boxes. Refs STSMACOM-786.
+
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -145,6 +145,7 @@ class SearchAndSort extends React.Component {
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
     initiallySelectedRecord: PropTypes.string,
+    inputType: PropTypes.string,
     isCountHidden: PropTypes.bool,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
@@ -1218,6 +1219,7 @@ class SearchAndSort extends React.Component {
       autofocusSearchField,
       searchFieldButtonLabel,
       advancedSearchOptions,
+      inputType,
     } = this.props;
     const {
       locallyChangedSearchTerm,
@@ -1250,6 +1252,8 @@ class SearchAndSort extends React.Component {
               onChangeIndex={this.onChangeIndex}
               onChange={this.onChangeSearch}
               onClear={this.onClearSearchQuery}
+              inputType={inputType}
+              onSubmitSearch={this.onSubmitSearch}
             />
           )}
         </FormattedMessage>

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1253,6 +1253,8 @@ class SearchAndSort extends React.Component {
               onChange={this.onChangeSearch}
               onClear={this.onClearSearchQuery}
               inputType={inputType}
+              lockWidth
+              newLineOnShiftEnter
               onSubmitSearch={this.onSubmitSearch}
             />
           )}

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -30,6 +30,7 @@ filterConfig | array of structures | Configuration for the module's filters, as 
 hasRowClickHandlers | bool | Defaults to true. Turns row-level click handlers on and off for the results.
 initialFilters | string | The initial state of the filters when the application started up, used when resetting to the initial state. Takes the same form as the `filters` part of the URL: a comma-separated list of `group`.`name` filters that are selected.
 disableFilters | object whose keys are filter-group names | In the display of filter groups, those that are named in this object are greyed out and cannot be selected.
+inputType | string | Type of search box. Can  be `input` or `textarea`.
 filterChangeCallback | function | If provided, this function is invoked when the user changes a filter. It is passed the new set of filters, in the form of an object whose keys are the `group`.`name` specifiers of each selected filter.
 onFilterChange | function | Callback to be called after filter value is changed. Gets filter name and filter values in a form of an object `{ name: <String>, values: <Array> }`.
 renderFilters | function | Renders a set of filters. Gets onChange callback to be called after filter value change.


### PR DESCRIPTION
## Description
Make support input and textarea as an input field by adding a new inputType prop

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/ecf9ec53-6699-4366-a1cf-eaac81167e3e

## Issues
[STSMACOM-786](https://issues.folio.org/browse/STSMACOM-786)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2158
https://github.com/folio-org/ui-inventory/pull/2322
https://github.com/folio-org/stripes-components/pull/2158