### PR TITLE
[STSMACOM-806] Add `onComponentLoad` prop to `<EditCustomFieldsRecord>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Upgrade `stylelint` and associated dependencies. Refs STSMACOM-803.
 * `<UserName>` must handle sparse data. Refs STSMACOM-802.
 * `<EditableList>` - added new `getReadOnlyFieldsForItem` prop to control read only fields for different items. Refs STSMACOM-801.
+* Add `onComponentLoad` prop to `<EditCustomFieldsRecord>`. Refs STSMACOM-806.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -76,6 +76,7 @@ const propTypes = {
     tenant: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  onComponentLoad: PropTypes.func,
   onToggle: PropTypes.func,
   reduxFormCustomFieldsValues: PropTypes.objectOf(PropTypes.string),
 };
@@ -87,6 +88,7 @@ const defaultProps = {
 
 const EditCustomFieldsRecord = ({
   accordionId,
+  onComponentLoad,
   onToggle,
   expanded,
   okapi,
@@ -176,6 +178,7 @@ const EditCustomFieldsRecord = ({
 
     if (customFieldsLoaded && sectionTitleLoaded) {
       initializeFields();
+      onComponentLoad?.();
     }
   }, [
     customFieldsLoaded,
@@ -187,6 +190,7 @@ const EditCustomFieldsRecord = ({
     isReduxForm,
     reduxFormCustomFieldsValues,
     finalFormCustomFieldsValues,
+    onComponentLoad
   ]);
 
   const renderCustomFieldLabel = customField => (

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -17,6 +17,7 @@ describe('EditCustomFieldsRecord', () => {
 
   const changeFinalFormField = sinon.spy();
   const changeReduxFormField = sinon.spy();
+  const onComponentLoad = sinon.spy();
   const onToggle = sinon.spy();
 
   const renderComponent = (props = {}) => {
@@ -32,6 +33,7 @@ describe('EditCustomFieldsRecord', () => {
             expanded
             formName="custom-fields-test"
             isReduxForm={false}
+            onComponentLoad={onComponentLoad}
             onToggle={onToggle}
             fieldComponent={Field}
             {...props}
@@ -98,6 +100,10 @@ describe('EditCustomFieldsRecord', () => {
 
     it('should show all visible custom fields', () => {
       expect(editCustomFields.customFields().length).to.equal(7);
+    });
+
+    it('should call onComponentLoad', () => {
+      expect(onComponentLoad.called).to.be.true;
     });
 
     describe('when Single Select field has a default option', () => {

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -182,6 +182,7 @@ Name | type | description | required | default
 `entityType` | string | used to filter custom files by particular entity type |true
 `expanded` | boolean | indicates if the accordion is open | true |
 `fieldComponent` | func | Field component | true |
+`onComponentLoad` | func | callback function invoked when all form fields have been rendered | false |
 `onToggle` | func | callback for toggling the accordion open/closed | true |
 
 


### PR DESCRIPTION
See https://issues.folio.org/browse/STSMACOM-806.

Adds a `onComponentLoad` prop to `<EditCustomFieldsRecord>` that takes a callback function.
This will allow parent components to know when the rendering of form fields is complete.
`<EditCustomFieldsRecord>` renders its `<Field>` components asynchronously after data was fetched from the `/custom-fields` API.