### PR TITLE
STSMACOM-798 Remove required validation from 2 ViewCustomFieldRecord propTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Make `helpText` prop as optional for all types of custom field components. Refs STSMACOM-799.
 * Upgrade `stylelint` and associated dependencies. Refs STSMACOM-803.
 * `<UserName>` must handle sparse data. Refs STSMACOM-802.
+* `ViewCustomFieldRecord` - remove required validation from `expanded`, `onToggle` props. Refs STSMACOM-798.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -50,13 +50,13 @@ const propTypes = {
   customFieldsLabel: PropTypes.node,
   customFieldsValues: PropTypes.object.isRequired,
   entityType: PropTypes.string.isRequired,
-  expanded: PropTypes.bool.isRequired,
+  expanded: PropTypes.bool,
   noCustomFieldsFoundLabel: PropTypes.node,
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
-  onToggle: PropTypes.func.isRequired,
+  onToggle: PropTypes.func,
 };
 
 const defaultProps = {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-798

Proptypes no longer required: 
- expanded
- onToggle

As these can be implemented within an `AccordionStatus` component, which will provide those values from context.