### PR TITLE
STSMACOM-896 replace annotations with _.flow

### DIFF
--- a/lib/Notes/NoteCreatePage/NoteCreatePage.js
+++ b/lib/Notes/NoteCreatePage/NoteCreatePage.js
@@ -15,7 +15,6 @@ import NoteForm from '../components/NoteForm';
 import { noteTypesCollectionShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 
-@stripesConnect
 class NoteCreatePage extends Component {
   static propTypes = {
     domain: PropTypes.string.isRequired,
@@ -175,4 +174,4 @@ class NoteCreatePage extends Component {
   }
 }
 
-export default NoteCreatePage;
+export default stripesConnect(NoteCreatePage);

--- a/lib/Notes/NoteEditPage/NoteEditPage.js
+++ b/lib/Notes/NoteEditPage/NoteEditPage.js
@@ -16,7 +16,6 @@ import { noteTypesCollectionShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 import { getMetadataPropsFromResponse } from '../utils';
 
-@stripesConnect
 class NoteEditPage extends Component {
   static propTypes = {
     domain: PropTypes.string.isRequired,
@@ -207,4 +206,4 @@ class NoteEditPage extends Component {
   }
 }
 
-export default NoteEditPage;
+export default stripesConnect(NoteEditPage);

--- a/lib/Notes/NoteViewPage/NoteViewPage.js
+++ b/lib/Notes/NoteViewPage/NoteViewPage.js
@@ -20,7 +20,6 @@ import NoteView from './components/NoteView';
 import { noteShape } from '../response-shapes';
 import { referredEntityDataShape } from '../components/NoteForm/noteShapes';
 
-@stripesConnect
 class NoteViewPage extends Component {
   static propTypes = {
     entityTypePluralizedTranslationKeys: PropTypes.objectOf(PropTypes.string),
@@ -312,4 +311,4 @@ class NoteViewPage extends Component {
   }
 }
 
-export default injectIntl(NoteViewPage);
+export default injectIntl(stripesConnect(NoteViewPage));

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -42,7 +42,7 @@ const searchQueryParams = {
   [notesColumnNames.TITLE_AND_DETAILS]: 'title',
   [notesColumnNames.TYPE]: 'noteType',
 };
-@stripesConnect
+
 class NotesSmartAccordion extends Component {
   static propTypes = {
     domainName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
@@ -407,4 +407,4 @@ class NotesSmartAccordion extends Component {
   }
 }
 
-export default withRouter(NotesSmartAccordion);
+export default withRouter(stripesConnect(NotesSmartAccordion));


### PR DESCRIPTION
Just like PR #1568, replace annotations that don't play nice with our esbuild-loader setup. Unfortunately, I missed a bunch of annotations in the original PR.

Refs [STSMACOM-896](https://folio-org.atlassian.net/browse/STSMACOM-896)