### PR TITLE
STSMACOM-812: <EditableListForm> - don't show an error after the user clicks on the edit icon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Set default title for Accordion in `<EditCustomFieldsRecord>`. Refs STSMACOM-805.
 * `<EditableList>` - make `confirmationMessage` prop accept a function. Refs STSMACOM-810.
 * Don't use `form.getState` in `<EditableListForm>` because redux-form doesn't have this API. Initialization will happen automatically when fresh data has been loaded after edit. Fixes STSMACOM-813.
+* `<EditableListForm>` - don't show an error after the user clicks on the edit icon. Fixes STSMACOM-812.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -502,6 +502,7 @@ class EditableListForm extends React.Component {
         newState.status = buildStatusArray(this.props.contentData);
       }
       newState.status[index].editing = !newState.status[index].editing;
+      newState.status[index].error = false;
       newState.lastAction = new Date().getTime();
       return newState;
     });


### PR DESCRIPTION
## Purpose
Don't show an error when a user clicks on the Cancel button and then again edits the item.

## Issues
[STSMACOM-812](https://folio-org.atlassian.net/browse/STSMACOM-812)

## Screencast

https://github.com/folio-org/stripes-smart-components/assets/77053927/e0bc2170-b550-47c8-b340-8aae10a21e69

