### PR TITLE
STSMACOM-904: Add `hideEditButton`, `interactive` and `noRowClick` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Apply wrappers with `flow()` instead of annotations. Refs STSMACOM-896.
 * `ConfigManager` - Add `userId` property to retrieve the user's own settings from mod-settings. Refs STSMACOM-902.
-* Add `hideEditButton`, `interactive` and `noRowClick` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
+* Add `hideEditButton`, `interactive` and `canClickRow` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Apply wrappers with `flow()` instead of annotations. Refs STSMACOM-896.
 * `ConfigManager` - Add `userId` property to retrieve the user's own settings from mod-settings. Refs STSMACOM-902.
+* Add `hideEditButton`, `interactive` and `noRowClick` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -55,6 +55,7 @@ class NotesSmartAccordion extends Component {
     hideNewButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    interactive: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     mutator: PropTypes.object.isRequired,
     noRowClick: PropTypes.bool,
@@ -69,6 +70,7 @@ class NotesSmartAccordion extends Component {
   }
 
   static defaultProps = {
+    interactive: true,
     hideAssignButton: false,
     hideEditButton: false,
     hideNewButton: false,

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -58,7 +58,7 @@ class NotesSmartAccordion extends Component {
     interactive: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     mutator: PropTypes.object.isRequired,
-    noRowClick: PropTypes.bool,
+    canClickRow: PropTypes.bool,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
     pathToNoteCreate: PropTypes.string,
@@ -75,7 +75,7 @@ class NotesSmartAccordion extends Component {
     hideEditButton: false,
     hideNewButton: false,
     label: <FormattedMessage id="stripes-smart-components.notes" />,
-    noRowClick: false,
+    canClickRow: true,
     referredRecordData: {},
   };
 
@@ -369,7 +369,7 @@ class NotesSmartAccordion extends Component {
       entityType,
       entityId,
       mutator,
-      noRowClick,
+      canClickRow,
       onToggle,
       open,
       id,
@@ -390,7 +390,7 @@ class NotesSmartAccordion extends Component {
           domainNotes={this.getDomainNotes()}
           noteTypes={this.getNoteTypeNames()}
           onNoteCreateButtonClick={this.onNoteCreateButtonClick}
-          onAssignedNoteClick={noRowClick ? null : this.onAssignedNoteClick}
+          onAssignedNoteClick={canClickRow ? this.onAssignedNoteClick : null}
           onAssignedNoteEditClick={this.onAssignedNoteEditClick}
           entityName={entityName}
           entityType={entityType}

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -47,19 +47,21 @@ class NotesSmartAccordion extends Component {
   static propTypes = {
     domainName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
     entityId: PropTypes.string.isRequired,
-    entityName: PropTypes.string.isRequired,
+    entityName: PropTypes.string,
     entityType: PropTypes.string.isRequired,
     headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
+    hideEditButton: PropTypes.bool,
     hideNewButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     mutator: PropTypes.object.isRequired,
+    noRowClick: PropTypes.bool,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    pathToNoteCreate: PropTypes.string.isRequired,
-    pathToNoteDetails: PropTypes.string.isRequired,
+    pathToNoteCreate: PropTypes.string,
+    pathToNoteDetails: PropTypes.string,
     referredRecordData: PropTypes.object,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
@@ -68,8 +70,10 @@ class NotesSmartAccordion extends Component {
 
   static defaultProps = {
     hideAssignButton: false,
+    hideEditButton: false,
     hideNewButton: false,
     label: <FormattedMessage id="stripes-smart-components.notes" />,
+    noRowClick: false,
     referredRecordData: {},
   };
 
@@ -363,10 +367,13 @@ class NotesSmartAccordion extends Component {
       entityType,
       entityId,
       mutator,
+      noRowClick,
       onToggle,
       open,
       id,
+      interactive,
       hideAssignButton,
+      hideEditButton,
       hideNewButton,
       label,
       headerProps,
@@ -381,7 +388,7 @@ class NotesSmartAccordion extends Component {
           domainNotes={this.getDomainNotes()}
           noteTypes={this.getNoteTypeNames()}
           onNoteCreateButtonClick={this.onNoteCreateButtonClick}
-          onAssignedNoteClick={this.onAssignedNoteClick}
+          onAssignedNoteClick={noRowClick ? null : this.onAssignedNoteClick}
           onAssignedNoteEditClick={this.onAssignedNoteEditClick}
           entityName={entityName}
           entityType={entityType}
@@ -392,8 +399,10 @@ class NotesSmartAccordion extends Component {
           onSortDomainNotes={this.onSortDomainNotes}
           fetchDomainNotes={this.fetchDomainNotes}
           id={id}
+          interactive={interactive}
           open={open}
           hideAssignButton={hideAssignButton}
+          hideEditButton={hideEditButton}
           hideNewButton={hideNewButton}
           onToggle={onToggle}
           label={label}

--- a/lib/Notes/NotesSmartAccordion/readme.md
+++ b/lib/Notes/NotesSmartAccordion/readme.md
@@ -33,5 +33,8 @@ domainName | string | App name.
 entityName | string | The title of the record name(e.g. A Biographical Dictionary of Later Han).
 entityType | string | Record name(e.g. package).
 entityId | string | Record id.
+hideEditButton | bool   | Hides the edit button. Default is false.
+interactive | bool   | Applies a "pointer" cursor when the mouse hovers over a row. Default is true.
+noRowClick | bool   | Prevents clicking on a row. Default is false.
 pathToNoteCreate | string | Path to Note create page.
 pathToNoteDetails | string | Path to Note details page. NotesSmartAccordion will add / with note id during redirecting to details page. 

--- a/lib/Notes/NotesSmartAccordion/readme.md
+++ b/lib/Notes/NotesSmartAccordion/readme.md
@@ -35,6 +35,6 @@ entityType | string | Record name(e.g. package).
 entityId | string | Record id.
 hideEditButton | bool   | Hides the edit button. Default is false.
 interactive | bool   | Applies a "pointer" cursor when the mouse hovers over a row. Default is true.
-noRowClick | bool   | Prevents clicking on a row. Default is false.
+canClickRow | bool   | If true, the row is clickable. Default is true.
 pathToNoteCreate | string | Path to Note create page.
 pathToNoteDetails | string | Path to Note details page. NotesSmartAccordion will add / with note id during redirecting to details page. 

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -365,4 +365,68 @@ describe('Notes smart accordion', () => {
 
     it('should not display create note button', () => notesAccordion.has({ newButton: false }));
   });
+
+  describe('when hideEditButton prop is true', () => {
+    setupApplication({
+      scenarios: ['create-notes-with-note-types'],
+    });
+
+    beforeEach(async () => {
+      await mount(
+        <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
+          <NotesSmartAccordion
+            domainName="dummy"
+            entityId="providerId"
+            id="notes-accordion"
+            open
+            interactive={false}
+            entityType="provider"
+            hideAssignButton
+            hideEditButton
+            hideNewButton
+            noRowClick
+          />
+        </div>
+      );
+    });
+
+    it('should not display edit note button', () => notesAccordion.has({ editButton: false }));
+  });
+
+  describe('when noRowClick prop is true', () => {
+    setupApplication({
+      scenarios: ['create-notes-with-note-types'],
+    });
+
+    beforeEach(async () => {
+      const domainName = 'dummy';
+
+      await mount(
+        <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
+          <NotesSmartAccordion
+            id="notes-accordion"
+            open
+            onToggle={() => {}}
+            domainName={domainName}
+            entityName="Cool Provider"
+            entityType="provider"
+            entityId="providerId"
+            pathToNoteCreate={`${domainName}/notes/new`}
+            pathToNoteDetails={`${domainName}/notes`}
+            noRowClick
+          />
+        </div>
+      );
+    });
+
+    describe('when a note in the notes list was clicked', () => {
+      beforeEach(async () => {
+        await notesAccordion.clickNote(0);
+      });
+
+      it('should not redirect to note view page', function () {
+        expect(this.location.pathname + this.location.search).to.equal('/dummy');
+      });
+    });
+  });
 });

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -375,6 +375,7 @@ describe('Notes smart accordion', () => {
       await mount(
         <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
           <NotesSmartAccordion
+            canClickRow={false}
             domainName="dummy"
             entityId="providerId"
             id="notes-accordion"
@@ -384,7 +385,6 @@ describe('Notes smart accordion', () => {
             hideAssignButton
             hideEditButton
             hideNewButton
-            noRowClick
           />
         </div>
       );
@@ -393,7 +393,7 @@ describe('Notes smart accordion', () => {
     it('should not display edit note button', () => notesAccordion.has({ editButton: false }));
   });
 
-  describe('when noRowClick prop is true', () => {
+  describe('when canClickRow prop is false', () => {
     setupApplication({
       scenarios: ['create-notes-with-note-types'],
     });
@@ -404,6 +404,7 @@ describe('Notes smart accordion', () => {
       await mount(
         <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
           <NotesSmartAccordion
+            canClickRow={false}
             id="notes-accordion"
             open
             onToggle={() => {}}
@@ -413,7 +414,6 @@ describe('Notes smart accordion', () => {
             entityId="providerId"
             pathToNoteCreate={`${domainName}/notes/new`}
             pathToNoteDetails={`${domainName}/notes`}
-            noRowClick
           />
         </div>
       );

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -26,10 +26,12 @@ export default class NotesAccordion extends Component {
   static propTypes = {
     headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
+    hideEditButton: PropTypes.bool,
     hideNewButton: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    interactive: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    onAssignedNoteClick: PropTypes.func.isRequired,
+    onAssignedNoteClick: PropTypes.func,
     onAssignedNoteEditClick: PropTypes.func.isRequired,
     onHeaderClick: PropTypes.func.isRequired,
     onNoteCreateButtonClick: PropTypes.func.isRequired,
@@ -42,7 +44,9 @@ export default class NotesAccordion extends Component {
   };
 
   static defaultProps = {
+    interactive: true,
     hideAssignButton: false,
+    hideEditButton: false,
     hideNewButton: false,
   };
 
@@ -144,6 +148,7 @@ export default class NotesAccordion extends Component {
   render() {
     const {
       id,
+      interactive,
       open,
       assignedNotes,
       noteTypes,
@@ -154,6 +159,7 @@ export default class NotesAccordion extends Component {
       sortedColumn,
       sortDirection,
       headerProps,
+      hideEditButton,
     } = this.props;
 
     const {
@@ -172,6 +178,8 @@ export default class NotesAccordion extends Component {
           headerProps={headerProps}
         >
           <NotesList
+            hideEditButton={hideEditButton}
+            interactive={interactive}
             notes={assignedNotes}
             noteTypes={noteTypes}
             onNoteClick={onAssignedNoteClick}

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.css
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.css
@@ -15,3 +15,7 @@
   justify-content: flex-start;
   align-items: flex-start;
 }
+
+div.qlEditor {
+  padding: 0;
+}

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -34,6 +34,8 @@ const noteShape = PropTypes.shape({
 
 class NotesList extends React.Component {
   static propTypes = {
+    hideEditButton: PropTypes.bool,
+    interactive: PropTypes.bool,
     intl: PropTypes.shape({
       formatMessage: PropTypes.func.isRequired,
     }).isRequired,
@@ -42,13 +44,15 @@ class NotesList extends React.Component {
       loading: PropTypes.bool,
     }),
     onHeaderClick: PropTypes.func.isRequired,
-    onNoteClick: PropTypes.func.isRequired,
+    onNoteClick: PropTypes.func,
     onNoteEditClick: PropTypes.func.isRequired,
     sortDirection: PropTypes.oneOf(['ascending', 'descending']),
     sortedColumn: PropTypes.oneOf(Object.values(notesColumnNames)),
   }
 
   static defaultProps = {
+    hideEditButton: false,
+    interactive: true,
     notes: {
       items: [],
       loading: false,
@@ -108,6 +112,7 @@ class NotesList extends React.Component {
   }
 
   getItems() {
+    const { hideEditButton } = this.props;
     const { isDetailsExpanded } = this.state;
 
     return this.props.notes.items
@@ -157,7 +162,7 @@ class NotesList extends React.Component {
               {detailsContent}
               <div>
                 {getStringLength(content) > DETAILS_CUTOFF_LENGTH && this.renderShowMoreButton(id)}
-                {this.renderEditButton(note)}
+                {!hideEditButton && this.renderEditButton(note)}
               </div>
             </div>
           ),
@@ -182,6 +187,7 @@ class NotesList extends React.Component {
       sortedColumn,
       sortDirection,
       intl: { formatMessage },
+      interactive,
     } = this.props;
 
     const columnMapping = {
@@ -196,10 +202,10 @@ class NotesList extends React.Component {
       <FormattedMessage id="stripes-smart-components.notes">
         {
           ([ariaLabel]) => (
-            <div className="ql-editor">
+            <div className={`ql-editor ${css.qlEditor}`}>
               <MultiColumnList
                 id="notes-list"
-                interactive
+                interactive={interactive}
                 ariaLabel={ariaLabel}
                 contentData={this.getItems()}
                 visibleColumns={Object.values(notesColumnNames)}
@@ -210,6 +216,7 @@ class NotesList extends React.Component {
                 onRowClick={onNoteClick}
                 getCellClass={this.getCellClass}
                 onHeaderClick={onHeaderClick}
+                showSortIndicator
                 sortedColumn={sortedColumn}
                 sortDirection={sortDirection}
               />

--- a/lib/Notes/tests/interactors.js
+++ b/lib/Notes/tests/interactors.js
@@ -108,6 +108,7 @@ export const NoteSmartAccordionInteractor = Accordion.extend('notes accordion')
     noteCount: MultiColumnList().rowCount(),
     newButton: Button('New').exists(),
     assignButton: Button(including('Assign')).exists(),
+    editButton: Button(including('Edit')).exists(),
   })
   .actions({
     clickNew: ({ find }) => find(Button('New')).click(),


### PR DESCRIPTION
## Purpose
1. Be able to display notes without an edit button.
2. Be able to not redirect to note details after hitting a list item.
3. Remove a "pointer" cursor from the list items, since they will not be a link to redirect to note details.
4. Remove the padding of the ql-editor container.
5. Add a sort icon for the list headers.

## Approach
1. Add `hideEditButton` property.
2. Add `noRowClick` property.
3. Add `interactive` property to make it configurable.
4. Increase the specificity in styles to overwrite the built-in ql-editor styles.
5. Set the `showSortIndicator` property.

## Issues
[STSMACOM-904](https://folio-org.atlassian.net/browse/STSMACOM-904)

## Screenshots
![image](https://github.com/user-attachments/assets/d424af55-69a1-4995-bcd3-f182520213c0)
