### PR TITLE
STSMACOM-849: Pass sortable columns to MCL (follow-up).

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -1313,6 +1313,7 @@ class SearchAndSort extends React.Component {
       resultsOnResetMarkedPosition,
       resultRowFormatter,
       showSortIndicator,
+      sortableColumns,
       hasRowClickHandlers,
       hidePageIndices,
       pagingCanGoPrevious,
@@ -1356,6 +1357,7 @@ class SearchAndSort extends React.Component {
             formatter={resultsFormatter}
             visibleColumns={visibleColumnsProp || visibleColumns}
             showSortIndicator={showSortIndicator}
+            sortableFields={sortableColumns}
             sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
             sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
             isEmptyMessage={message}


### PR DESCRIPTION
Follow-up PR.

## Description
After adding the `showSortIndicator` property, Tab navigation only works for fields that are interactive (not in the `nonInteractiveHeaders` list). Passing the `sortableColumns` will return the previous behavior where we could navigate through all the result list headers using the Tab key, and will leave the correct indication for sortable fields.

During Tab navigation, this will allow screen readers to read all column names, rather than just interactive ones.

## Issues
[STCOM-1328](https://folio-org.atlassian.net/browse/STCOM-1328)

## Screenshots
![image](https://github.com/user-attachments/assets/79a4b199-09e1-4733-a7d9-c0c150ab2811)

