### PR TITLE
STSMACOM-846: Add optional `isRequestUrlExceededLimit` property to `SearchAndSort` to return a specific error message in `StripesConnectedSource`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Supply boolean value to enabled option of useQuery. STSMACOM-778.
 * Add an optional `isCursorAtEnd` property for `SearchField`. Pass `resetSelectedItem` to `onDismissDetail`. STSMACOM-841.
 * Add check for the error status when error occurs during adding tag. STSMACOM-844.
+* Add optional `isRequestUrlExceededLimit` property to `<SearchAndSort>` to return a specific error message in `StripesConnectedSource`. Refs STSMACOM-846.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ export { default as ApolloConnectedSource } from './lib/SearchAndSort/ConnectedS
 export * from './lib/SearchAndSort/nsQueryFunctions';
 export * from './lib/SearchAndSort/parseFilters';
 export { default as buildUrl } from './lib/SearchAndSort/buildUrl';
+export * from './lib/SearchAndSort/requestUrlLimit';
 
 export { default as Settings } from './lib/Settings';
 

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -1,3 +1,6 @@
+import { FormattedMessage } from 'react-intl';
+import { REQUEST_URL_LIMIT } from '../requestUrlLimit';
+
 const UNKNOWN_RECORDS_COUNT = 999999999;
 
 export default class StripesConnectedSource {
@@ -63,7 +66,14 @@ export default class StripesConnectedSource {
   }
 
   failureMessage() {
+    const { isRequestUrlExceededLimit } = this.props;
+
     const failed = this.recordsObj.failed;
+
+    if (isRequestUrlExceededLimit) {
+      return <FormattedMessage id="stripes-smart-components.error.requestUrlLimit" values={{ limit: REQUEST_URL_LIMIT }} />;
+    }
+
     // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors
     const res = `Error ${failed.httpStatus}: ${failed.message.replace(/.*:\s*/, '')}`;
     this.logger.log('source', 'failureMessage', res);

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -160,6 +160,7 @@ class SearchAndSort extends React.Component {
     inputType: PropTypes.string,
     isCountHidden: PropTypes.bool,
     isCursorAtEnd: PropTypes.bool,
+    isRequestUrlExceededLimit: PropTypes.bool,
     location: PropTypes.shape({ // provided by withRouter
       pathname: PropTypes.string.isRequired,
       search: PropTypes.string.isRequired,

--- a/lib/SearchAndSort/index.js
+++ b/lib/SearchAndSort/index.js
@@ -2,3 +2,4 @@ export { default } from './SearchAndSort';
 export { default as makeQueryFunction } from './makeQueryFunction';
 export { default as SearchAndSortQuery } from './SearchAndSortQuery';
 export { default as advancedSearchQueryToRows } from './advancedSearchQueryToRows';
+export * from './requestUrlLimit';

--- a/lib/SearchAndSort/requestUrlLimit.js
+++ b/lib/SearchAndSort/requestUrlLimit.js
@@ -1,0 +1,1 @@
+export const REQUEST_URL_LIMIT = 4121;

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -180,8 +180,8 @@ describe('SearchAndSort Query Navigation', () => {
 
         expect(onDismissDetailSpy.called).to.be.true;
         expect(onDismissDetailSpy.firstCall.args[0]).to.be.a('function');
-      })
-    })
+      });
+    });
   });
 
   describe('advanced search', () => {

--- a/lib/SearchAndSort/tests/StripesConnectedSource-test.js
+++ b/lib/SearchAndSort/tests/StripesConnectedSource-test.js
@@ -1,0 +1,21 @@
+import {
+  describe,
+  it,
+} from 'mocha';
+import { expect } from 'chai';
+
+import StripesConnectedSource from '../ConnectedSource/StripesConnectedSource';
+import { REQUEST_URL_LIMIT } from '../requestUrlLimit';
+
+describe('StripesConnectedSource', () => {
+  describe('when a request URL is too long', () => {
+    it('should display an error message', () => {
+      expect(new StripesConnectedSource({ isRequestUrlExceededLimit: true }).failureMessage().props).to.deep.equal({
+        id: 'stripes-smart-components.error.requestUrlLimit',
+        values: {
+          limit: REQUEST_URL_LIMIT,
+        },
+      });
+    });
+  });
+});

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -282,5 +282,6 @@
   "columnManager.showColumns": "Show columns",
   "editableList.actionsColumnHeader": "Actions",
   "editableList.confirmationModal.cancelLabel": "No, do not delete",
-  "editableList.confirmationModal.confirmLabel": "Yes, delete"
+  "editableList.confirmationModal.confirmLabel": "Yes, delete",
+  "error.requestUrlLimit": "Search URI request character limit has been exceeded. The character limit is {limit}. Please revise your search and/or facet selections."
 }


### PR DESCRIPTION
## Purpose:
Display a specific error message in the results pane when the request URL exceeds the limit.

## Approach
Add the `isRequestUrlExceededLimit` property to indicate whether the limit is exceeded.

## Issues
[STSMACOM-846](https://folio-org.atlassian.net/browse/STSMACOM-846)

## Screencast




https://github.com/user-attachments/assets/6a60bced-cbc3-4d86-b78e-efe99428f664



