### PR TITLE
STSMACOM-809 EditableList - keep changed values when request fails, but clear them when clicking cancel (follow-up)

### DIFF
--- a/lib/EditableList/EditableList.js
+++ b/lib/EditableList/EditableList.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import sortBy from 'lodash/sortBy';
 import EditableListFinalForm from './EditableListFinalForm';
@@ -55,11 +55,16 @@ const defaultProps = {
 
 const EditableList = (props) => {
   const { contentData, nameKey, formType } = props;
-  const items = sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
   const EditableListForm = (formType === 'redux-form')
     ? EditableListReduxForm
     : EditableListFinalForm;
-  return (<EditableListForm initialValues={{ items }} {...props} />);
+
+  const initialValues = useMemo(() => {
+    const items = sortBy(contentData, [t => t[nameKey] && t[nameKey].toLowerCase()]);
+
+    return { items };
+  }, [contentData, nameKey]);
+  return (<EditableListForm initialValues={initialValues} {...props} />);
 };
 
 EditableList.propTypes = propTypes;

--- a/lib/EditableList/EditableListFinalForm.js
+++ b/lib/EditableList/EditableListFinalForm.js
@@ -10,7 +10,6 @@ export default stripesFinalForm({
   navigationCheck: true,
   enableReinitialize: true,
   destroyOnUnmount: false,
-  keepDirtyOnReinitialize: true, // when update request fails with an error - keep unsaved changes in form
 })(props => <EditableListForm
   {...props}
   FieldArray={FieldArray}


### PR DESCRIPTION
## Description
EditableList - keep changed values when request fails, but clear them when clicking cancel
Previously I added `keepDirtyOnReinitialize` to fix form reset when requests failed, but it caused the cancel button not resetting edited values to initial values

Turns out the root cause was constantly changing `initialValues` which in turn causes form reinitialize on each render
Now `initialValues` are memoized

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/481e5597-da06-4ab4-9881-29c642f3899e

## Issues
[STSMACOM-809](https://folio-org.atlassian.net/browse/STSMACOM-809)