### PR TITLE
STSMACOM-872: Reset `qindex` once the search field is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 * Add the `endDateInputRef` prop to `DateRangeFilter` to access the end date element. Refs STSMACOM-859.
 * Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components. Fixes STSMACOM-871.
+
+## [9.2.3] IN PROGRESS
+
 * Reset `qindex` once the search field is empty. Fixes STSMACOM-872.
 
 ## [9.2.0](https://github.com/folio-org/stripes-smart-components/tree/v9.2.0) (2024-10-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 * Add the `endDateInputRef` prop to `DateRangeFilter` to access the end date element. Refs STSMACOM-859.
 * Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components. Fixes STSMACOM-871.
+* Reset `qindex` once the search field is empty. Fixes STSMACOM-872.
 
 ## [9.2.0](https://github.com/folio-org/stripes-smart-components/tree/v9.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.1.3...v9.2.0)

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -645,7 +645,7 @@ class SearchAndSort extends React.Component {
     } = this.props;
     this.log('action', 'cleared search query');
     this.setState({ locallyChangedSearchTerm: '' });
-    this.transitionToParams({ query: '', ...extraParamsToReset });
+    this.transitionToParams({ query: '', qindex: '', ...extraParamsToReset });
   };
 
   onCloseEdit = (e) => {

--- a/lib/SearchAndSort/tests/SearchAndSort-test.js
+++ b/lib/SearchAndSort/tests/SearchAndSort-test.js
@@ -129,6 +129,20 @@ describe('SearchAndSort Query Navigation', () => {
           expect(onResetAllSpy.called).to.be.true;
         });
       });
+
+      describe('Selecting another query index', () => {
+        beforeEach(async () => {
+          await Bigtest.Select().choose('all');
+        });
+
+        describe('Clearing text field', () => {
+          beforeEach(async () => {
+            await TextField().fillIn('');
+          });
+
+          it('removes `qindex` from query', () => HTML({ id: 'query-debug' }).has({ text: 'search:' }));
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Purpose
Avoid resetting the selected search option when the text in the search box becomes empty.

## Issues
[STSMACOM-872](https://folio-org.atlassian.net/browse/STSMACOM-872)

## Screencast

https://github.com/user-attachments/assets/fc304968-5a12-4444-bdb8-356b965fd0f0

