### PR TITLE
STSMACOM-863: Improve confirmation modal footer for `ControlledVocab` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Omit (don't disable) "+ New" button in `<EditableList>` when user lacks permission. Refs STSMACOM-836.
 * Avoid deprecated `defaultProps` for functional components. Refs STSMACOM-835.
 * Upgrade `notes` to `v4.0`. Refs STSMACOM-861.
+* Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 
 ## [9.1.3](https://github.com/folio-org/stripes-smart-components/tree/v9.1.3) (2024-05-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.1.2...v9.1.3)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -15,6 +15,7 @@ import {
   Paneset,
   Row,
   Loading,
+  ModalFooter,
 } from '@folio/stripes-components';
 
 import EditableList from '../EditableList';
@@ -437,8 +438,21 @@ class ControlledVocab extends React.Component {
     const type = this.props.labelSingular;
     const { cannotDeleteTermHeader, cannotDeleteTermMessage } = this.props.translations ?? {};
 
+    const footer = (
+      <ModalFooter>
+        <Button
+          buttonStyle="primary"
+          onClick={this.hideItemInUseDialog}
+          marginBottom0
+        >
+          <FormattedMessage id="stripes-core.label.okay" />
+        </Button>
+      </ModalFooter>
+    );
+
     return (
       <Modal
+        footer={footer}
         open={this.state.showItemInUseDialog}
         label={
           cannotDeleteTermHeader ?
@@ -454,13 +468,6 @@ class ControlledVocab extends React.Component {
                 <FormattedMessage id={cannotDeleteTermMessage} /> :
                 <FormattedMessage id="stripes-smart-components.cv.cannotDeleteTermMessage" values={{ type }} />
             }
-          </Col>
-        </Row>
-        <Row>
-          <Col xs>
-            <Button buttonStyle="primary" onClick={this.hideItemInUseDialog}>
-              <FormattedMessage id="stripes-core.label.okay" />
-            </Button>
           </Col>
         </Row>
       </Modal>


### PR DESCRIPTION
[STSMACOM-863](https://folio-org.atlassian.net/browse/STSMACOM-863): 
Improve confirmation modal footer for `ControlledVocab` component. Need to improve the correct button alignment and spacing using existing Folio patterns via utilizing ModalFooter for the modal button.

###Current
![image (7)](https://github.com/user-attachments/assets/fca20494-4be4-4c4c-b734-0e392c784285)

###Expected
![Screenshot 2024-10-17 at 13 42 06](https://github.com/user-attachments/assets/9ed2b47e-70a0-487b-a83e-8cf4d1e2abd0)
