### PR TITLE
STSMACOM-896 apply wrappers with flow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 10.1.0 IN PROGRESS
 
+* Apply wrappers with `flow()` instead of annotations. Refs STSMACOM-896.
+
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)
 

--- a/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
+++ b/lib/Notes/NoteViewPage/components/NoteView/NoteView.js
@@ -40,8 +40,7 @@ import {
   referredEntityDataShape,
 } from '../../../components/NoteForm/noteShapes';
 
-@withStripes
-export default class NoteView extends Component {
+class NoteView extends Component {
   static propTypes = {
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
     entityTypeTranslationKeys: PropTypes.objectOf(PropTypes.string),
@@ -317,3 +316,5 @@ export default class NoteView extends Component {
     );
   }
 }
+
+export default withStripes(NoteView);


### PR DESCRIPTION
Replace annotations such as `@withStripes` with a [`_.flow()`](https://lodash.com/docs/4.17.15#flow)-based syntax for better compatibility with esbuild-loader >= 3.1.0.

Refs [STSMACOM-896](https://folio-org.atlassian.net/browse/STSMACOM-896)