### PR TITLE
FCFIELDS-44 Update payload used by `<EditCustomFieldsSettings>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Show the username in the "last updated" accordion in the Note editing pane. Fixes STSMACOM-748.
 * Added `indexRef` and `inputRef` props to `<SearchAndSort>`. Refs STSMACOM-788.
 * Extend NotesAccordion and NotesSmartAccodion components to accept a prop  hideNewButton. Refs STSMACOM-789.
+* `<EditCustomFieldsSettings>` now passes the `entityType` when making PUT requests to `/custom-fields`. Refs FCFIELDS-44.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -164,7 +164,7 @@ const EditCustomFieldsSettings = ({
   const updateCustomFields = data => {
     return makeOkapiRequest('custom-fields')({
       method: 'PUT',
-      body: JSON.stringify({ customFields: data }),
+      body: JSON.stringify({ customFields: data, entityType }),
     });
   };
 

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -259,6 +259,7 @@ describe('EditCustomFieldsSettings', () => {
           },
         },
       });
+      expect(body.entityType).to.equal('user');
     });
   });
 });


### PR DESCRIPTION
This PR is related to [FCFIELDS-44](https://issues.folio.org/browse/FCFIELDS-44) and should be merged along with [FCFIELDS PR#41](https://github.com/folio-org/folio-custom-fields/pull/41).

This PR updates the payload that `<EditCustomFieldsSettings>` is sending to Okapi when updating custom fields. This modification aligns the payload with the revised [putCustomFieldCollection.json](https://github.com/folio-org/folio-custom-fields/pull/41/files#diff-943241611b2670b400a2d4ad16b9a76dbf12925cadaac1c5c1ac91bb319c36a0) schema.

With this change the `<EditCustomFieldsSettings>` component requires at least `custom-fields 3.0`.

## Additional Actions
* This requires [FCFIELDS PR#41](https://github.com/folio-org/folio-custom-fields/pull/41) to be merged beforehand as a prerequisite.
* Needs to be merged together with [MODUSERS PR#322](https://github.com/folio-org/mod-users/pull/322): Update `mod-users` to use the latest `folio-custom-fields` dependency and provide the `custom-fields 3.0` interface.