### PR TITLE
`<ControlledVocab>` - pass override headers to PUT method, new prop to hide "New" button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix incorrect state calculation in `<SearchAndSortQuery>`. Fixes STSMACOM-820.
 * Do not trigger logic for auto-opening the record's view screen in `<SearchAndSort>` if URL already contains the record ID. Fixes STSMACOM-822.
 * Use `react-quill` compatible with `react` `v18`. Refs STSMACOM-821.
+* `<ControlledVocab>` - pass override headers to PUT method, new prop to hide "New" button. Refs STSMACOM-825.
 
 ## [9.1.0](https://github.com/folio-org/stripes-smart-components/tree/v9.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.0.1...v9.1.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -133,8 +133,6 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
-    /* Options to pass to RESTResource PUT method */
-    optionsForUpdate: PropTypes.object,
     parseRow: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
@@ -312,7 +310,7 @@ class ControlledVocab extends React.Component {
 
   onUpdateItem(item) {
     this.props.mutator.activeRecord.update({ id: item.id });
-    return this.props.mutator.values.PUT(this.props.preUpdateHook(item), this.props.optionsForUpdate)
+    return this.props.mutator.values.PUT(this.props.preUpdateHook(item))
       .then(() => {
         this.showSuccessCallout(item, ACTIONS.EDIT);
       });

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -91,6 +91,7 @@ class ControlledVocab extends React.Component {
     actionSuppressor: PropTypes.object,
     actuatorType: PropTypes.string,
     baseUrl: PropTypes.string.isRequired,
+    canCreate: PropTypes.bool,
     clientGeneratePk: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.string
@@ -99,6 +100,7 @@ class ControlledVocab extends React.Component {
     editable: PropTypes.bool,
     formatter: PropTypes.object,
     hiddenFields: PropTypes.arrayOf(PropTypes.string),
+    hideCreateButton: PropTypes.bool,
     id: PropTypes.string,
     itemTemplate: PropTypes.object,
     label: PropTypes.node.isRequired,
@@ -131,6 +133,8 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
+    /* Options to pass to RESTResource PUT method */
+    optionsForUpdate: PropTypes.object,
     parseRow: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
@@ -187,12 +191,12 @@ class ControlledVocab extends React.Component {
     */
     validate: PropTypes.func,
     visibleFields: PropTypes.arrayOf(PropTypes.string),
-    canCreate: PropTypes.bool,
   };
 
   static defaultProps = {
     visibleFields: ['name', 'description'],
     hiddenFields: [],
+    hideCreateButton: false,
     readOnlyFields: [],
     columnMapping: {},
     itemTemplate: {},
@@ -308,7 +312,7 @@ class ControlledVocab extends React.Component {
 
   onUpdateItem(item) {
     this.props.mutator.activeRecord.update({ id: item.id });
-    return this.props.mutator.values.PUT(this.props.preUpdateHook(item))
+    return this.props.mutator.values.PUT(this.props.preUpdateHook(item), this.props.optionsForUpdate)
       .then(() => {
         this.showSuccessCallout(item, ACTIONS.EDIT);
       });

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -104,6 +104,7 @@ const propTypes = {
   getReadOnlyFieldsForItem: PropTypes.func,
 
   handleSubmit: PropTypes.func.isRequired,
+  hideCreateButton: PropTypes.bool,
   /**
    * id for Add action.
    */
@@ -196,6 +197,7 @@ const defaultProps = {
   createButtonLabel: '+ Add new',
   editable: true,
   fieldComponents: {},
+  hideCreateButton: false,
   itemTemplate: {},
   uniqueField: 'id',
   validate: noop,
@@ -692,6 +694,7 @@ class EditableListForm extends React.Component {
       editable,
       canCreate,
       columnMapping,
+      hideCreateButton,
     } = this.props;
 
     const actionColumnMapping = {
@@ -742,7 +745,7 @@ class EditableListForm extends React.Component {
           <Col xs>
             <Headline size="medium" margin="none">{this.props.label}</Headline>
           </Col>
-          { editable &&
+          { (editable && !hideCreateButton) &&
             <Col xs>
               <Row end="xs">
                 <Col xs>

--- a/lib/EditableList/readme.md
+++ b/lib/EditableList/readme.md
@@ -50,6 +50,7 @@ getReadOnlyFieldsForItem | function | Function that takes a row item as an argum
 formatter | object | Allows custom content/components to be displayed in the grid. see example below. | | no
 columnMapping | object | Allows custom column names to be applied in case they differ from the properties of `contentData`'s objects| | no
 fieldComponents | object | Allows custom components for edit mode to be used. Fields not supplied will use a `<TextField>` by default| | no
+hideCreateButton | boolean | Hides create button | false | no
 columnWidths | object | Allows custom column widths to be set. If you use this, be sure to set a width for an 'actions' column as part of this object. | | no
 id | string | Used as a basic suffix for `id` attributes throughout the component. | |
 editable | boolean | Used as a flag for the component to be editable or not editable (without '+ New' button and column 'actions'). | `true` | no

--- a/lib/EditableList/tests/EditableList-test.js
+++ b/lib/EditableList/tests/EditableList-test.js
@@ -237,3 +237,29 @@ describe('Editable List - with confirmation modal', () => {
     });
   });
 });
+
+describe('EditableList - when hideNewButton prop is true', () => {
+  setupApplication();
+
+  beforeEach(async () => {
+    await mount((
+      <EditableList
+        contentData={[]}
+        createButtonLabel="+ Add new"
+        hideNewButton
+        columnMapping={{}}
+        visibleFields={['name']}
+        nameKey="id"
+        onDelete={() => {}}
+        onStatusChange={onStatusChange}
+        withDeleteConfirmation
+        confirmationHeading={itemId => `Item with id: ${itemId}`}
+        confirmationMessage="Want to delete this item?"
+        formType="final-form"
+        onSubmit={() => {}}
+      />
+    ));
+  });
+
+  it('should not render the button', () => Button({ text: '+ Add new' }).absent());
+});


### PR DESCRIPTION
## Description
For Inventory Classification Browse we need 2 changes in <ControlledVocab>
- add PUT method options override - by default Accept header is “text/plain”, but classification browse configuration doesn’t support it
- ability to hide "+New" button

## Screenshots

## Issues
[STSMACOM-825](https://folio-org.atlassian.net/browse/STSMACOM-825)

## Related PRs
https://github.com/folio-org/stripes-connect/pull/229
https://github.com/folio-org/ui-inventory/pull/2432