### PR TITLE
[STSMACOM-805] Set default title for Accordion in `<EditCustomFieldsRecord>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Upgrade `stylelint` and associated dependencies. Refs STSMACOM-803.
 * `<UserName>` must handle sparse data. Refs STSMACOM-802.
 * `<EditableList>` - added new `getReadOnlyFieldsForItem` prop to control read only fields for different items. Refs STSMACOM-801.
+* Set default title for Accordion in `<EditCustomFieldsRecord>`. Refs STSMACOM-805.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -56,6 +56,7 @@ const propTypes = {
   changeFinalFormField: PropTypes.func,
   changeReduxFormField: PropTypes.func,
   columnCount: PropTypes.number,
+  customFieldsLabel: PropTypes.node,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool,
   fieldComponent: PropTypes.oneOfType([
@@ -82,11 +83,13 @@ const propTypes = {
 
 const defaultProps = {
   columnCount: 4,
+  customFieldsLabel: <FormattedMessage id="stripes-smart-components.customFields" />,
   isReduxForm: false,
 };
 
 const EditCustomFieldsRecord = ({
   accordionId,
+  customFieldsLabel,
   onToggle,
   expanded,
   okapi,
@@ -121,6 +124,8 @@ const EditCustomFieldsRecord = ({
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const columnWidth = rowShapes / columnCount;
+  const customFieldsAccordionTitle = sectionTitle.value || customFieldsLabel;
+
   const [isValid, setIsValid] = useState(true);
 
   const collectDataOptionsForSelect = (customField) => {
@@ -309,7 +314,7 @@ const EditCustomFieldsRecord = ({
           id={accordionId}
           onToggle={onToggle}
           label={sectionTitleLoaded
-            ? sectionTitle.value
+            ? customFieldsAccordionTitle
             : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
           }
         >

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -111,5 +111,17 @@ describe('EditCustomFieldsRecord', () => {
         expect(changeFinalFormField.calledWith('customFields.multi_select-2', ['opt_0', 'opt_1'])).to.be.true;
       });
     });
+
+    describe('when there is no custom field label', () => {
+      beforeEach(function () {
+        this.server.get('/configurations/entries', () => ({
+          configs: [],
+        }));
+      });
+
+      it('should show default accordion label', () => {
+        expect(editCustomFields.accordion.label).to.equal('Custom fields');
+      });
+    });
   });
 });

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -110,6 +110,7 @@ Name | type | description | required | default
 `accordionId` | string | used to set accordion id | true |
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true |
 `columnCount` | number | grid display in the same menner as other accordions in current page | false | 4
+`customFieldsLabel` | node | default accordion label | false | `<FormattedMessage id="stripes-smart-components.customFields" />`
 `customFieldsValues` | object | values for the custom fields | true |
 `entityType` | string | used to filter custom files by particular entity type | true |
 `expanded` | boolean | accordion open or closed | true |
@@ -179,6 +180,7 @@ Name | type | description | required | default
 `accordionId` | string | used to set accordion id | true |
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
 `columnCount` | number | grid display in the same manner as other accordions in current page | false | 4
+`customFieldsLabel` | node | default accordion label | false | `<FormattedMessage id="stripes-smart-components.customFields" />`
 `entityType` | string | used to filter custom files by particular entity type |true
 `expanded` | boolean | indicates if the accordion is open | true |
 `fieldComponent` | func | Field component | true |


### PR DESCRIPTION
See https://issues.folio.org/browse/STSMACOM-805.

Added a default accordion label to `<EditCustomFieldsRecord>`.
Done in the same way its been done in `<ViewCustomFieldsRecord>`.