### PR TITLE
STSMACOM-854: Bump up `actions/upload-artifact@v2` to `actions/upload

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -153,7 +153,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -171,7 +171,7 @@ jobs:
           comment_title: BigTest Unit Test Statistics
 
       - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bigtest-coverage-report

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -93,7 +93,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -111,7 +111,7 @@ jobs:
           comment_title: BigTest Unit Test Statistics
 
       - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bigtest-coverage-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Return a specific error message in `StripesConnectedSource`. STSMACOM-851.
 * Changed translation keys in `LocationLookup` to stripes-components. STSMACOM-852.
 * DateRangeFilter - pass `requiredFields` argument to all calls of `validateDateRange`. STSMACOM-853.
+* Bump up `actions/upload-artifact@v2` to `actions/upload-artifact@v4`. Refs STSMACOM-854.
 
 ## [9.1.1] (IN PROGRESS)
 


### PR DESCRIPTION
STSMACOM-854: Bump up `actions/upload-artifact@v2` to `actions/upload-artifact@v4` to resolve the workflow-building issue [here](https://github.com/folio-org/stripes-smart-components/actions/runs/10825984039/job/30036018466)

![Screenshot 2024-09-12 at 12 20 59](https://github.com/user-attachments/assets/103dd1fa-5c68-45e2-ae3c-c1c6d56ee3d5)
