### PR TITLE
STSMACOM-841: Add an optional `isCursorAtEnd` property for `SearchField`. Pass `resetSelectedItem` to `onDismissDetail`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Improve AdvancedSearch parsing algorithm to keep repeated spaces in queries. Fixes STSMACOM-837.
 * Support Optimistic Locking in Tags. Refs STSMACOM-839.
 * Supply boolean value to enabled option of useQuery. STSMACOM-778.
+* Add an optional `isCursorAtEnd` property for `SearchField`. Pass `resetSelectedItem` to `onDismissDetail`. STSMACOM-841.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -159,6 +159,7 @@ class SearchAndSort extends React.Component {
     ]),
     inputType: PropTypes.string,
     isCountHidden: PropTypes.bool,
+    isCursorAtEnd: PropTypes.bool,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired,
@@ -824,6 +825,10 @@ class SearchAndSort extends React.Component {
     }
   };
 
+  resetSelectedItem = () => {
+    this.setState({ selectedItem: undefined });
+  };
+
   collapseDetails = () => {
     const {
       packageInfo: { stripes },
@@ -831,9 +836,9 @@ class SearchAndSort extends React.Component {
     } = this.props;
 
     if (onDismissDetail) {
-      onDismissDetail();
+      onDismissDetail(this.resetSelectedItem);
     } else {
-      this.setState({ selectedItem: undefined });
+      this.resetSelectedItem();
     }
 
     this.transitionToParams({ _path: `${stripes.route}/view` });
@@ -1202,6 +1207,7 @@ class SearchAndSort extends React.Component {
       inputType,
       indexRef,
       inputRef,
+      isCursorAtEnd,
     } = this.props;
     const {
       locallyChangedSearchTerm,
@@ -1240,6 +1246,7 @@ class SearchAndSort extends React.Component {
               onSubmitSearch={this.onSubmitSearch}
               indexRef={indexRef}
               inputRef={inputRef}
+              isCursorAtEnd={isCursorAtEnd}
             />
           )}
         </FormattedMessage>

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -39,6 +39,7 @@ const Pane = HTML.extend('pane')
 
 describe('SearchAndSort Query Navigation', () => {
   const onResetAllSpy = sinon.spy();
+  const onDismissDetailSpy = sinon.spy();
   const filterPane = Pane('Search & filter');
   setupApplication({
     component: (
@@ -51,9 +52,18 @@ describe('SearchAndSort Query Navigation', () => {
         onResetAll={onResetAllSpy}
         title="Test samples"
         module={{ displayName: 'Test samples' }}
-        viewRecordComponent={(props) => <PaneComponent {...props}>content</PaneComponent>}
+        viewRecordComponent={(props) => (
+          <PaneComponent
+            dismissible
+            onClose={onDismissDetailSpy}
+            {...props}
+          >
+            content
+          </PaneComponent>
+        )}
         detailProps={{ paneTitle: 'Single User' }}
         showSingleResult
+        onDismissDetail={onDismissDetailSpy}
       />)
   });
 
@@ -64,6 +74,7 @@ describe('SearchAndSort Query Navigation', () => {
     });
     await this.server.createList('user', 1000);
 
+    onDismissDetailSpy.resetHistory();
     onResetAllSpy.resetHistory();
     window.localStorage.setItem('@folio/ui-dummy/filterPaneVisibility', true);
   });
@@ -162,6 +173,15 @@ describe('SearchAndSort Query Navigation', () => {
     it('sends screen-reader message to SRStatus component', () => SRStatusInteractor({ text: 'Search returned 1 result' }).exists());
 
     it('opens the pane of the single result', () => Pane('Single User').exists());
+
+    describe('when closing details view', () => {
+      it('should call onDismissDetail callback with a function', async () => {
+        await Pane('Single User').find(IconButton({ icon: 'times' })).click();
+
+        expect(onDismissDetailSpy.called).to.be.true;
+        expect(onDismissDetailSpy.firstCall.args[0]).to.be.a('function');
+      })
+    })
   });
 
   describe('advanced search', () => {


### PR DESCRIPTION
## Description
- pass an optional `isCursorAtEnd` property to `SearchField` to be able to have a cursor at the end of the entered search term;
- pass `resetSelectedItem` to `onDismissDetail` to be able to reset the row highlighting in the `onDismissDetail` callback.

## Refs
[STSMACOM-841](https://folio-org.atlassian.net/browse/STSMACOM-841)