### PR TITLE
STSMACOM-792: Extend `Tags` component to accept `mutateEntity` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Show the username in the "last updated" accordion in the Note editing pane. Fixes STSMACOM-748.
 * Added `indexRef` and `inputRef` props to `<SearchAndSort>`. Refs STSMACOM-788.
 * Extend NotesAccordion and NotesSmartAccodion components to accept a prop  hideNewButton. Refs STSMACOM-789.
+* Extend `Tags` component to accept `mutateEntity` prop. Refs STSMACOM-792.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -40,6 +40,7 @@ class Tags extends React.Component {
     entityTagsPath: PropTypes.string,
     getEntity: PropTypes.func,
     getEntityTags: PropTypes.func,
+    mutateEntity: PropTypes.func,
     link: PropTypes.string.isRequired,
     mutator: PropTypes.shape({
       entities: PropTypes.shape({ PUT: PropTypes.func.isRequired }),
@@ -84,25 +85,32 @@ class Tags extends React.Component {
     this.saveTags(tags);
   };
 
+  onError = error => {
+    const errorId = error.status === OPTIMISTIC_LOCKING_STATUS
+      ? 'stripes-components.optimisticLocking.saveError'
+      : 'stripes-smart-components.cannotSaveTagToRecord';
+
+    this.showCallout('error', errorId);
+  };
+
   onRemove = tag => {
     const {
       getEntity,
       getEntityTags,
       entityTagsPath,
+      mutateEntity,
     } = this.props;
     const entity = getEntity(this.props);
     const tags = getEntityTags(this.props);
     const tagList = tags.filter(t => t !== tag);
 
     set(entity, entityTagsPath, { tagList });
-    this.props.mutator.entities.PUT(entity)
-      .catch(err => {
-        if (err.status !== OPTIMISTIC_LOCKING_STATUS) {
-          return;
-        }
 
-        this.showCallout('error', 'stripes-components.optimisticLocking.saveError');
-      });
+    if (mutateEntity) {
+      mutateEntity(entity, { onError: error => this.onError(error) });
+    } else {
+      this.props.mutator.entities.PUT(entity).catch(error => this.onError(error));
+    }
   };
 
   // add tag to the list of entity tags
@@ -111,19 +119,19 @@ class Tags extends React.Component {
       getEntity,
       getEntityTags,
       entityTagsPath,
+      mutateEntity,
     } = this.props;
     const entity = getEntity(this.props);
     const tagList = getEntityTags(this.props);
     const tagsToSave = { tagList: sortBy(uniq([...tags, ...tagList])) };
-    set(entity, entityTagsPath, tagsToSave);
-    this.props.mutator.entities.PUT(entity)
-      .catch(err => {
-        const errorId = err.status === OPTIMISTIC_LOCKING_STATUS
-          ? 'stripes-components.optimisticLocking.saveError'
-          : 'stripes-smart-components.cannotSaveTagToRecord';
 
-        this.showCallout('error', errorId);
-      });
+    set(entity, entityTagsPath, tagsToSave);
+
+    if (mutateEntity) {
+      mutateEntity(entity, { onError: error => this.onError(error) });
+    } else {
+      this.props.mutator.entities.PUT(entity).catch(error => this.onError(error));
+    }
   }
 
   // add tags to global list of tags


### PR DESCRIPTION
Support `mutateEntity` callback to be able to use `react-queries`. Required by https://github.com/folio-org/ui-inventory/pull/2371/