### PR TITLE
STSMACOM-850: Trim value to validate required field in the ControlledVocab component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add `requiredFields` prop to `DateRangeFilter` to support open-ended date ranges. STSMACOM-838.
 * Provide `startLabel` and `endLabel` props in `<DateRangeFilter>` to enable unique accessible labeling. STSMACOM-848.
 * Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names. STSMACOM-849.
+* Trim value to validate required field in the `ControlledVocab` component. STSMACOM-850.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -414,7 +414,7 @@ class ControlledVocab extends React.Component {
         const itemErrors = this.props.validate(item, index, items) || {};
 
         // Check if the primary field has had data entered into it.
-        if (!item[primaryField]) {
+        if (!item[primaryField]?.trim()) {
           itemErrors[primaryField] =
             <FormattedMessage id="stripes-core.label.missingRequiredField" />;
         }


### PR DESCRIPTION
## Purpose
Trimming a value to validate the required field in the ControlledVocab component is needed to prevent saving white space.

## Refs
https://folio-org.atlassian.net/browse/STSMACOM-850