### PR TITLE
STSMACOM-844: Add check for the error status when optimistic locking triggered by tags assignment to Instance record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Support Optimistic Locking in Tags. Refs STSMACOM-839.
 * Supply boolean value to enabled option of useQuery. STSMACOM-778.
 * Add an optional `isCursorAtEnd` property for `SearchField`. Pass `resetSelectedItem` to `onDismissDetail`. STSMACOM-841.
+* Add check for the error status when error occurs during adding tag. STSMACOM-844.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/Tags/Tags.js
+++ b/lib/Tags/Tags.js
@@ -101,7 +101,7 @@ class Tags extends React.Component {
   };
 
   onError = error => {
-    const errorId = error.status === OPTIMISTIC_LOCKING_STATUS
+    const errorId = error.status === OPTIMISTIC_LOCKING_STATUS || error.response?.status === OPTIMISTIC_LOCKING_STATUS
       ? 'stripes-components.optimisticLocking.saveError'
       : 'stripes-smart-components.cannotSaveTagToRecord';
 


### PR DESCRIPTION
## Purpose
* When the `mutateEntity` prop is defined, and there is an error during adding/removing the tag, the error is not handled correctly. The response is `{ error: { response: { status: XXX } } }`.
* That's why we get **Cannot save tag data to record. Check that you have the required permissions.** error message instead of **This record cannot be saved because it is not the most recent version.**

## Links
[STSMACOM-844](https://folio-org.atlassian.net/browse/STSMACOM-844)

## Screenshots

https://github.com/user-attachments/assets/8554e7e2-ec06-4bd7-9f6d-b5ef7555f7b6

