### PR TITLE
STSMACOM-851: Return a specific 400 error message in `StripesConnectedSource`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Provide `startLabel` and `endLabel` props in `<DateRangeFilter>` to enable unique accessible labeling. STSMACOM-848.
 * Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names. STSMACOM-849.
 * Trim value to validate required field in the `ControlledVocab` component. STSMACOM-850.
+* Return a specific 400 error message in `StripesConnectedSource`. STSMACOM-851.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -66,12 +66,19 @@ export default class StripesConnectedSource {
   }
 
   failureMessage() {
-    const { isRequestUrlExceededLimit } = this.props;
+    const {
+      isRequestUrlExceededLimit,
+      parentResources,
+    } = this.props;
 
     const failed = this.recordsObj.failed;
 
     if (isRequestUrlExceededLimit) {
       return <FormattedMessage id="stripes-smart-components.error.requestUrlLimit" values={{ limit: REQUEST_URL_LIMIT }} />;
+    }
+
+    if (failed.httpStatus === 400) {
+      return <FormattedMessage id="stripes-smart-components.error.badRequest" values={{ query: parentResources.query.query }} />;
     }
 
     // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors

--- a/lib/SearchAndSort/tests/StripesConnectedSource-test.js
+++ b/lib/SearchAndSort/tests/StripesConnectedSource-test.js
@@ -18,4 +18,28 @@ describe('StripesConnectedSource', () => {
       });
     });
   });
+
+  it('should return a specific 400 error message', () => {
+    const query = 'www.itemcase.com/test/uri';
+
+    const props = {
+      parentResources: {
+        records: {
+          failed: {
+            httpStatus: 400,
+          },
+        },
+        query: {
+          query,
+        },
+      },
+    };
+
+    expect(new StripesConnectedSource(props).failureMessage().props).to.deep.equal({
+      id: 'stripes-smart-components.error.badRequest',
+      values: {
+        query,
+      },
+    });
+  });
 });

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -283,5 +283,6 @@
   "editableList.actionsColumnHeader": "Actions",
   "editableList.confirmationModal.cancelLabel": "No, do not delete",
   "editableList.confirmationModal.confirmLabel": "Yes, delete",
+  "error.badRequest": "Search could not be processed for {query}. Please check your query and try again.",
   "error.requestUrlLimit": "Search URI request character limit has been exceeded. The character limit is {limit}. Please revise your search and/or facet selections."
 }


### PR DESCRIPTION
## Purpose
Replace the 400 error message with "Search could not be processed for [query]. Please check your query and try again."

## Refs
[STSMACOM-851](https://folio-org.atlassian.net/browse/STSMACOM-851)

## Screenshots
![image](https://github.com/user-attachments/assets/67520032-31c6-4d30-bfe5-5b57c5b11d35)
