### PR TITLE
STSMACOM-820 Fix incorrect state calculation in <SearchAndSortQuery>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 9.2.0 IN PROGRESS
 
+## [9.1.1] (IN PROGRESS)
+
+* Fix incorrect state calculation in `<SearchAndSortQuery>`. Fixes STSMACOM-820.
+
 ## [9.1.0](https://github.com/folio-org/stripes-smart-components/tree/v9.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.0.1...v9.1.0)
 

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -326,15 +326,27 @@ class SearchAndSortQuery extends React.Component {
     this.setState(curState => {
       const nextState = Object.assign({}, curState, stateToSet);
       nextState.changeType = changeType;
+
+      // calculate full next state, leave calculation of `searchChanged`, `filterChanged` etc flags until we actually have the full next state
+      return queryStateReducer(curState, nextState);
+    });
+    // React will batch these two setState calls and only one re-render will happen.
+    // this second call will have the result of first one as curState so now we can actually compare current state and initial values to determine
+    // if current values match initial values
+    this.setState(curState => {
+      const nextState = {};
       nextState.searchChanged = !isEqual(
-        nextState.searchFields,
+        curState.searchFields,
         curState.default.searchFields
       );
       nextState.filterChanged = !isEqual(
-        nextState.filterFields,
+        curState.filterFields,
         curState.default.filterFields
       );
-      nextState.sortChanged = !isEqual(nextState.sortFields, curState.default.sortFields);
+      nextState.sortChanged = !isEqual(
+        curState.sortFields,
+        curState.default.sortFields,
+      );
       return queryStateReducer(curState, nextState);
     },
     () => {

--- a/lib/SearchAndSort/SearchAndSortQuery.js
+++ b/lib/SearchAndSort/SearchAndSortQuery.js
@@ -330,9 +330,10 @@ class SearchAndSortQuery extends React.Component {
       // calculate full next state, leave calculation of `searchChanged`, `filterChanged` etc flags until we actually have the full next state
       return queryStateReducer(curState, nextState);
     });
-    // React will batch these two setState calls and only one re-render will happen.
-    // this second call will have the result of first one as curState so now we can actually compare current state and initial values to determine
-    // if current values match initial values
+    /* React will batch these two setState calls and only one re-render will happen.
+      this second call will have the result of first one as curState so now we can actually compare current state and initial values to determine
+      if current values match initial values
+    */
     this.setState(curState => {
       const nextState = {};
       nextState.searchChanged = !isEqual(

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SASQTestHarness.js
@@ -50,6 +50,19 @@ const SASQTestHarness = ({
         displayName: 'inactive',
       }
       ],
+    },
+    {
+      label: 'Patron group',
+      name:'patronGroup',
+      values:[{
+        name: 'faculty',
+        displayName: 'faculty',
+      },
+      {
+        name: 'staff',
+        displayName: 'staff',
+      }
+      ],
     }
   ];
 

--- a/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSortQueryTests/SearchAndSortQuery-test.js
@@ -57,7 +57,6 @@ describe('SearchAndSortQuery Navigation', () => {
     });
   });
 
-
   describe('navigating to a qindex parameter', () => {
     beforeEach(async () => {
       await Button('test-qindex-nav').click();
@@ -106,6 +105,17 @@ describe('SearchAndSortQuery Navigation', () => {
 
       it('removes the filter from the query string', () => {
         return HTML(including('?qindex=title&query=testSearch')).exists();
+      });
+    });
+
+    describe('when unselecting default filter, selecting another one and selecting default filter again', () => {
+      beforeEach(async () => {
+        await Checkbox('active').click();
+        await Checkbox('staff').click();
+        await Checkbox('active').click();
+      });
+      it('should have both filters selected', () => {
+        return HTML(including('?filters=patronGroup.staff%2Cstatus.active&qindex=title&query=testSearch')).exists();
       });
     });
   });


### PR DESCRIPTION
## Description
There is a bug in `<SearchAndSortQuery>` that resets filter state when user selects a filter value from initial values.

https://github.com/folio-org/stripes-smart-components/assets/19309423/2746e8c0-6223-4307-bd74-899011d6002e

The root cause is incorrect order of operations during component state update and a little bit of state mutation
### Incorrect order
Prevously we had this bit of code to get next state:
```
nextState.changeType = changeType;
nextState.searchChanged = !isEqual(
  nextState.searchFields,
  curState.default.searchFields
);
nextState.filterChanged = !isEqual(
  nextState.filterFields,
  curState.default.filterFields
);
nextState.sortChanged = !isEqual(nextState.sortFields, curState.default.sortFields);
return queryStateReducer(curState, nextState);
```
The issue is that in `isEqual(nextState.filterFields, curState.default.filterFields)` `nextState.filterFields` is not a complete object of filter values after update. It's just an object with properties to add to state, so we cannot know if next state is the same as default state just from this object.
For that we need to calculate the full next state, and only after that can we compare it to default state.
We can call `this.setState` twice - first call to calculate selected filter and other values, and then the first call will take twose values and compare them to defaults to set flags

### State mutation
Related https://github.com/folio-org/ui-plugin-find-instance/pull/212 fixes a state mutation issue and uses `nextState.filterFields` instead of `nextState.filterChanged` for it's logic. More details in comments there

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/f39bcc80-8992-4831-9f99-db6c6d48abdc

## Issues
[STSMACOM-820](https://folio-org.atlassian.net/browse/STSMACOM-820)