### PR TITLE
STSMACOM-864 `<DateRangeFilter>` - add new `ignoreDatesOrder` prop to ignore order of dates during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Upgrade `notes` to `v4.0`. Refs STSMACOM-861.
 * Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 * Add the `endDateInputRef` prop to `DateRangeFilter` to access the end date element. Refs STSMACOM-859.
+* `<DateRangeFilter>` - add new `ignoreDatesOrder` prop to ignore order of dates during validation. Refs STSMACOM-864.
 
 ## [9.1.3](https://github.com/folio-org/stripes-smart-components/tree/v9.1.3) (2024-05-06)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.1.2...v9.1.3)

--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.js
@@ -56,7 +56,7 @@ const InvalidOrderError = () => (
   </span>
 );
 
-const getInitialValidationData = (selectedValues, dateFormat, requiredFields) => {
+const getInitialValidationData = (selectedValues, dateFormat, requiredFields, ignoreDatesOrder) => {
   const {
     startDate,
     endDate,
@@ -65,7 +65,7 @@ const getInitialValidationData = (selectedValues, dateFormat, requiredFields) =>
   const dateRangeIsNotEmpty = startDate !== '' || endDate !== '';
 
   return dateRangeIsNotEmpty
-    ? validateDateRange(selectedValues, dateFormat, requiredFields)
+    ? validateDateRange(selectedValues, dateFormat, requiredFields, ignoreDatesOrder)
     : defaultFilterState;
 };
 
@@ -98,6 +98,7 @@ const TheComponent = ({
   endLabel,
   hideCalendarButton = false,
   endDateInputRef,
+  ignoreDatesOrder = false,
 }) => {
   const [filterValue, setFilterValue] = React.useState({
     ...defaultFilterState,
@@ -143,7 +144,7 @@ const TheComponent = ({
     const bothDatesEmpty = startDate === '' && endDate === '';
 
     if (!bothDatesEmpty) {
-      const validationData = validateDateRange(selectedValuesState, dateFormat, requiredFields);
+      const validationData = validateDateRange(selectedValuesState, dateFormat, requiredFields, ignoreDatesOrder);
 
       setFilterValue(prevState => ({
         ...prevState,
@@ -152,7 +153,7 @@ const TheComponent = ({
 
       if (validationData.dateRangeValid) applyFilter();
     }
-  }, [applyFilter, dateFormat, endDate, selectedValuesState, startDate, requiredFields]);
+  }, [applyFilter, dateFormat, endDate, selectedValuesState, startDate, requiredFields, ignoreDatesOrder]);
 
   const handleDateChange = (event, field) => {
     const date = event.target.value;
@@ -183,10 +184,10 @@ const TheComponent = ({
 
   React.useEffect(() => {
     setFilterValue({
-      ...getInitialValidationData(selectedValues, dateFormat, requiredFields),
+      ...getInitialValidationData(selectedValues, dateFormat, requiredFields, ignoreDatesOrder),
       selectedValues
     });
-  }, [selectedValues, dateFormat, requiredFields]);
+  }, [selectedValues, dateFormat, requiredFields, ignoreDatesOrder]);
 
   return (
     <>
@@ -245,6 +246,7 @@ TheComponent.propTypes = {
   endLabel: PropTypes.string,
   focusRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   hideCalendarButton: PropTypes.bool,
+  ignoreDatesOrder: PropTypes.bool,
   makeFilterString: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.md
+++ b/lib/SearchAndSort/components/DateRangeFilter/DateRangeFilter.md
@@ -14,6 +14,8 @@
 | `requiredFields` | string[] | Set which fields for this filter are requred. See #Validation for more details on the behavior. | true |  `[DATE_TYPES.START, DATE_TYPES.END]`
 | `startLabel` | string | Will be set as the `aria-label` on the range start field. | false |
 | `endLabel` | string | Will be set as the `aria-label` on the range end field. | false |
+| `hideCalendarButton` | bool | Hide calenber icon button. | false |
+| `ignoreDatesOrder` | bool | Ignore order of dates during validation | false |
 
 ## Validation
 

--- a/lib/SearchAndSort/components/DateRangeFilter/date-validations.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/date-validations.js
@@ -7,7 +7,7 @@ export const isDateValid = (date, dateFormat) => {
   return momentDateWrapper.isValid();
 };
 
-export const validateDateRange = (dateRange, dateFormat, requiredFields = [DATE_TYPES.START, DATE_TYPES.END]) => {
+export const validateDateRange = (dateRange, dateFormat, requiredFields = [DATE_TYPES.START, DATE_TYPES.END], ignoreDatesOrder = false) => {
   const {
     startDate,
     endDate,
@@ -29,7 +29,7 @@ export const validateDateRange = (dateRange, dateFormat, requiredFields = [DATE_
   let wrongDatesOrder = false;
   if (bothDatesEntered) {
     const bothDatesValid = !startDateInvalid && !endDateInvalid;
-    wrongDatesOrder = bothDatesValid && startDateMomentWrapper.isAfter(endDateMomentWrapper);
+    wrongDatesOrder = !ignoreDatesOrder && (bothDatesValid && startDateMomentWrapper.isAfter(endDateMomentWrapper));
     dateRangeValid = bothDatesEntered && bothDatesValid && !wrongDatesOrder;
   } else if (startDateEmpty && endDateEmpty) {
     startDateMissing = requiredFields.includes(DATE_TYPES.START);

--- a/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
+++ b/lib/SearchAndSort/components/DateRangeFilter/tests/DateRangeFilter-test.js
@@ -276,6 +276,40 @@ describe('DateRangeFilter', () => {
 
       it('should not apply the filter', () => converge(() => { if (onChangeHandler.called) throw Error('expected onChangeHandler to not be called!'); }));
     });
+
+    describe('and `ignoreDatesOrder` prop is true', () => {
+      setupApplication({
+        component: (
+          <DateRangeFilterHarness
+            selectedDates={{
+              startDate: '2016-01-01',
+              endDate: '2006-01-01',
+            }}
+            startLabel="test start label"
+            endLabel="test end label"
+            ignoreDatesOrder
+          />)
+      });
+
+      it('should not display corresponding error below the filter', () => ErrorInteractor(wrongOrderMessage).absent());
+
+      describe.only('and "Apply" button was clicked', () => {
+        beforeEach(async () => {
+          await applyButton.click();
+        });
+
+        it('should apply the filter', () => {
+          const resultingFilterValue = makeDateRangeFilterString('2016-01-01', '2006-01-01');
+
+          const expectedArguments = {
+            name: filterName,
+            values: [resultingFilterValue],
+          };
+
+          return converge(() => { if (!onChangeHandler.calledWith(expectedArguments)) throw Error('expected onChangeHandler to be called!'); });
+        });
+      });
+    });
   });
 
   describe('when an end date is not required', () => {


### PR DESCRIPTION
## Description
`<DateRangeFilter>` - add new `ignoreDatesOrder` prop to ignore order of dates during validation

## Screenshots

https://github.com/user-attachments/assets/784b4f3e-2936-4947-9514-a227cd4441a3



## Issues
[STSMACOM-864](https://folio-org.atlassian.net/browse/STSMACOM-864)

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/90