### PR TITLE
STSMACOM-822: Do not trigger logic for auto-opening the record's view screen in `<SearchAndSort>` if URL already contains the record ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [9.1.1] (IN PROGRESS)
 
 * Fix incorrect state calculation in `<SearchAndSortQuery>`. Fixes STSMACOM-820.
+* Do not trigger logic for auto-opening the record's view screen in `<SearchAndSort>` if URL already contains the record ID. Fixes STSMACOM-822.
 
 ## [9.1.0](https://github.com/folio-org/stripes-smart-components/tree/v9.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.0.1...v9.1.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -411,6 +411,9 @@ class SearchAndSort extends React.Component {
     const totalCountResult = currentState.totalCount();
     if (showSingleResult &&
       totalCountResult === 1 &&
+      // Check for the absence of record ID in the URL to prevent the record from being automatically opened when
+      // a user navigates from another route to `../view/:id`. The record will be open in any case.
+      // Otherwise, the previously open record replaces the newly created one.
       !recordId &&
       (this.lastNonNullResultCount > 1 || (previousState.records()[0] !== currentState.records()[0]))) {
       this.onSelectRow(null, currentState.records()[0]);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -398,16 +398,20 @@ class SearchAndSort extends React.Component {
       showSingleResult,
       finishedResourceName,
       stripes: { logger },
+      location,
     } = this.props;
 
     const previousState = makeConnectedSource(prevProps, logger);
     const currentState = makeConnectedSource(this.props, logger);
+
+    const recordId = location.pathname.split('/')[3];
 
     // if the results list is winnowed down to a single record, display the record.
     // If there's a single hit, open the detail pane as side-effect.
     const totalCountResult = currentState.totalCount();
     if (showSingleResult &&
       totalCountResult === 1 &&
+      !recordId &&
       (this.lastNonNullResultCount > 1 || (previousState.records()[0] !== currentState.records()[0]))) {
       this.onSelectRow(null, currentState.records()[0]);
     }

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -191,3 +191,41 @@ describe('SearchAndSort Query Navigation', () => {
     });
   });
 });
+
+describe('SearchAndSort when the result ID is in the URL', () => {
+  const onSelectRowSpy = sinon.spy();
+
+  setupApplication({
+    component: (
+      <SASTestHarness
+        testQindex="contributors"
+        testQindexLabel="test-qindex-nav"
+        testQuery="testquery"
+        testQueryLabel="test-query-nav"
+        customPaneSub="Custom pane sub"
+        onSelectRow={onSelectRowSpy}
+        title="Test samples"
+        module={{ displayName: 'Test samples' }}
+        viewRecordComponent={(props) => <PaneComponent {...props}>content</PaneComponent>}
+        detailProps={{ paneTitle: 'Single User' }}
+        showSingleResult
+      />)
+  });
+
+  beforeEach(async function () {
+    await this.visit('/dummy/view/111');
+    this.server.get('/samples', function ({ users }) {
+      const res = users.all();
+      return this.serialize(res, 'users');
+    });
+    onSelectRowSpy.resetHistory();
+    await this.server.db.users.remove();
+    await this.server.create('user', { userName: 'unique-user' });
+    await TextField().fillIn('unique-user');
+    await Button('Search').click();
+  });
+
+  it('should not cause automatic opening of a single result', () => {
+    expect(onSelectRowSpy.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Description
When there is a single search result and the third pane is open, and then the user creates a new record in a different route and when the new record is created the user is redirected to the main page (with the previously opened third pane). The third pane doesn't contain the newly created record, it contains the previously opened one. [video record](https://github.com/folio-org/stripes-smart-components/assets/77053927/5528549c-b886-467d-9262-179dcc033769) 

Root cause: 
The logic for automatically opening the record’s view screen fires even if the URL already contains the record’s view screen route. The logic must only be triggered if there is no open record.

## Approach

Add a check for a record ID in the URL. If it exists, then prevent the automatic opening of the record.

## Issues
[STSMACOM-822](https://folio-org.atlassian.net/browse/STSMACOM-822)

## Screencast

https://github.com/folio-org/stripes-smart-components/assets/77053927/56a3e40a-8db7-44e0-b22b-89599b5b2233

