### PR TITLE
STSMACOM-809 Pass validation error to `fieldComponents` in the same format as in `<FieldComponent>`

### DIFF
--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -45,7 +45,7 @@ const ItemEdit = ({
       const fieldProps = {
         'name': fieldName,
         'aria-label': ariaLabel,
-        error: error?.fieldErrors?.[name], // pass error to custom field components
+        ...(error && { error: error.fieldErrors[name] }), // pass error to custom field components
       };
 
       if (Object.hasOwnProperty.call(fieldComponents, name)) {


### PR DESCRIPTION
## Description
`<FieldComponent>` uses structure `{...(error && { error: error.fieldErrors[name] })}` to pass validation errors if they exist
`fieldComponents` used a different one, where `error` property would be `undefined` but still existed. I think there's a `hasOwnProperty` somewhere under the hood that checks existance of `erro` but not it's value that prevents error to be shown
Fix is to match the way `error` is passed to `fieldComponents`

##Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/0bead1c1-86e4-4175-b10c-e1d66435d46f


## Issues
[STSMACOM-809](https://folio-org.atlassian.net/browse/STSMACOM-809)