### PR TITLE
STSMACOM-827b - vanilla version... 

### DIFF
--- a/lib/ChangeDueDateDialog/DueDatePickerForm.js
+++ b/lib/ChangeDueDateDialog/DueDatePickerForm.js
@@ -1,43 +1,36 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form';
-
-import stripesForm from '@folio/stripes-form';
 import { Col, Datepicker, Row, Timepicker } from '@folio/stripes-components';
 
-class DueDatePickerForm extends React.Component {
-  static propTypes = {
-    dateProps: PropTypes.object,
-    timeProps: PropTypes.object,
-  }
+const DueDatePickerForm = ({ initialValues, onChange, dateProps, timeProps }) => {
+  const [dateTime, updateDateTime] = useState({ ...initialValues });
 
-  render() {
-    const { dateProps, timeProps } = this.props;
+  React.useEffect(() => onChange(dateTime), [dateTime.date, dateTime.time, onChange]); // eslint-disable-line
 
-    return (
-      <Row>
-        <Col xs={12} sm={6} md={3}>
-          <Field
-            name="date"
-            component={Datepicker}
-            timeZone="UTC"
-            {...dateProps}
-          />
-        </Col>
-        <Col xs={12} sm={6} md={3}>
-          <Field
-            name="time"
-            component={Timepicker}
-            timeZone="UTC"
-            {...timeProps}
-          />
-        </Col>
-      </Row>
-    );
-  }
-}
+  const handleChange = (e, _value, formattedValue) => {
+    updateDateTime((cur) => {
+      return { ...cur, [e.target.name]: formattedValue };
+    });
+  };
 
-export default stripesForm({
-  form: 'dueDatePickerForm',
-  navigationCheck: false,
-})(DueDatePickerForm);
+  return (
+    <Row>
+      <Col xs={12} sm={6} md={3}>
+        <Datepicker {...dateProps} name="date" onChange={handleChange} value={dateTime.date} />
+      </Col>
+      <Col xs={12} sm={6} md={3}>
+        <Timepicker {...timeProps} name="time" onChange={handleChange} value={dateTime.time} timeZone="UTC" />
+      </Col>
+    </Row>
+  );
+};
+
+DueDatePickerForm.propTypes = {
+  dateProps: PropTypes.object,
+  timeProps: PropTypes.object,
+  initialValues: PropTypes.object,
+  onChange: PropTypes.func,
+};
+
+export default DueDatePickerForm;
+


### PR DESCRIPTION
A form library is used in the change due date dialog only to catch changes to the entire form state values. It isn't used for submission, and the navigation blocking is turned off in this case...

This PR removes `stripes-form` from `changeDueDateDialog` and just goes vanilla.

The props of `DueDatePickerForm` are adjusted so that it uses the `initialValues` prop and the `onChange` handler whereas previously, `stripes-form` was using those.