### PR TITLE
STSMACOM-849: Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add check for the error status when error occurs during adding tag. STSMACOM-844.
 * Add optional `isRequestUrlExceededLimit` property to `<SearchAndSort>` to return a specific error message in `StripesConnectedSource`. Refs STSMACOM-846.
 * Add `requiredFields` prop to `DateRangeFilter` to support open-ended date ranges. STSMACOM-838.
+* Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names. STSMACOM-849.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -263,6 +263,7 @@ class SearchAndSort extends React.Component {
     searchFieldButtonLabel: PropTypes.node,
     selectedIndex: PropTypes.string,
     showSingleResult: PropTypes.bool, // whether to auto-show the details record when a search returns a single row
+    showSortIndicator: PropTypes.bool,
     sortableColumns: PropTypes.arrayOf(PropTypes.string),
     stripes: PropTypes.shape({
       connect: PropTypes.func,
@@ -1301,6 +1302,7 @@ class SearchAndSort extends React.Component {
       resultsCachedPosition,
       resultsOnResetMarkedPosition,
       resultRowFormatter,
+      showSortIndicator,
       hasRowClickHandlers,
       hidePageIndices,
       pagingCanGoPrevious,
@@ -1343,6 +1345,7 @@ class SearchAndSort extends React.Component {
             selectedRow={selectedItem}
             formatter={resultsFormatter}
             visibleColumns={visibleColumnsProp || visibleColumns}
+            showSortIndicator={showSortIndicator}
             sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
             sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
             isEmptyMessage={message}


### PR DESCRIPTION
## Description
Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names.

## Issues
[STSMACOM-849](https://folio-org.atlassian.net/browse/STSMACOM-849)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2333

## Screencast

![image](https://github.com/user-attachments/assets/1e1cb4a8-be2f-4bdd-a729-52fce418e032)


