### PR TITLE
STSMACOM-809 Fix issue with resetting unsaved changes after failed update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * `<EditableList>` - added new `getReadOnlyFieldsForItem` prop to control read only fields for different items. Refs STSMACOM-801.
 * `<EditableList>` - added confirmation modal when deleting items. Refs STSMACOM-807.
 * Add `onComponentLoad` prop to `<EditCustomFieldsRecord>`. Refs STSMACOM-806.
+* Keep final form state when update request fails in `<EditableList>`. Refs STSMACOM-809.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/EditableList/EditableListFinalForm.js
+++ b/lib/EditableList/EditableListFinalForm.js
@@ -10,6 +10,7 @@ export default stripesFinalForm({
   navigationCheck: true,
   enableReinitialize: true,
   destroyOnUnmount: false,
+  keepDirtyOnReinitialize: true, // when update request fails with an error - keep unsaved changes in form
 })(props => <EditableListForm
   {...props}
   FieldArray={FieldArray}

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -325,7 +325,7 @@ class EditableListForm extends React.Component {
   // Set props.initialValues to the currently-saved field values.
   initializeValues = () => {
     const { initialize, form } = this.props;
-    (initialize || form.initialize)();
+    (initialize || form.initialize)(form.getState().values);
   }
 
   onSave(fields, index) {

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -45,6 +45,7 @@ const ItemEdit = ({
       const fieldProps = {
         'name': fieldName,
         'aria-label': ariaLabel,
+        error: error?.fieldErrors?.[name], // pass error to custom field components
       };
 
       if (Object.hasOwnProperty.call(fieldComponents, name)) {


### PR DESCRIPTION
## Description
Fix issue with resetting unsaved changes after failed update
Final-form by default uses initial values when resetting a form. We need to prevent that from happening by using `keepDirtyOnReinitialize: true`

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/da56f7c8-6e7b-46d2-aa5c-187a47e89ddf


https://github.com/folio-org/stripes-smart-components/assets/19309423/d4d3a935-d1e7-45c8-97c6-db73c5acb893


## Issues
[STSMACOM-809](https://folio-org.atlassian.net/browse/STSMACOM-809)