### PR TITLE
STSMACOM-808: `<ItemEdit>` - pass the `error` to the `fieldComponents` callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * `ViewCustomFieldRecord` - remove required validation from `expanded`, `onToggle` props. Refs STSMACOM-798.
 * `<EditableList>` - added new `getReadOnlyFieldsForItem` prop to control read only fields for different items. Refs STSMACOM-801.
 * `<EditableList>` - added confirmation modal when deleting items. Refs STSMACOM-807.
+* `<ItemEdit>` - pass the `error` to the `fieldComponents` callback. Refs STSMACOM-808.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -50,7 +50,7 @@ const ItemEdit = ({
       if (Object.hasOwnProperty.call(fieldComponents, name)) {
         return (
           <div key={fieldKey} style={fieldStyle}>
-            { fieldComponents[name]({ fieldProps, fieldIndex, name, field, rowIndex }) }
+            { fieldComponents[name]({ fieldProps, fieldIndex, name, field, rowIndex, error }) }
           </div>
         );
       }


### PR DESCRIPTION
## Purpose
 `<ItemEdit>` - pass the `error` to the `fieldComponents` callback.
## Issues
[STSMACOM-808](https://folio-org.atlassian.net/browse/STSMACOM-808)