### PR TITLE
STSMACOM-791 use native blending for addressEdit/addressView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Show the username in the "last updated" accordion in the Note editing pane. Fixes STSMACOM-748.
 * Added `indexRef` and `inputRef` props to `<SearchAndSort>`. Refs STSMACOM-788.
 * Extend NotesAccordion and NotesSmartAccodion components to accept a prop  hideNewButton. Refs STSMACOM-789.
+* Refactor CSS away from postcss-color-function. Refs STSMACOM-791.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -87,8 +87,7 @@
 
 .addressFormBody {
   padding: 14px;
-  /* stylelint-disable-next-line function-no-unknown */
-  background-color: color(var(--bg) blend(var(--bg-hover) 20%));
+  background-color: color-mix(in oklch, var(--bg), var(--bg-hover) 20%);
   width: 100%;
 }
 

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -45,8 +45,7 @@
 
   &:hover {
     & :global .stripes__icon {
-      /* stylelint-disable-next-line function-no-unknown */
-      fill: color(#900 blend(#aaa 50%));
+      fill: color-mix(in oklch, #900, #aaa);
     }
   }
 }

--- a/lib/AddressFieldGroup/AddressView/AddressView.css
+++ b/lib/AddressFieldGroup/AddressView/AddressView.css
@@ -14,7 +14,6 @@
 
 .addressItemContent {
   padding: 14px;
-  /* stylelint-disable-next-line function-no-unknown */
-  background-color: color(var(--bg) blend(var(--bg-hover) 20%));
+  background-color: color-mix(in oklch, var(--bg), var(--bg-hover) 20%);
   width: 100%;
 }


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-791

`postcss-color-function` is a neglected dependency that we don't like anymore since it no longer emulates future CSS spec. In order to remove this, we have to migrate to native CSS functionality. Hello `color-mix()`!

