### PR TITLE
STSMACOM-830 - `<SearchAndSort>` - re-position Advanced search button when search panel does not have enough space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Do not trigger logic for auto-opening the record's view screen in `<SearchAndSort>` if URL already contains the record ID. Fixes STSMACOM-822.
 * Use `react-quill` compatible with `react` `v18`. Refs STSMACOM-821.
 * `<ControlledVocab>` - pass override headers to PUT method, new prop to hide "New" button. Refs STSMACOM-825.
+* `<SearchAndSort>` - re-position Advanced search button when search panel does not have enough space. Refs STSMACOM-830.
 
 ## [9.1.0](https://github.com/folio-org/stripes-smart-components/tree/v9.1.0) (2024-03-13)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.0.1...v9.1.0)

--- a/lib/SearchAndSort/SearchAndSort.css
+++ b/lib/SearchAndSort/SearchAndSort.css
@@ -13,3 +13,18 @@
     content: "\00a0\B7\00a0";
   }
 }
+
+.resetAndAdvancedSearchWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5em;
+}
+
+.resetButton {
+  flex: 1 110px;
+}
+
+.advancedSearchButton {
+  flex: 1 140px;
+}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -964,7 +964,6 @@ class SearchAndSort extends React.Component {
     return (
       <Button
         id="clickable-advanced-search"
-        label={<FormattedMessage id="stripes-smart-components.advancedSearch" />}
         fullWidth
         onClick={() => this.setState({ isAdvancedSearchOpen: true })}
         buttonClass={css.advancedSearchButton}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -36,8 +36,6 @@ import {
   handleFilterChange,
   handleFilterClear,
   AdvancedSearch,
-  Row,
-  Col,
 } from '@folio/stripes-components';
 
 import {
@@ -901,18 +899,21 @@ class SearchAndSort extends React.Component {
   }
 
   renderResetButton = (resetRows = noop) => {
+    const { advancedSearchOptions } = this.props;
+
     return (
-      <Col xs={12} lg={6}>
-        <ResetButton
-          id="clickable-reset-all"
-          label={<FormattedMessage id="stripes-smart-components.resetAll" />}
-          disabled={this.isResetButtonDisabled()}
-          onClick={() => {
-            resetRows();
-            this.onClearSearchAndFilters();
-          }}
-        />
-      </Col>
+      <ResetButton
+        id="clickable-reset-all"
+        rootClassName={css.resetButton}
+        fullWidth
+        label={<FormattedMessage id="stripes-smart-components.resetAll" />}
+        disabled={this.isResetButtonDisabled()}
+        marginBottom0={Boolean(advancedSearchOptions.length)}
+        onClick={() => {
+          resetRows();
+          this.onClearSearchAndFilters();
+        }}
+      />
     );
   };
 
@@ -950,10 +951,10 @@ class SearchAndSort extends React.Component {
         hasQueryOption={false}
       >
         {({ resetRows }) => (
-          <Row between="xs">
+          <div className={css.resetAndAdvancedSearchWrapper}>
             {this.renderResetButton(resetRows)}
             {this.renderAdvancedSearchButton()}
-          </Row>
+          </div>
         )}
       </AdvancedSearch>
     );
@@ -961,16 +962,15 @@ class SearchAndSort extends React.Component {
 
   renderAdvancedSearchButton = () => {
     return (
-      <Col xs={12} lg={6}>
-        <Button
-          id="clickable-advanced-search"
-          label={<FormattedMessage id="stripes-smart-components.advancedSearch" />}
-          fullWidth
-          onClick={() => this.setState({ isAdvancedSearchOpen: true })}
-        >
-          <FormattedMessage id="stripes-smart-components.advancedSearch" />
-        </Button>
-      </Col>
+      <Button
+        id="clickable-advanced-search"
+        label={<FormattedMessage id="stripes-smart-components.advancedSearch" />}
+        fullWidth
+        onClick={() => this.setState({ isAdvancedSearchOpen: true })}
+        buttonClass={css.advancedSearchButton}
+      >
+        <FormattedMessage id="stripes-smart-components.advancedSearch" />
+      </Button>
     );
   };
 

--- a/lib/SearchAndSort/components/ResetButton/ResetButton.js
+++ b/lib/SearchAndSort/components/ResetButton/ResetButton.js
@@ -17,6 +17,7 @@ export default class ResetButton extends Component {
     id: PropTypes.string,
     label: PropTypes.node,
     onClick: PropTypes.func.isRequired,
+    rootClassName: PropTypes.string,
   }
 
   render() {
@@ -26,10 +27,11 @@ export default class ResetButton extends Component {
       className,
       disabled,
       onClick,
+      rootClassName,
       ...restProps
     } = this.props;
     return (
-      <div className={css.resetButtonRoot}>
+      <div className={classnames(css.resetButtonRoot, rootClassName)}>
         <Button
           buttonStyle="none"
           id={id}


### PR DESCRIPTION
## Description
`<SearchAndSort>` - re-position Advanced search button when search panel does not have enough space.

## Screenshots

https://github.com/folio-org/stripes-smart-components/assets/19309423/51e26eaf-7fb4-43ac-822c-420d665c0a60


## Issues
[STSMACOM-830](https://folio-org.atlassian.net/browse/STSMACOM-830)