### PR TITLE
STSMACOM-788 Added `indexRef` and `inputRef` props to `<SearchAndSort>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `inputType` prop to `<SearchAndSort>` component to support both input and textarea search boxes. Refs STSMACOM-786.
 * Export new `advancedSearchQueryToRows` helper to be used in Inventory app to reduce code duplication. Refs STSMACOM-787.
+* Added `indexRef` and `inputRef` props to `<SearchAndSort>`. Refs STSMACOM-788.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -148,9 +148,17 @@ class SearchAndSort extends React.Component {
     history: PropTypes.shape({ // provided by withRouter
       push: PropTypes.func.isRequired,
     }).isRequired,
+    indexRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    ]),
     initialFilters: PropTypes.string,
     initialResultCount: PropTypes.number.isRequired,
     initiallySelectedRecord: PropTypes.string,
+    inputRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    ]),
     inputType: PropTypes.string,
     isCountHidden: PropTypes.bool,
     location: PropTypes.shape({ // provided by withRouter
@@ -1186,6 +1194,8 @@ class SearchAndSort extends React.Component {
       searchFieldButtonLabel,
       advancedSearchOptions,
       inputType,
+      indexRef,
+      inputRef,
     } = this.props;
     const {
       locallyChangedSearchTerm,
@@ -1222,6 +1232,8 @@ class SearchAndSort extends React.Component {
               lockWidth
               newLineOnShiftEnter
               onSubmitSearch={this.onSubmitSearch}
+              indexRef={indexRef}
+              inputRef={inputRef}
             />
           )}
         </FormattedMessage>

--- a/lib/SearchAndSort/readme.md
+++ b/lib/SearchAndSort/readme.md
@@ -28,8 +28,10 @@ maxSortKeys | number | If provided, specifies that maximum number of sort-keys t
 sortableColumns | array | If provided, specifies the columns that can be sorted.
 filterConfig | array of structures | Configuration for the module's filters, as documented [in the `<FilterGroups>` readme](https://github.com/folio-org/stripes-components/tree/master/lib/FilterGroups#filter-configuration).
 hasRowClickHandlers | bool | Defaults to true. Turns row-level click handlers on and off for the results.
+indexRef | ref | Reference to search index dropdown element.
 initialFilters | string | The initial state of the filters when the application started up, used when resetting to the initial state. Takes the same form as the `filters` part of the URL: a comma-separated list of `group`.`name` filters that are selected.
 disableFilters | object whose keys are filter-group names | In the display of filter groups, those that are named in this object are greyed out and cannot be selected.
+inputRef | ref | Reference to search query input element.
 inputType | string | Type of search box. Can  be `input` or `textarea`.
 filterChangeCallback | function | If provided, this function is invoked when the user changes a filter. It is passed the new set of filters, in the form of an object whose keys are the `group`.`name` specifiers of each selected filter.
 onFilterChange | function | Callback to be called after filter value is changed. Gets filter name and filter values in a form of an object `{ name: <String>, values: <Array> }`.


### PR DESCRIPTION
## Description
 Added `indexRef` and `inputRef` props to `<SearchAndSort>`

## Issues
[STSMACOM-788](https://issues.folio.org/browse/STSMACOM-788)

## Related PRs
https://github.com/folio-org/ui-inventory/pull/2335
https://github.com/folio-org/stripes-components/pull/2169