### PR TITLE
STSMACOM-887: Change the request URL limit for `REQUEST_URL_LIMIT` due to increase to 8192.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Check for `active` status of `<Settings>` navigation links independently from the applied href and query string. Query string should only be applied to active link. Refs STSMACOM-837.
 * `<EditableListForm>` use `lodash.isEmpty` to check for empty `state.status` in re-initialization checks on component update. Fixes STSMACOM-876.
 * `<NoteFields>` improve "Display as pop-up" markup and fix label a11y issue. Refs STSMACOM-882.
+* Change the request URL limit for `REQUEST_URL_LIMIT` due to increase to 8192. Refs STSMACOM-887.
 
 ## [9.2.3] IN PROGRESS
 

--- a/lib/SearchAndSort/requestUrlLimit.js
+++ b/lib/SearchAndSort/requestUrlLimit.js
@@ -1,1 +1,2 @@
-export const REQUEST_URL_LIMIT = 4121;
+// OKAPI-1198
+export const REQUEST_URL_LIMIT = 8192;


### PR DESCRIPTION
## Description:
Okapi’s URI max length was increased from 4096 to 8192 in [OKAPI-1198](https://folio-org.atlassian.net/browse/OKAPI-1198). This requires a change to the `REQUEST_URL_LIMIT` variable.

## Issues
[STSMACOM-887](https://folio-org.atlassian.net/browse/STSMACOM-887)
