### PR TITLE
STSMACOM-800 Add field type `DATE_PICKER` to custom fields components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Use the default match and search option in Advanced search when they are not entered. Refs STSMACOM-793.
 * Show successful toast notifications for Create and Edit actions in `<ControlledVocab>`. Refs STSMACOM-796.
 * `<ControlledVocab>` - last updated by column - show "System" when items are created by system user. Refs STSMACOM-797.
+* Add field type `DATE_PICKER` to custom fields components. Refs FCFIELDS-46.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Use the default match and search option in Advanced search when they are not entered. Refs STSMACOM-793.
 * Show successful toast notifications for Create and Edit actions in `<ControlledVocab>`. Refs STSMACOM-796.
 * `<ControlledVocab>` - last updated by column - show "System" when items are created by system user. Refs STSMACOM-797.
-* Add field type `DATE_PICKER` to custom fields components. Refs FCFIELDS-46.
+* Add field type `DATE_PICKER` to custom fields components. Refs STSMACOM-800.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
+++ b/lib/CustomFields/components/CustomFieldsForm/tests/CustomFieldsForm-test.js
@@ -96,7 +96,15 @@ describe('CustomFieldsForm', () => {
   });
 
   it('should display custom field labels in "Add custom field" alphabetically', () => {
-    const sortedLabels = ['Checkbox', 'Multi-select', 'Radio button set', 'Single select', 'Text area', 'Text field'];
+    const sortedLabels = [
+      'Checkbox',
+      'Date picker',
+      'Multi-select',
+      'Radio button set',
+      'Single select',
+      'Text area',
+      'Text field',
+    ];
     const visibleLabels = customFieldsForm.customFieldSelectButtons().map(button => button.label);
 
     expect(visibleLabels).to.deep.equal(sortedLabels);

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -24,6 +24,7 @@ const editFieldsByType = {
   [fieldTypes.RADIO_BUTTON_GROUP]: editFields.RadioButtonSetFields,
   [fieldTypes.SELECT]: editFields.SelectDropdownFields,
   [fieldTypes.MULTISELECT]: editFields.SelectDropdownFields,
+  [fieldTypes.DATE_PICKER]: editFields.TextboxFields,
 };
 
 const viewSectionsByType = {
@@ -33,6 +34,7 @@ const viewSectionsByType = {
   [fieldTypes.RADIO_BUTTON_GROUP]: viewSections.RadioButtonSetSection,
   [fieldTypes.SELECT]: viewSections.SelectDropdownSection,
   [fieldTypes.MULTISELECT]: viewSections.SelectDropdownSection,
+  [fieldTypes.DATE_PICKER]: viewSections.TextboxViewSection,
 };
 
 const propTypes = {

--- a/lib/CustomFields/constants.js
+++ b/lib/CustomFields/constants.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
   Checkbox,
+  Datepicker,
   TextField,
   TextArea,
   Select,
@@ -16,6 +17,7 @@ export const fieldTypes = {
   SELECT: 'SINGLE_SELECT_DROPDOWN',
   MULTISELECT: 'MULTI_SELECT_DROPDOWN',
   RADIO_BUTTON_GROUP: 'RADIO_BUTTON',
+  DATE_PICKER: 'DATE_PICKER',
 };
 
 export const fieldTypesLabelIds = {
@@ -25,6 +27,7 @@ export const fieldTypesLabelIds = {
   [fieldTypes.SELECT]: 'stripes-smart-components.customFields.fieldTypes.SELECT',
   [fieldTypes.MULTISELECT]: 'stripes-smart-components.customFields.fieldTypes.MULTISELECT',
   [fieldTypes.RADIO_BUTTON_GROUP]: 'stripes-smart-components.customFields.fieldTypes.RADIO_BUTTON',
+  [fieldTypes.DATE_PICKER]: 'stripes-smart-components.customFields.fieldTypes.DATE_PICKER',
 };
 
 export const fieldTypesLabels = {
@@ -34,6 +37,7 @@ export const fieldTypesLabels = {
   [fieldTypes.SELECT]: <FormattedMessage id={fieldTypesLabelIds[fieldTypes.SELECT]} />,
   [fieldTypes.MULTISELECT]: <FormattedMessage id={fieldTypesLabelIds[fieldTypes.MULTISELECT]} />,
   [fieldTypes.RADIO_BUTTON_GROUP]: <FormattedMessage id={fieldTypesLabelIds[fieldTypes.RADIO_BUTTON_GROUP]} />,
+  [fieldTypes.DATE_PICKER]: <FormattedMessage id={fieldTypesLabelIds[fieldTypes.DATE_PICKER]} />,
 };
 
 export const NO_DEFAULT_OPTIONS_VALUE = 'no-default';
@@ -124,6 +128,13 @@ export const defaultFieldConfigs = {
         }],
       }
     }
+  },
+  [fieldTypes.DATE_PICKER]: {
+    name: '',
+    visible: true,
+    required: false,
+    helpText: '',
+    type: fieldTypes.DATE_PICKER,
   }
 };
 
@@ -134,6 +145,7 @@ export const fieldComponents = {
   [fieldTypes.SELECT]: Select,
   [fieldTypes.RADIO_BUTTON_GROUP]: RadioButtonGroup,
   [fieldTypes.MULTISELECT]: MultiSelection,
+  [fieldTypes.DATE_PICKER]: Datepicker,
 };
 
 export const rowShapes = 12;

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -294,6 +294,8 @@ const EditCustomFieldsRecord = ({
       });
     } else if (customField.type === fieldTypes.CHECKBOX) {
       return createCustomFieldRenderFunction(customField)({ type: 'checkbox' });
+    } else if (customField.type === fieldTypes.DATE_PICKER) {
+      return createCustomFieldRenderFunction(customField)({ backendDateStandard: 'YYYY-MM-DD' });
     } else {
       return createCustomFieldRenderFunction(customField)();
     }

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -97,7 +97,7 @@ describe('EditCustomFieldsRecord', () => {
     });
 
     it('should show all visible custom fields', () => {
-      expect(editCustomFields.customFields().length).to.equal(5);
+      expect(editCustomFields.customFields().length).to.equal(6);
     });
 
     describe('when Single Select field has a default option', () => {

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -224,10 +224,10 @@ describe('EditCustomFieldsSettings', () => {
 
   describe('when creating a custom field with options', () => {
     beforeEach(async () => {
-      await editCustomFields.addFieldButton.selectCustomFieldType(1);
-      await editCustomFields.customFields(5).fillName('Test field');
-      await editCustomFields.customFields(5).options(0).fillOptionName('beta');
-      await editCustomFields.customFields(5).options(1).fillOptionName('alpha');
+      await editCustomFields.addFieldButton.selectCustomFieldType(2);
+      await editCustomFields.customFields(6).fillName('Test field');
+      await editCustomFields.customFields(6).options(0).fillOptionName('beta');
+      await editCustomFields.customFields(6).options(1).fillOptionName('alpha');
       await editCustomFields.save();
     });
 
@@ -237,7 +237,7 @@ describe('EditCustomFieldsSettings', () => {
       const {
         name,
         selectField,
-      } = body.customFields[5];
+      } = body.customFields[6];
 
       expect({ name, selectField }).to.deep.equal({
         name: 'Test field',

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { chunk } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Accordion,
@@ -39,6 +39,7 @@ const {
   SELECT,
   MULTISELECT,
   CHECKBOX,
+  DATE_PICKER
 } = fieldTypes;
 
 const propTypes = {
@@ -88,6 +89,8 @@ const ViewCustomFieldsRecord = ({
     sectionTitleLoaded,
     sectionTitleFetchFailed,
   } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
+
+  const { formatDate } = useIntl();
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const columnWidth = rowShapes / columnCount;
@@ -143,7 +146,9 @@ const ViewCustomFieldsRecord = ({
       if (type === SELECT || type === RADIO_BUTTON_GROUP) {
         return getSelectedOptionLabel(customField);
       }
-
+      if (type === DATE_PICKER) {
+        return formatDate(new Date(customFieldValue));
+      }
       if (type === TEXTAREA || type === TEXTFIELD) {
         return customFieldValue;
       }

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -32,6 +32,7 @@ describe('ViewCustomFieldsRecord', () => {
           'single_select-1': 'opt_0',
           'multi_select-2': ['opt_1', 'opt_2'],
           'radio_1': 'opt_1',
+          'date1': '2023-04-01'
         }}
         entityType="user"
         expanded
@@ -63,11 +64,15 @@ describe('ViewCustomFieldsRecord', () => {
   });
 
   it('should display current number of fields', () => {
-    expect(viewCustomFields.fields().length).to.equal(5);
+    expect(viewCustomFields.fields().length).to.equal(6);
   });
 
   it('should display value for fields with a value', () => {
     expect(viewCustomFields.fields(0).value).to.equal('Some text value');
+  });
+
+  it('should display formated date value for DATE_PICKER type', () => {
+    expect(viewCustomFields.fields(5).value).to.equal('4/1/2023');
   });
 
   it('should display dash for fields without a value', () => {

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -225,6 +225,16 @@ export default function config() {
           }],
         }
       }
+    }, {
+      'id': '6',
+      'name': 'Date',
+      'refId': 'date1',
+      'type': 'DATE_PICKER',
+      'entityType': 'user',
+      'visible': true,
+      'required': false,
+      'order': 6,
+      'helpText': 'Enter a date here',
     }],
   });
 

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -219,6 +219,7 @@
   "customFields.fieldTypes.RADIO_BUTTON": "Radio button set",
   "customFields.fieldTypes.SELECT": "Single select",
   "customFields.fieldTypes.MULTISELECT": "Multi-select",
+  "customFields.fieldTypes.DATE_PICKER": "Date picker",
   "customFields.fieldLabel": "Field label",
   "customFields.fieldFormat": "Field format",
   "customFields.fieldValue.required": "{field} is required",


### PR DESCRIPTION
See [STSMACOM-800](https://issues.folio.org/browse/STSMACOM-800).
UI work for [FCFIELDS-46](https://issues.folio.org/browse/FCFIELDS-46).

This PR introduces a new field type for custom fields, `DATE_PICKER`, designed to handle ISO 8601 date values. Custom fields UI components have been updated to utilize this new field type. To add and edit date values the `<Datepicker>` component from `stripes-components` is used. Tests have been updated and translations added.

The required backend work has been done in [folio-custom-fields PR #42](https://github.com/folio-org/folio-custom-fields/pull/42).

[screen-capture.webm](https://github.com/folio-org/stripes-smart-components/assets/25431636/021da625-655f-417e-bde4-9d28ed886e46)
