### PR TITLE
STSMACOM-903 Pass props for rendering aside content for custom fields accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.1.0 IN PROGRESS
 
 * Apply wrappers with `flow()` instead of annotations. Refs STSMACOM-896.
+* Pass props for rendering aside content for `<EditCustomFieldsRecord>`'s accordion. Refs STSMACOM-903.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -57,6 +57,8 @@ const propTypes = {
   changeReduxFormField: PropTypes.func,
   columnCount: PropTypes.number,
   customFieldsLabel: PropTypes.node,
+  displayWhenClosed: PropTypes.node,
+  displayWhenOpen: PropTypes.node,
   entityType: PropTypes.string.isRequired,
   expanded: PropTypes.bool,
   fieldComponent: PropTypes.oneOfType([
@@ -85,6 +87,8 @@ const propTypes = {
 const EditCustomFieldsRecord = ({
   accordionId,
   customFieldsLabel = <FormattedMessage id="stripes-smart-components.customFields" />,
+  displayWhenClosed,
+  displayWhenOpen,
   onComponentLoad,
   onToggle,
   expanded,
@@ -315,6 +319,8 @@ const EditCustomFieldsRecord = ({
             ? customFieldsAccordionTitle
             : <Icon data-test-custom-fields-loading-icon icon="spinner-ellipsis" />
           }
+          displayWhenClosed={displayWhenClosed}
+          displayWhenOpen={displayWhenOpen}
         >
           {
             customFieldsLoaded && formattedCustomFields.map((row, i) => (


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STSMACOM-903

## Purpose

Since the `<EditCustomFieldsRecord>` component includes an `<Accordion>`, it should support passing content as props based on the accordion’s state — `displayWhenClosed` and `displayWhenOpen`.
The prop names are consistent with those used in the `<Accordion>` component.

As per the current business requirement, this accordion might be marked as _hidden_ within the order template. This designation allows the component to be excluded from the rendering of both the PO and POL form and view. (Ref https://folio-org.atlassian.net/browse/UIOR-1394)

## Screenshots


https://github.com/user-attachments/assets/d4986439-8008-4701-bf18-9713213e2021


