### PR TITLE
STSMACOM-748: Show the username in the 'last updated' accordion in the Note editing pane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `inputType` prop to `<SearchAndSort>` component to support both input and textarea search boxes. Refs STSMACOM-786.
 * Export new `advancedSearchQueryToRows` helper to be used in Inventory app to reduce code duplication. Refs STSMACOM-787.
+* Show the username in the "last updated" accordion in the Note editing pane. Fixes STSMACOM-748.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/Notes/utils/getMetadataFormResponse.js
+++ b/lib/Notes/utils/getMetadataFormResponse.js
@@ -4,20 +4,14 @@ const getMetadataPropsFromResponse = (responseMetadata) => {
     createdByUsername: createdBy,
     updatedByUsername,
     updatedDate: lastUpdatedDate,
-    updatedByUserId,
-    createdByUserId,
   } = responseMetadata;
-
-  const lastUpdatedBy = createdByUserId === updatedByUserId
-    ? createdBy
-    : updatedByUsername;
 
   const metadataProps = {};
 
   if (createdDate) { metadataProps.createdDate = createdDate; }
   if (createdBy) { metadataProps.createdBy = createdBy; }
   if (lastUpdatedDate) { metadataProps.lastUpdatedDate = lastUpdatedDate; }
-  if (lastUpdatedBy) { metadataProps.lastUpdatedBy = lastUpdatedBy; }
+  if (updatedByUsername) { metadataProps.lastUpdatedBy = updatedByUsername; }
 
   return metadataProps;
 };

--- a/lib/Notes/utils/getMetadataFormResponse.js
+++ b/lib/Notes/utils/getMetadataFormResponse.js
@@ -2,9 +2,15 @@ const getMetadataPropsFromResponse = (responseMetadata) => {
   const {
     createdDate,
     createdByUsername: createdBy,
+    updatedByUsername,
     updatedDate: lastUpdatedDate,
-    updatedByUserId: lastUpdatedBy
+    updatedByUserId,
+    createdByUserId,
   } = responseMetadata;
+
+  const lastUpdatedBy = createdByUserId === updatedByUserId
+    ? createdBy
+    : updatedByUsername;
 
   const metadataProps = {};
 


### PR DESCRIPTION
## Purpose
Show the `username` in the `last updated` accordion in the Note editing pane.

## Issues
[STSMACOM-748](https://issues.folio.org/browse/STSMACOM-748)

## Screenshots
![image](https://github.com/folio-org/stripes-smart-components/assets/77053927/50ac29ad-4dea-479a-ad0a-9f7d7ecdd0df)
