### PR TITLE
STSMACOM-882 `<NoteFields>` improve "Display as pop-up" markup and fix label a11y issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove unnecessary `aria-rowindex` in `ItemView` and `ItemEdit` components. Fixes STSMACOM-871.
 * Check for `active` status of `<Settings>` navigation links independently from the applied href and query string. Query string should only be applied to active link. Refs STSMACOM-837.
 * `<EditableListForm>` use `lodash.isEmpty` to check for empty `state.status` in re-initialization checks on component update. Fixes STSMACOM-876.
+* `<NoteFields>` improve "Display as pop-up" markup and fix label a11y issue. Refs STSMACOM-882.
 
 ## [9.2.3] IN PROGRESS
 

--- a/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
+++ b/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
@@ -90,39 +90,29 @@ export default class NoteFields extends Component {
         {showDisplayAsPopupOptions && (
           <Row>
             <Col xs={12}>
-              <Row>
-                <Col xs={12}>
-                  <Label tagName="div">
-                    <span className={styles.heading}>
-                      <FormattedMessage id="stripes-smart-components.notes.displayAsPopup.label" />
-                    </span>
-                  </Label>
-                </Col>
-              </Row>
-              <Row>
-                <Col xs={12}>
-                  <Field
-                    name="popUpOnCheckOut"
-                    type="checkbox"
-                    component={Checkbox}
-                    data-test-note-popup-on-checkout-field
-                    label={<FormattedMessage id="stripes-smart-components.notes.displayAsPopup.checkout" />}
-                    readOnly={fieldsAreDisabled}
-                  />
-                </Col>
-              </Row>
-              <Row>
-                <Col xs={12}>
-                  <Field
-                    name="popUpOnUser"
-                    type="checkbox"
-                    component={Checkbox}
-                    data-test-note-popup-on-users-field
-                    label={<FormattedMessage id="stripes-smart-components.notes.displayAsPopup.users" />}
-                    readOnly={fieldsAreDisabled}
-                  />
-                </Col>
-              </Row>
+              <Label for="display-as-popup-group">
+                <span className={styles.heading}>
+                  <FormattedMessage id="stripes-smart-components.notes.displayAsPopup.label" />
+                </span>
+              </Label>
+              <div id="display-as-popup-group">
+                <Field
+                  name="popUpOnCheckOut"
+                  type="checkbox"
+                  component={Checkbox}
+                  data-test-note-popup-on-checkout-field
+                  label={<FormattedMessage id="stripes-smart-components.notes.displayAsPopup.checkout" />}
+                  readOnly={fieldsAreDisabled}
+                />
+                <Field
+                  name="popUpOnUser"
+                  type="checkbox"
+                  component={Checkbox}
+                  data-test-note-popup-on-users-field
+                  label={<FormattedMessage id="stripes-smart-components.notes.displayAsPopup.users" />}
+                  readOnly={fieldsAreDisabled}
+                />
+              </div>
             </Col>
           </Row>
         )}

--- a/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
+++ b/lib/Notes/components/NoteForm/components/NoteFields/NoteFields.js
@@ -90,12 +90,12 @@ export default class NoteFields extends Component {
         {showDisplayAsPopupOptions && (
           <Row>
             <Col xs={12}>
-              <Label for="display-as-popup-group">
+              <Label id="display-as-popup-group-label">
                 <span className={styles.heading}>
                   <FormattedMessage id="stripes-smart-components.notes.displayAsPopup.label" />
                 </span>
               </Label>
-              <div id="display-as-popup-group">
+              <fieldset aria-labelledby="display-as-popup-group-label">
                 <Field
                   name="popUpOnCheckOut"
                   type="checkbox"
@@ -112,7 +112,7 @@ export default class NoteFields extends Component {
                   label={<FormattedMessage id="stripes-smart-components.notes.displayAsPopup.users" />}
                   readOnly={fieldsAreDisabled}
                 />
-              </div>
+              </fieldset>
             </Col>
           </Row>
         )}


### PR DESCRIPTION
## Description
axe previously showed an a11y issue related to checkbox group labels. Latest code doesn't show this issue anymore, but applied the fix anyways.
Re-organized "Display as pop-up" checkbox group markup.

## Screenshots
![image](https://github.com/user-attachments/assets/6c90e93c-ed4d-454d-8c24-874e324d6c85)

## Issues
[STSMACOM-882](https://folio-org.atlassian.net/browse/STSMACOM-882)