### PR TITLE
STSMACOM-855: `DateRangeFilter` - add the optional `hideCalendarButton` property to hide the calendar icon button; add error message for invalid `YYYY` format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Changed translation keys in `LocationLookup` to stripes-components. STSMACOM-852.
 * DateRangeFilter - pass `requiredFields` argument to all calls of `validateDateRange`. STSMACOM-853.
 * Bump up `actions/upload-artifact@v2` to `actions/upload-artifact@v4`. Refs STSMACOM-854.
+* `DateRangeFilter` - add the optional `hideCalendarButton` property to hide the calendar icon button; add error message for invalid YYYY format. Refs STSMACOM-855.
 
 ## [9.1.1] (IN PROGRESS)
 

--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -23,11 +23,17 @@ const defaultFilterState = {
   },
 };
 
-const renderInvalidDateError = (dateType) => (
-  <span data-test-invalid-date={dateType}>
-    <FormattedMessage id="stripes-smart-components.dateRange.invalidDate" />
-  </span>
-);
+const renderInvalidDateError = (dateType, dateFormat) => {
+  if (dateFormat === 'YYYY') {
+    return <FormattedMessage id="stripes-smart-components.dateRange.invalidYear" />;
+  }
+
+  return (
+    <span data-test-invalid-date={dateType}>
+      <FormattedMessage id="stripes-smart-components.dateRange.invalidDate" />
+    </span>
+  );
+};
 
 const renderMissingDateError = (dateType) => {
   const translationId = dateType === DATE_TYPES.START
@@ -63,8 +69,8 @@ const getInitialValidationData = (selectedValues, dateFormat, requiredFields) =>
     : defaultFilterState;
 };
 
-const getDateError = ({ errors, dateInvalid, dateMissing, type }) => {
-  return (errors[dateInvalid] && renderInvalidDateError(DATE_TYPES[type]))
+const getDateError = ({ errors, dateFormat, dateInvalid, dateMissing, type }) => {
+  return (errors[dateInvalid] && renderInvalidDateError(DATE_TYPES[type], dateFormat))
     || (errors[dateMissing] && renderMissingDateError(DATE_TYPES[type]));
 };
 
@@ -90,6 +96,7 @@ const TheComponent = ({
   startLabel,
   // accessible label for disambiguating this end input from others.
   endLabel,
+  hideCalendarButton = false,
 }) => {
   const [filterValue, setFilterValue] = React.useState({
     ...defaultFilterState,
@@ -105,6 +112,7 @@ const TheComponent = ({
 
   const startDateError = getDateError({
     errors,
+    dateFormat,
     dateInvalid: 'startDateInvalid',
     dateMissing: 'startDateMissing',
     type: 'START'
@@ -112,6 +120,7 @@ const TheComponent = ({
 
   const endDateError = getDateError({
     errors,
+    dateFormat,
     dateInvalid: 'endDateInvalid',
     dateMissing: 'endDateMissing',
     type: 'END'
@@ -195,6 +204,7 @@ const TheComponent = ({
           setFocusRefOnFocus(element);
         }}
         aria-label={startLabel}
+        hideCalendarButton={hideCalendarButton}
       />
       <Datepicker
         name={DATE_TYPES.END}
@@ -209,6 +219,7 @@ const TheComponent = ({
         usePortal
         inputRef={setFocusRef}
         aria-label={endLabel}
+        hideCalendarButton={hideCalendarButton}
       />
       <div role="alert">
         {wrongDatesOrder && <InvalidOrderError />}
@@ -228,6 +239,7 @@ TheComponent.propTypes = {
   dateFormat: PropTypes.string,
   endLabel: PropTypes.string,
   focusRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  hideCalendarButton: PropTypes.bool,
   makeFilterString: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
@@ -14,6 +14,7 @@ import DATE_TYPES from '../date-types';
 const filterName = 'dateRange';
 const dateFormat = 'YYYY-MM-DD';
 const invalidMessage = 'Please enter a valid date';
+const invalidYearMessage = 'Please enter a valid year';
 const missingStartDateMessage = 'Please enter a start date';
 const missingEndDateMessage = 'Please enter an end date';
 const wrongOrderMessage = 'Start date is greater than end date';
@@ -201,6 +202,22 @@ describe('DateRangeFilter', () => {
 
       it('should not apply the filter', () => converge(() => { if (onChangeHandler.called) throw Error('expected onChangeHandler to not be called!'); }));
     });
+  });
+
+  describe('when YYYY format is used and the provided year is invalid', () => {
+    setupApplication({
+      component: (
+        <DateRangeFilterHarness
+          dateFormat="YYYY"
+          selectedDates={{
+            startDate: '',
+            endDate: '200a',
+          }}
+        />)
+    });
+
+
+    it('should display corresponding error below the end date input', () => endPicker.find(ErrorInteractor(invalidYearMessage)).exists());
   });
 
   describe('and start date is missing', () => {

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -35,6 +35,7 @@
   "dateRange.to": "To",
   "dateRange.apply": "Apply",
   "dateRange.invalidDate": "Please enter a valid date",
+  "dateRange.invalidYear": "Please enter a valid year",
   "dateRange.missingStartDate": "Please enter a start date",
   "dateRange.missingEndDate": "Please enter an end date",
   "dateRange.wrongOrder": "Start date is greater than end date",


### PR DESCRIPTION
## Purpose
- add the ability to hide the calendar icon button;
- show a different error message if format is YYYY and the year is invalid.

## Approach
- the optional `hideCalendarButton` property to hide the calendar icon button;
- add an error message specificly for invalid `YYYY` format.

## Related PRs
https://github.com/folio-org/stripes-components/pull/2347

## Issues
[STSMACOM-855](https://folio-org.atlassian.net/browse/STSMACOM-855)