### PR TITLE
STSMACOM-902: ConfigManager - Add `userId` property to be able to retrieve user's own settings, not just tenant settings from mod-settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.1.0 IN PROGRESS
 
 * Apply wrappers with `flow()` instead of annotations. Refs STSMACOM-896.
+* `ConfigManager` - Add `userId` property to retrieve the user's own settings from mod-settings. Refs STSMACOM-902.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -30,7 +30,7 @@ const getPath = (_q, _p, _r, _l, props) => {
   }
 
   return getSettingsPath({ scope, configName, userId });
-}
+};
 
 class ConfigManager extends React.Component {
   static manifest = Object.freeze({

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -7,14 +7,36 @@ import { Callout } from '@folio/stripes-components';
 import ConfigReduxForm from './ConfigReduxForm';
 import ConfigFinalForm from './ConfigFinalForm';
 
+const getConfigurationsPath = (moduleName, configName) => {
+  return `configurations/entries?query=(module==${moduleName} and configName==${configName})`;
+};
+
+const getSettingsPath = ({ scope, configName, userId }) => {
+  const userIdQuery = userId ? ` and userId==${userId}` : '';
+
+  return `settings/entries?query=(scope==${scope} and key==${configName}${userIdQuery})`;
+};
+
+const getPath = (_q, _p, _r, _l, props) => {
+  const {
+    moduleName,
+    configName,
+    scope,
+    userId,
+  } = props;
+
+  if (moduleName) {
+    return getConfigurationsPath(moduleName, configName);
+  }
+
+  return getSettingsPath({ scope, configName, userId });
+}
+
 class ConfigManager extends React.Component {
   static manifest = Object.freeze({
     settings: {
       type: 'okapi',
-      path: (_q, _p, _r, _l, props) => (props.moduleName ?
-        `configurations/entries?query=(module==${props.moduleName} and configName==${props.configName})` :
-        `settings/entries?query=(scope==${props.scope} and key==${props.configName}${props.userId ? ` and userId==${props.userId}` : ''})`
-      ),
+      path: getPath,
       POST: {
         path: (_q, _p, _r, _l, props) => `${props.moduleName ? 'configurations' : 'settings'}/entries`,
       },
@@ -69,7 +91,7 @@ class ConfigManager extends React.Component {
       { value },
       (moduleName ?
         { module: moduleName, configName } :
-        { 
+        {
           scope,
           key: configName,
           ...(userId && { userId }),

--- a/lib/ConfigManager/ConfigManager.js
+++ b/lib/ConfigManager/ConfigManager.js
@@ -13,7 +13,7 @@ class ConfigManager extends React.Component {
       type: 'okapi',
       path: (_q, _p, _r, _l, props) => (props.moduleName ?
         `configurations/entries?query=(module==${props.moduleName} and configName==${props.configName})` :
-        `settings/entries?query=(scope==${props.scope} and key==${props.configName})`
+        `settings/entries?query=(scope==${props.scope} and key==${props.configName}${props.userId ? ` and userId==${props.userId}` : ''})`
       ),
       POST: {
         path: (_q, _p, _r, _l, props) => `${props.moduleName ? 'configurations' : 'settings'}/entries`,
@@ -46,6 +46,7 @@ class ConfigManager extends React.Component {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }),
+    userId: PropTypes.string,
     validate: PropTypes.func,
   };
 
@@ -60,7 +61,7 @@ class ConfigManager extends React.Component {
   }
 
   onSave(data) {
-    const { resources, mutator, moduleName, configName, scope, calloutMessage, onBeforeSave, onAfterSave } = this.props;
+    const { resources, mutator, moduleName, configName, scope, calloutMessage, onBeforeSave, onAfterSave, userId } = this.props;
     const value = (onBeforeSave) ? onBeforeSave(data) : data[configName];
     const setting = Object.assign(
       {},
@@ -68,7 +69,11 @@ class ConfigManager extends React.Component {
       { value },
       (moduleName ?
         { module: moduleName, configName } :
-        { scope, key: configName })
+        { 
+          scope,
+          key: configName,
+          ...(userId && { userId }),
+        }),
     );
 
     const action = (setting.id) ? 'PUT' : 'POST';

--- a/lib/ConfigManager/readme.md
+++ b/lib/ConfigManager/readme.md
@@ -26,4 +26,5 @@ onBeforeSave | func | Optional callback used before config has been saved to pro
 onAfterSave | func | Optional callback used after config has been saved successfully.
 formType | string | Optional specification of what form library to use. Default `redux-form`; the other supported value is `final-form`.
 validate | func | Optional validation function for the form library.
+userId | string | Optional user id for retrieving the user's own settings from mod-settings.
 stripes | object | The stripes object: if provided, it is passed down into the child component of the config-form.


### PR DESCRIPTION
## Description
`ConfigManager` - Add `userId` property to be able to retrieve user's own settings, not just tenant settings from mod-settings. This change is made specifically for https://github.com/folio-org/ui-myprofile/pull/251

## Issues
[STSMACOM-902](https://folio-org.atlassian.net/browse/STSMACOM-902)


