### PR TITLE
STSMACOM-879 Use `this.resources` in `StripesConnectedSource` instead of accessing props directly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Reset `qindex` once the search field is empty. Fixes STSMACOM-872.
 * Use `<IfAnyPermission>` and `stripes.hasAnyPerm` to check for Notes assign/unassign perm. Fixes STSMACOM-875.
 * Fetch updaters in `<ViewMetaData>` on `props.metadata` changes. Fixes STSMACOM-878.
+* Use `this.resources` in `StripesConnectedSource` instead of accessing props directly. Fixes STSMACOM-879.
 
 ## [9.2.0](https://github.com/folio-org/stripes-smart-components/tree/v9.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.1.3...v9.2.0)

--- a/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
+++ b/lib/SearchAndSort/ConnectedSource/StripesConnectedSource.js
@@ -66,10 +66,7 @@ export default class StripesConnectedSource {
   }
 
   failureMessage() {
-    const {
-      isRequestUrlExceededLimit,
-      parentResources,
-    } = this.props;
+    const { isRequestUrlExceededLimit } = this.props;
 
     const failed = this.recordsObj.failed;
 
@@ -80,7 +77,7 @@ export default class StripesConnectedSource {
     // stripes-connect failure object has: dataKey, httpStatus, message, module, resource, throwErrors
     const res = `Error ${failed.httpStatus}: ${failed.message.replace(/.*:\s*/, '')}`;
     this.logger.log('source', 'failureMessage', res);
-    return <FormattedMessage id="stripes-smart-components.error.badRequest" values={{ query: parentResources.query.query }} />;
+    return <FormattedMessage id="stripes-smart-components.error.badRequest" values={{ query: this.resources.query.query }} />;
   }
 
   fetchMore(increment) {


### PR DESCRIPTION
## Description
`StripesConnectedSource` can accept either `parentResources` or `resources` and one of them can be undefined. Because of this we should use `this.resources` instead, which takes this into account

## Screenshots

https://github.com/user-attachments/assets/ec30f55d-c9b2-4643-afd6-ca3d663eb68b



## Issues
[STSMACOM-879](https://folio-org.atlassian.net/browse/STSMACOM-879)