### PR TITLE
STSMACOM-871: Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Upgrade `notes` to `v4.0`. Refs STSMACOM-861.
 * Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 * Add the `endDateInputRef` prop to `DateRangeFilter` to access the end date element. Refs STSMACOM-859.
+* Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components. Fixes STSMACOM-871.
 
 ## [9.2.0](https://github.com/folio-org/stripes-smart-components/tree/v9.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.1.3...v9.2.0)

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -87,7 +87,6 @@ const ItemEdit = ({
         { [css.isOdd]: !(rowIndex % 2) },
         rowClass,
       )}
-      aria-rowindex={rowIndex + 2}
     >
       {fields}
     </div>

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -87,6 +87,7 @@ const ItemEdit = ({
         { [css.isOdd]: !(rowIndex % 2) },
         rowClass,
       )}
+      aria-rowindex={rowIndex + 2}
     >
       {fields}
     </div>

--- a/lib/EditableList/ItemEdit.js
+++ b/lib/EditableList/ItemEdit.js
@@ -87,7 +87,7 @@ const ItemEdit = ({
         { [css.isOdd]: !(rowIndex % 2) },
         rowClass,
       )}
-      aria-rowindex={rowIndex + 2}
+      data-row-inner={rowIndex + 2}
     >
       {fields}
     </div>

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -10,7 +10,6 @@ const ItemView = ({ cells, rowClass, rowIndex }) => (
       { [css.isOdd]: !(rowIndex % 2) },
       rowClass,
     )}
-    aria-rowindex={rowIndex + 2}
   >
     {cells}
   </div>

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -10,6 +10,7 @@ const ItemView = ({ cells, rowClass, rowIndex }) => (
       { [css.isOdd]: !(rowIndex % 2) },
       rowClass,
     )}
+    aria-rowindex={rowIndex + 2}
   >
     {cells}
   </div>

--- a/lib/EditableList/ItemView.js
+++ b/lib/EditableList/ItemView.js
@@ -10,7 +10,7 @@ const ItemView = ({ cells, rowClass, rowIndex }) => (
       { [css.isOdd]: !(rowIndex % 2) },
       rowClass,
     )}
-    aria-rowindex={rowIndex + 2}
+    data-row-inner={rowIndex + 2}
   >
     {cells}
   </div>


### PR DESCRIPTION
* Remove unnecessary `aria-rowindex` attribute in `<EditableList>` item wrappers in order to avoid accessibility errorss. It is unnecessary to add this attribute in `<EditableList>`, because `<MultiColumnList>` already adds `aria-rowindex` to a wrapper element of each row.

## Links
[STSMACOM-871](https://folio-org.atlassian.net/browse/STSMACOM-871)