### PR TITLE
STSMACOM-813 Don't use `form.getState`  in `<EditableListForm>` because redux-form doesn't have this API. Initialization will happen automatically when fresh data has been loaded after edit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Keep final form state when update request fails in `<EditableList>`. Refs STSMACOM-809.
 * Set default title for Accordion in `<EditCustomFieldsRecord>`. Refs STSMACOM-805.
 * `<EditableList>` - make `confirmationMessage` prop accept a function. Refs STSMACOM-810.
+* Don't use `form.getState` in `<EditableListForm>` because redux-form doesn't have this API. Initialization will happen automatically when fresh data has been loaded after edit. Fixes STSMACOM-813.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -325,7 +325,7 @@ class EditableListForm extends React.Component {
   // Set props.initialValues to the currently-saved field values.
   initializeValues = () => {
     const { initialize, form } = this.props;
-    (initialize || form.initialize)(form.getState().values);
+    (initialize || form.initialize)();
   }
 
   onSave(fields, index) {


### PR DESCRIPTION
## Description
`form.getState` with redux-form causes an error because redux-form doesn't have the same API as final-form
The good news is that we can initialize the form without passing initial values as an argument - correct fresh data will be used automatically when data is re-loaded after update

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/0f4437a9-b945-4c87-a196-e7a92ec406f5



## Issues
[STSMACOM-813](https://folio-org.atlassian.net/browse/STSMACOM-813)