### PR TITLE
STSMACOM-873 - Settings link not maintaining active status/style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improve confirmation modal footer for `ControlledVocab` component. Refs STSMACOM-863.
 * Add the `endDateInputRef` prop to `DateRangeFilter` to access the end date element. Refs STSMACOM-859.
 * Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components. Fixes STSMACOM-871.
+* Check for `active` status of `<Settings>` navigation links independently from the applie href and query string. Query string should only be applied to active link. Refs STSMACOM-837.
 
 ## [9.2.3] IN PROGRESS
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -64,23 +64,26 @@ class Settings extends Component {
         const search = props.location.search || '';
         const link = `${props.match.path}/${p.route}`;
         let href = link;
-
-        // apply the query string for the active link only.
-        if (props.location.pathname.startsWith(link)) {
-          href = link + search;
-          activeLink = link;
-        }
-        if (p.perm && !stripes.hasPerm(p.perm)) return null;
+        let isActive = false;
 
         // NavListItem allows for isActive to be set independently, rather than
         // strict internal comparison of the href and the `activeLink`
-        // Since the location can be augmented after navigation, it's best to
-        // solely rely on the pathname for appying the style.
+        // Since the location can be augmented after navigation through subsequent navigation
+        // or through appending a query string, it's best to
+        // solely rely on the pathname for appying the style vs equality.
+        if (props.location.pathname.startsWith(link)) {
+          // apply the query string for the active link only.
+          href = link + search;
+          activeLink = link;
+          isActive = true;
+        }
+        if (p.perm && !stripes.hasPerm(p.perm)) return null;
+
         return (
           <NavListItem
             key={p.route}
             to={href}
-            isActive={props.location.pathname.startsWith(link)}
+            isActive={isActive}
           >
             {p.label}
           </NavListItem>

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -62,12 +62,29 @@ class Settings extends Component {
     const navlinks = (section) => {
       const navItems = section.pages.map((p) => {
         const search = props.location.search || '';
-        const link = `${props.match.path}/${p.route}${search}`;
+        const link = `${props.match.path}/${p.route}`;
+        let href = link;
+
+        // apply the query string for the active link only.
         if (props.location.pathname.startsWith(link)) {
+          href = link + search;
           activeLink = link;
         }
         if (p.perm && !stripes.hasPerm(p.perm)) return null;
-        return <NavListItem key={p.route} to={link}>{p.label}</NavListItem>;
+
+        // NavListItem allows for isActive to be set independently, rather than
+        // strict internal comparison of the href and the `activeLink`
+        // Since the location can be augmented after navigation, it's best to
+        // solely rely on the pathname for appying the style.
+        return (
+          <NavListItem
+            key={p.route}
+            to={href}
+            isActive={props.location.pathname.startsWith(link)}
+          >
+            {p.label}
+          </NavListItem>
+        );
       }).filter(x => x !== null);
 
       return (

--- a/lib/Settings/tests/Settings-test.js
+++ b/lib/Settings/tests/Settings-test.js
@@ -76,7 +76,7 @@ function setupApplication({
   });
 }
 
-describe.only('Settings', () => {
+describe('Settings', () => {
   const settings = settingsInteractor();
   setupApplication({ component: TestApp });
   beforeEach(async function () { // eslint-disable-line func-names

--- a/lib/Settings/tests/Settings-test.js
+++ b/lib/Settings/tests/Settings-test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import setupStripesCore from '@folio/stripes-core/test/bigtest/helpers/setup-application';
+import {
+  describe,
+  beforeEach,
+  it,
+} from 'mocha';
+
+
+
+import { HTML } from '@folio/stripes-testing';
+import { Paneset } from '@folio/stripes-components';
+import mirageOptions from '../../../tests/network';
+import Settings from '../Settings';
+
+const settingsInteractor = HTML.extend('Settings')
+  .selector('#app-settings-nav-pane')
+  .filters({
+    numLinks: (el) => el.querySelector('[data-test-nav-list]').querySelectorAll('a').length,
+    navTitle: (el) => el.querySelector('[data-test-pane-header]').innerText
+  });
+
+const MockSettingsPage = () => <div>Mock Settings</div>;
+
+const TestApp = (props) => {
+  const pages = [
+    { route: 'perms', label: 'Permission sets', component: MockSettingsPage, perm: 'perms.permissions.get' },
+    { route: 'groups', label: 'Patron groups', component: MockSettingsPage },
+  ];
+  return ((
+    <Paneset>
+      <Settings pages={pages} paneTitle="Test title" {...props} />
+    </Paneset>
+  ));
+};
+
+function setupApplication({
+  scenarios,
+  component = null,
+  permissions = {},
+  stripesConfig
+} = {}) {
+  const initialState = {
+    discovery: {
+      modules: {
+        'users-module-id': 'users-test',
+      },
+    }
+  }
+  setupStripesCore({
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
+    stripesConfig,
+    scenarios,
+    permissions,
+    initialState,
+    // setup a dummy app for smart components
+    modules: [{
+      type: 'app',
+      name: '@folio/ui-dummy',
+      displayName: 'dummy.title',
+      route: '/dummy',
+      module: (props) => component(props),
+    }],
+
+    translations: {
+      'dummy.title': 'Dummy'
+    }
+  });
+
+  // go to the dummy app where smart components are mounted
+  beforeEach(async function () { // eslint-disable-line func-names
+    await this.visit('/dummy');
+  });
+}
+
+describe.only('Settings', () => {
+  const settings = settingsInteractor();
+  setupApplication({ component: TestApp });
+  beforeEach(async function () { // eslint-disable-line func-names
+    await this.visit('/dummy');
+  });
+
+  it('renders the pane title', () => settings.has({ navTitle: 'Test title' }));
+  it('renders correct number of links', () => settings.has({ numLinks: 2 }));
+});


### PR DESCRIPTION
## [STSMACOM-873](https://folio-org.atlassian.net/browse/STSMACOM-873)

## Problem(s)
At first discovery, it's obvious that the settings navigation links for apps like Data Import do not render themselves as active when they are clicked. Many apps work fine, but in the case of these instances, the module itself modifies the query string after the settings view is initially rendered. This throws off the built-in logic that determines the active status of the link (strict equals of the link's `href` against the location) and it's even worse if the pathname is modified... (Service Interaction).
Upon deeper inspection both in the history and the past solution of the issue, there was an issue with the query string not being maintained in the link - so that a second click of the link may throw off logic since initialization for the view wouldn't be re-run, which would mess up sorting (as seen in [UIDATIMP-1321](https://folio-org.atlassian.net/browse/UIDATIMP-1321)) The logic of the solution for UIDATIMP-1321 causes the query string of the activeLink to be passed on to all of the other settings NavLinks listed 😬 (on top of the style not being correctly rendered)

## Approach
* Only apply the query string to the href of the determined active link  (keeping UIDATIMP-1321's needs intact)
* Use the startsWith pathname comparison to determine the boolean `isActive` prop of the rendered `NavListItem`s

Behavior Before (Note the hrefs to the links presented at bottom)
![settingsLinksBefore](https://github.com/user-attachments/assets/78a6fa78-94ec-4a04-be13-cfb04003a1c9)

Behavior After:
![settingsLinksAfter](https://github.com/user-attachments/assets/0de33e56-b95d-4492-b4c5-77e3ab667201)


