### PR TITLE
STSMACOM-816 Safely render user-supplied markup in Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * `<EditableList>` - make `confirmationMessage` prop accept a function. Refs STSMACOM-810.
 * Don't use `form.getState` in `<EditableListForm>` because redux-form doesn't have this API. Initialization will happen automatically when fresh data has been loaded after edit. Fixes STSMACOM-813.
 * `<EditableListForm>` - don't show an error after the user clicks on the edit icon. Fixes STSMACOM-812.
+* Safely render user-provided markup in `<NotesView>` component. Fixes STSMACOM-816.
 
 ## [9.0.0](https://github.com/folio-org/stripes-smart-components/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v8.0.0...v9.0.0)

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -23,6 +23,7 @@ import {
   Button,
   KeyValue,
   NoValue,
+  CleanHTML,
 } from '@folio/stripes-components';
 
 import { NOTE_LINKS_MIN_NUMBER } from '../../../constants';
@@ -225,8 +226,6 @@ export default class NoteView extends Component {
       assigned,
     } = this.state.sections;
 
-    const noteContentMarkup = { __html: noteData.content };
-
     const paneTitle = noteData.title;
 
     const paneTitleAppIcon = <AppIcon app={paneHeaderAppIcon} size="small" />;
@@ -284,11 +283,22 @@ export default class NoteView extends Component {
                     <KeyValue
                       label={<FormattedMessage id="stripes-smart-components.details" />}
                     >
-                      <div
+                      <CleanHTML
+                        markup={noteData.content}
+                        containerProps={
+                          {
+                            className: `editor-preview ql-editor ${styles['note-details-container']}`,
+                            'data-test-note-view-note-details': true
+                          }
+                        }
+                        allowSVG
+                        allowLinks
+                      />
+                      {/* <div
                         className={`editor-preview ql-editor ${styles['note-details-container']}`}
                         data-test-note-view-note-details
                         dangerouslySetInnerHTML={noteContentMarkup}
-                      />
+                      /> */}
                     </KeyValue>
                   </Col>
                 </Row>

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/interactor.js
@@ -3,7 +3,8 @@ import {
   scoped,
   clickable,
   text,
-  isPresent
+  isPresent,
+  computed,
 } from '@bigtest/interactor';
 
 import { AccordionInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
@@ -11,6 +12,12 @@ import { MetaSection as MetaSectionInteractor } from '@folio/stripes-testing';
 import NoValueInteractor from '@folio/stripes-components/lib/NoValue/tests/interactor';
 
 import ReferredRecordInteractor from '../../../../components/ReferredRecord/tests/interactor';
+
+function markup(selector) {
+  return computed(function () {
+    return this.$(selector).innerHTML;
+  });
+}
 
 export default interactor(class NoteViewInteractor {
   static defaultScope = '[data-test-note-view]';
@@ -26,4 +33,5 @@ export default interactor(class NoteViewInteractor {
   metaSection = MetaSectionInteractor();
   hasEmptyNoteType = isPresent(`[data-test-note-view-note-type] ${NoValueInteractor.defaultScope}`);
   hasEmptyNoteTitle = isPresent(`[data-test-note-view-note-title] ${NoValueInteractor.defaultScope}`);
+  noteContentText = markup('[data-test-note-view-note-details]');
 });

--- a/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/tests/note-view-test.js
@@ -31,6 +31,18 @@ const noteData = {
   type: 'General note',
 };
 
+const noteWithContentData = {
+  ...noteData,
+  content: '<strong>Message <em>is</em> <u>rendered</u></strong>',
+};
+
+const noteWithSusContentData = {
+  ...noteData,
+  content: '<strong>Message <em>is</em> <u>rendered</u><a href="javascript:alert("failure")">link</a></strong>',
+};
+
+const cleanContent = '<strong>Message <em>is</em> <u>rendered</u><a>link</a></strong>';
+
 describe('NoteView', () => {
   const noteView = new NoteViewInteractor();
 
@@ -110,6 +122,46 @@ describe('NoteView', () => {
 
     it('should display inserted Reffered Record element', () => {
       expect(noteView.insertedReferredRecord.isPresent).to.be.true;
+    });
+  });
+
+  describe('rendering NoteView component with content', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(
+        <NoteView
+          noteData={noteWithContentData}
+          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+          referredEntityData={referredEntityData}
+          renderReferredRecord={() => <div data-test-inserted-referred-record>Test</div>}
+        />
+      );
+    });
+
+    it('should display note content', () => {
+      expect(noteView.noteContentText).to.equal(noteWithContentData.content);
+    });
+  });
+
+  describe('rendering NoteView component with suspicious content', () => {
+    setupApplication();
+
+    beforeEach(async () => {
+      await mount(
+        <NoteView
+          noteData={noteWithSusContentData}
+          entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
+          entityTypeTranslationKeys={entityTypeTranslationKeys}
+          referredEntityData={referredEntityData}
+          renderReferredRecord={() => <div data-test-inserted-referred-record>Test</div>}
+        />
+      );
+    });
+
+    it('should screen suspicious content for display', () => {
+      expect(noteView.noteContentText).to.equal(cleanContent);
     });
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STSMACOM-816

Makes use of a new component: `<CleanHTML>` which can be used in place of any element using React's `_dangerouslySetInnerHTML`

Test included. (but will fail before https://github.com/folio-org/stripes-components/pull/2239 is merged)