### PR TITLE
STSMACOM-810 `<EditableList>` - make `confirmationMessage` prop accept a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * `<EditableList>` - added confirmation modal when deleting items. Refs STSMACOM-807.
 * Add `onComponentLoad` prop to `<EditCustomFieldsRecord>`. Refs STSMACOM-806.
 * Keep final form state when update request fails in `<EditableList>`. Refs STSMACOM-809.
+* `<EditableList>` - make `confirmationMessage` prop accept a function. Refs STSMACOM-810.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -56,7 +56,7 @@ const propTypes = {
    */
   columnWidths: PropTypes.object,
   confirmationHeading: PropTypes.oneOfType([PropTypes.func, PropTypes.string, PropTypes.node]).isRequired,
-  confirmationMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  confirmationMessage: PropTypes.oneOfType([PropTypes.func, PropTypes.string, PropTypes.node]).isRequired,
   confirmationCancelLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   confirmationConfirmLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
@@ -666,13 +666,14 @@ class EditableListForm extends React.Component {
     }
 
     const heading = typeof confirmationHeading === 'function' ? confirmationHeading(itemIdToDelete) : confirmationHeading;
+    const message = typeof confirmationMessage === 'function' ? confirmationMessage(itemIdToDelete) : confirmationMessage;
 
     return (
       <ConfirmationModal
         id={`editList-fconfirmation-modal-${this.testingId}`}
         open={isConfirmationModalOpen}
         heading={heading}
-        message={confirmationMessage}
+        message={message}
         cancelLabel={confirmationCancelLabel}
         confirmLabel={confirmationConfirmLabel}
         onCancel={this.handleDeleteCancel}

--- a/lib/EditableList/readme.md
+++ b/lib/EditableList/readme.md
@@ -55,7 +55,7 @@ id | string | Used as a basic suffix for `id` attributes throughout the componen
 editable | boolean | Used as a flag for the component to be editable or not editable (without '+ New' button and column 'actions'). | `true` | no
 withDeleteConfirmation | boolean | Should user be asked to confirm delete action | `false` | no
 confirmationHeading | function/string/node | Confirmation modal heading. If it's a function - it will be called with id of the deleted item. | | yes
-confirmationMessage | string/node | Confirmation modal message | | yes
+confirmationMessage | function/string/node | Confirmation modal message. If it's a function - it will be called with id of the deleted item. | | yes
 confirmationCancelLabel | string/node | Confirmation modal cancel button label | default label | no
 confirmationConfirmLabel | string/node | Confirmation modal confirm button label | default label | no
 


### PR DESCRIPTION
## Description
Make `confirmationMessage`  prop accept a function that will be called with deleted item id

## Issues
[STSMACOM-810](https://folio-org.atlassian.net/browse/STSMACOM-810)