### PR TITLE
STSMACOM-778 - Supply boolean value to enabled option of useQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Extend `ViewMetadata` component to accept a child render function for custom rendering. Refs STSMACOM-828.
 * Improve AdvancedSearch parsing algorithm to keep repeated spaces in queries. Fixes STSMACOM-837.
 * Support Optimistic Locking in Tags. Refs STSMACOM-839.
+* Supply boolean value to enabled option of useQuery. STSMACOM-778.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/utils/useRemoteStorageMappings.js
+++ b/lib/utils/useRemoteStorageMappings.js
@@ -15,7 +15,7 @@ const useRemoteStorageMappings = () => {
   const queryKey = [API, searchParams];
   const queryFn = () => ky(API, { searchParams }).json();
 
-  const { data } = useQuery({ queryKey, queryFn, enabled: withRemoteStorage });
+  const { data } = useQuery({ queryKey, queryFn, enabled: Boolean(withRemoteStorage) });
 
   const records = data?.mappings ?? [];
 


### PR DESCRIPTION
[STSMACOM-778](https://folio-org.atlassian.net/browse/STSMACOM-778) - useRemoteStorageMappings doesn't validate the presence of interfaces it relies on

When "remote-storage-mappings" is not available, stripes.hasInterface returns undefined which is not being consumed by useQuery enable option as false. Hence it has to be "withRemoteStorage" has to be booleanized.
With this change, ui-inventory will not make calls to remote storage mappings API when this optional interface is not available.