### PR TITLE
STSMACOM-893 EntryManager sort by id if sort-key is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Change the request URL limit for `REQUEST_URL_LIMIT` due to increase to 8192. Refs STSMACOM-887.
 * Correctly import from `stripes-*` libraries. Refs STSMACOM-884.
 * *BREAKING* Upgrade `@folio/stripes-*` dependencies. Refs STSMACOM-891.
+* `<EntryManager>` sort entries by `id` if the requested sort-key is absent. Refs STSMACOM-893.
 
 ## [9.2.3] IN PROGRESS
 

--- a/lib/EntryManager/EntrySelector.js
+++ b/lib/EntryManager/EntrySelector.js
@@ -22,6 +22,19 @@ import {
 } from '@folio/stripes-components';
 import ConnectedWrapper from './ConnectedWrapper';
 
+/**
+ * listSortByLowerCase
+ * Sort the list by the lower-cased value of key. If the key is not present
+ * on an item, use its `id` property instead.
+ *
+ * @param {Array} list Array of items to sort
+ * @param {string} key property of an object to sort by
+ * @returns list, sorted by the lower-cased value of key
+ */
+export const listSortByLowerCase = (list, key) => {
+  return _.sortBy(list, [(i) => (i[key] ? i[key].toLowerCase() : i.id)]);
+};
+
 class EntrySelector extends React.Component {
   static propTypes = {
     addButtonTitle: PropTypes.string,
@@ -331,7 +344,7 @@ class EntrySelector extends React.Component {
     } = this.props;
 
     const rows = this.filteredRows(contentData);
-    const links = _.sortBy(rows, [record => record[nameKey].toLowerCase()]).map(item => (
+    const links = listSortByLowerCase(rows, nameKey).map(item => (
       <div data-test-nav-list-item key={item.id}>
         <NavListItem
           to={this.linkPath(item.id)}

--- a/lib/EntryManager/EntrySelector.test.js
+++ b/lib/EntryManager/EntrySelector.test.js
@@ -1,0 +1,27 @@
+import { listSortByLowerCase } from './EntrySelector';
+
+describe('listSortByLowerCase', () => {
+  it('sorts by [key] when key is present', () => {
+    const list = [
+      { id: 'AA', name: 'Aa' },
+      { id: 'Ab', name: 'Ab' },
+      { id: 'b', name: 'b' },
+      { id: 'c', name: 'C' },
+    ];
+
+    const shuffled = [...list].sort(() => Math.random() - 0.5);
+    expect(listSortByLowerCase(shuffled, 'name')).toEqual(list);
+  });
+
+  it('sorts by [id] when key is missing', () => {
+    const list = [
+      { id: 'Aa' },
+      { id: 'Ab', name: 'Ab' },
+      { id: 'b', name: 'b' },
+      { id: 'c', name: 'C' },
+    ];
+
+    const shuffled = [...list].sort(() => Math.random() - 0.5);
+    expect(listSortByLowerCase(shuffled, 'name')).toEqual(list);
+  });
+});


### PR DESCRIPTION
Avoid an NPE when sorting lists if the requested sort-key is missing by using `id` as the key instead. Should we check for `id`? Eh, maybe, but `<EntryManager>` is a tool for handling entries retrieved from API requests so it seems like a safe assumption.

This bug was introduced in 1a8f5450b566c0cf21626760e2ef40de5e63f8c2.

Refs [STSMACOM-893](https://folio-org.atlassian.net/browse/STSMACOM-893)