### PR TITLE
STSMACOM-853 DateRangeFilter - update all calls of `validateDateRange`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names. STSMACOM-849.
 * Trim value to validate required field in the `ControlledVocab` component. STSMACOM-850.
 * Return a specific error message in `StripesConnectedSource`. STSMACOM-851.
-* DateRangeFilter - update all calls of `validateDateRange`. STSMACOM-853.
+* DateRangeFilter - pass `requiredFields` argument to all calls of `validateDateRange`. STSMACOM-853.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Add `showSortIndicator` prop to `SearchAndSort` to display sort indicator next to the column names. STSMACOM-849.
 * Trim value to validate required field in the `ControlledVocab` component. STSMACOM-850.
 * Return a specific error message in `StripesConnectedSource`. STSMACOM-851.
+* DateRangeFilter - update all calls of `validateDateRange`. STSMACOM-853.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -50,7 +50,7 @@ const InvalidOrderError = () => (
   </span>
 );
 
-const getInitialValidationData = (selectedValues, dateFormat) => {
+const getInitialValidationData = (selectedValues, dateFormat, requiredFields) => {
   const {
     startDate,
     endDate,
@@ -59,7 +59,7 @@ const getInitialValidationData = (selectedValues, dateFormat) => {
   const dateRangeIsNotEmpty = startDate !== '' || endDate !== '';
 
   return dateRangeIsNotEmpty
-    ? validateDateRange(selectedValues, dateFormat)
+    ? validateDateRange(selectedValues, dateFormat, requiredFields)
     : defaultFilterState;
 };
 
@@ -170,10 +170,10 @@ const TheComponent = ({
 
   React.useEffect(() => {
     setFilterValue({
-      ...getInitialValidationData(selectedValues, dateFormat),
+      ...getInitialValidationData(selectedValues, dateFormat, requiredFields),
       selectedValues
     });
-  }, [selectedValues, dateFormat]);
+  }, [selectedValues, dateFormat, requiredFields]);
 
   return (
     <>

--- a/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
@@ -250,6 +250,25 @@ describe('DateRangeFilter', () => {
       it('should not apply the filter', () => converge(() => { if (onChangeHandler.called) throw Error('expected onChangeHandler to not be called!'); }));
     });
   });
+
+  describe('when an end date is not required', () => {
+    setupApplication({
+      component: (
+        <DateRangeFilterHarness
+          requiredFields={[DATE_TYPES.START]}
+        />
+      ),
+    });
+
+    describe('when applying the range', () => {
+      beforeEach(async () => {
+        await startPicker.fillIn('2005-01-03');
+        await applyButton.click();
+      });
+
+      it('should not show end date validation error', () => endPicker.find(ErrorInteractor(invalidMessage)).absent());
+    });
+  });
 });
 
 describe('Validate date range', () => {


### PR DESCRIPTION
## Description
After [STSMACOM-838](https://folio-org.atlassian.net/browse/STSMACOM-838) validateDateRange function now accepts requiredFields argument, which should be passed to all calls

## Issues
[STSMACOM-853](https://folio-org.atlassian.net/browse/STSMACOM-853)

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/74