### PR TITLE
Fix the reinitialization of useEffect dependency when the component re-renders

### DIFF
--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -75,6 +75,8 @@ const arePropsEqual = (prev, next) => {
   );
 };
 
+const DEFAULT_REQUIRED_FIELDS = [DATE_TYPES.START, DATE_TYPES.END];
+
 const TheComponent = ({
   dateFormat = 'YYYY-MM-DD',
   placement = 'right-start',
@@ -83,7 +85,7 @@ const TheComponent = ({
   makeFilterString,
   onChange,
   focusRef,
-  requiredFields = [DATE_TYPES.START, DATE_TYPES.END],
+  requiredFields = DEFAULT_REQUIRED_FIELDS,
   // accessible label for disambiguating this start input from others.
   startLabel,
   // accessible label for disambiguating this end input from others.


### PR DESCRIPTION
After merging https://github.com/folio-org/stripes-smart-components/pull/1512 some of the tests started failing due to infinite calling of the `useEffect` inside the `<DateRangeFilter>` component.

![image](https://github.com/user-attachments/assets/33015dac-392b-414a-a09b-3a483d5ecf54)

The absence of explicit passing of the `requiredFields` prop causes the application of the default value, which is an array literal. Accordingly, with each render of the component, this array is created anew and the reference to this object in memory changes, which serves as an indicator for calling the `useEffect` callback.