### PR TITLE
STSMACOM-904: Add hideEditButton, interactive and canClickRow props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. (#1579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-smart-components
 
+## IN PROGRESS
+
+* Add `hideEditButton`, `interactive` and `canClickRow` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
+
 ## [9.2.6](https://github.com/folio-org/stripes-smart-components/tree/v9.2.6) (2024-12-10)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.5...v9.2.6)
 

--- a/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
+++ b/lib/Notes/NotesSmartAccordion/NotesSmartAccordion.js
@@ -47,19 +47,22 @@ class NotesSmartAccordion extends Component {
   static propTypes = {
     domainName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
     entityId: PropTypes.string.isRequired,
-    entityName: PropTypes.string.isRequired,
+    entityName: PropTypes.string,
     entityType: PropTypes.string.isRequired,
     headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
+    hideEditButton: PropTypes.bool,
     hideNewButton: PropTypes.bool,
     history: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    interactive: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     mutator: PropTypes.object.isRequired,
+    canClickRow: PropTypes.bool,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    pathToNoteCreate: PropTypes.string.isRequired,
-    pathToNoteDetails: PropTypes.string.isRequired,
+    pathToNoteCreate: PropTypes.string,
+    pathToNoteDetails: PropTypes.string,
     referredRecordData: PropTypes.object,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
@@ -67,9 +70,12 @@ class NotesSmartAccordion extends Component {
   }
 
   static defaultProps = {
+    interactive: true,
     hideAssignButton: false,
+    hideEditButton: false,
     hideNewButton: false,
     label: <FormattedMessage id="stripes-smart-components.notes" />,
+    canClickRow: true,
     referredRecordData: {},
   };
 
@@ -363,10 +369,13 @@ class NotesSmartAccordion extends Component {
       entityType,
       entityId,
       mutator,
+      canClickRow,
       onToggle,
       open,
       id,
+      interactive,
       hideAssignButton,
+      hideEditButton,
       hideNewButton,
       label,
       headerProps,
@@ -381,7 +390,7 @@ class NotesSmartAccordion extends Component {
           domainNotes={this.getDomainNotes()}
           noteTypes={this.getNoteTypeNames()}
           onNoteCreateButtonClick={this.onNoteCreateButtonClick}
-          onAssignedNoteClick={this.onAssignedNoteClick}
+          onAssignedNoteClick={canClickRow ? this.onAssignedNoteClick : null}
           onAssignedNoteEditClick={this.onAssignedNoteEditClick}
           entityName={entityName}
           entityType={entityType}
@@ -392,8 +401,10 @@ class NotesSmartAccordion extends Component {
           onSortDomainNotes={this.onSortDomainNotes}
           fetchDomainNotes={this.fetchDomainNotes}
           id={id}
+          interactive={interactive}
           open={open}
           hideAssignButton={hideAssignButton}
+          hideEditButton={hideEditButton}
           hideNewButton={hideNewButton}
           onToggle={onToggle}
           label={label}

--- a/lib/Notes/NotesSmartAccordion/readme.md
+++ b/lib/Notes/NotesSmartAccordion/readme.md
@@ -33,5 +33,8 @@ domainName | string | App name.
 entityName | string | The title of the record name(e.g. A Biographical Dictionary of Later Han).
 entityType | string | Record name(e.g. package).
 entityId | string | Record id.
+hideEditButton | bool   | Hides the edit button. Default is false.
+interactive | bool   | Applies a "pointer" cursor when the mouse hovers over a row. Default is true.
+canClickRow | bool   | If true, the row is clickable. Default is true.
 pathToNoteCreate | string | Path to Note create page.
 pathToNoteDetails | string | Path to Note details page. NotesSmartAccordion will add / with note id during redirecting to details page. 

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -409,4 +409,68 @@ describe('Notes smart accordion', () => {
       expect(notesAccordion.newButtonDisplayed).to.be.false;
     });
   });
+
+  describe('when hideEditButton prop is true', () => {
+    setupApplication({
+      scenarios: ['create-notes-with-note-types'],
+    });
+
+    beforeEach(async () => {
+      await mount(
+        <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
+          <NotesSmartAccordion
+            canClickRow={false}
+            domainName="dummy"
+            entityId="providerId"
+            id="notes-accordion"
+            open
+            interactive={false}
+            entityType="provider"
+            hideAssignButton
+            hideEditButton
+            hideNewButton
+          />
+        </div>
+      );
+    });
+
+    it('should not display edit note button', () => notesAccordion.has({ editButton: false }));
+  });
+
+  describe('when canClickRow prop is false', () => {
+    setupApplication({
+      scenarios: ['create-notes-with-note-types'],
+    });
+
+    beforeEach(async () => {
+      const domainName = 'dummy';
+
+      await mount(
+        <div style={{ maxWidth: '500px', marginLeft: '20px' }}>
+          <NotesSmartAccordion
+            canClickRow={false}
+            id="notes-accordion"
+            open
+            onToggle={() => {}}
+            domainName={domainName}
+            entityName="Cool Provider"
+            entityType="provider"
+            entityId="providerId"
+            pathToNoteCreate={`${domainName}/notes/new`}
+            pathToNoteDetails={`${domainName}/notes`}
+          />
+        </div>
+      );
+    });
+
+    describe('when a note in the notes list was clicked', () => {
+      beforeEach(async () => {
+        await notesAccordion.clickNote(0);
+      });
+
+      it('should not redirect to note view page', function () {
+        expect(this.location.pathname + this.location.search).to.equal('/dummy');
+      });
+    });
+  });
 });

--- a/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
+++ b/lib/Notes/NotesSmartAccordion/tests/notes-smart-accordion-test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it } from '@bigtest/mocha';
+import { Interactor } from '@bigtest/interactor';
 import React from 'react';
 import { expect } from 'chai';
 
@@ -9,6 +10,7 @@ import { NotesAccordion, NotesModal } from './interactors';
 
 const notesAccordion = new NotesAccordion();
 const notesModal = new NotesModal();
+const editButton = new Interactor('[data-test-note-edit-button]');
 
 describe('Notes smart accordion', () => {
   describe('when hideNewButton prop is false', () => {
@@ -434,7 +436,9 @@ describe('Notes smart accordion', () => {
       );
     });
 
-    it('should not display edit note button', () => notesAccordion.has({ editButton: false }));
+    it('should not display edit note button', () => {
+      expect(editButton.isPresent).to.be.false;
+    });
   });
 
   describe('when canClickRow prop is false', () => {
@@ -465,7 +469,7 @@ describe('Notes smart accordion', () => {
 
     describe('when a note in the notes list was clicked', () => {
       beforeEach(async () => {
-        await notesAccordion.clickNote(0);
+        await notesAccordion.notes(0).click();
       });
 
       it('should not redirect to note view page', function () {

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -26,10 +26,12 @@ export default class NotesAccordion extends Component {
   static propTypes = {
     headerProps: PropTypes.object,
     hideAssignButton: PropTypes.bool,
+    hideEditButton: PropTypes.bool,
     hideNewButton: PropTypes.bool,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    interactive: PropTypes.bool,
     label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    onAssignedNoteClick: PropTypes.func.isRequired,
+    onAssignedNoteClick: PropTypes.func,
     onAssignedNoteEditClick: PropTypes.func.isRequired,
     onHeaderClick: PropTypes.func.isRequired,
     onNoteCreateButtonClick: PropTypes.func.isRequired,
@@ -42,7 +44,9 @@ export default class NotesAccordion extends Component {
   };
 
   static defaultProps = {
+    interactive: true,
     hideAssignButton: false,
+    hideEditButton: false,
     hideNewButton: false,
   };
 
@@ -144,6 +148,7 @@ export default class NotesAccordion extends Component {
   render() {
     const {
       id,
+      interactive,
       open,
       assignedNotes,
       noteTypes,
@@ -154,6 +159,7 @@ export default class NotesAccordion extends Component {
       sortedColumn,
       sortDirection,
       headerProps,
+      hideEditButton,
     } = this.props;
 
     const {
@@ -172,6 +178,8 @@ export default class NotesAccordion extends Component {
           headerProps={headerProps}
         >
           <NotesList
+            hideEditButton={hideEditButton}
+            interactive={interactive}
             notes={assignedNotes}
             noteTypes={noteTypes}
             onNoteClick={onAssignedNoteClick}

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.css
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.css
@@ -15,3 +15,7 @@
   justify-content: flex-start;
   align-items: flex-start;
 }
+
+div.qlEditor {
+  padding: 0;
+}

--- a/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
+++ b/lib/Notes/components/NotesAccordion/components/NotesList/NotesList.js
@@ -34,6 +34,8 @@ const noteShape = PropTypes.shape({
 
 class NotesList extends React.Component {
   static propTypes = {
+    hideEditButton: PropTypes.bool,
+    interactive: PropTypes.bool,
     intl: PropTypes.shape({
       formatMessage: PropTypes.func.isRequired,
     }).isRequired,
@@ -42,13 +44,15 @@ class NotesList extends React.Component {
       loading: PropTypes.bool,
     }),
     onHeaderClick: PropTypes.func.isRequired,
-    onNoteClick: PropTypes.func.isRequired,
+    onNoteClick: PropTypes.func,
     onNoteEditClick: PropTypes.func.isRequired,
     sortDirection: PropTypes.oneOf(['ascending', 'descending']),
     sortedColumn: PropTypes.oneOf(Object.values(notesColumnNames)),
   }
 
   static defaultProps = {
+    hideEditButton: false,
+    interactive: true,
     notes: {
       items: [],
       loading: false,
@@ -108,6 +112,7 @@ class NotesList extends React.Component {
   }
 
   getItems() {
+    const { hideEditButton } = this.props;
     const { isDetailsExpanded } = this.state;
 
     return this.props.notes.items
@@ -157,7 +162,7 @@ class NotesList extends React.Component {
               {detailsContent}
               <div>
                 {getStringLength(content) > DETAILS_CUTOFF_LENGTH && this.renderShowMoreButton(id)}
-                {this.renderEditButton(note)}
+                {!hideEditButton && this.renderEditButton(note)}
               </div>
             </div>
           ),
@@ -182,6 +187,7 @@ class NotesList extends React.Component {
       sortedColumn,
       sortDirection,
       intl: { formatMessage },
+      interactive,
     } = this.props;
 
     const columnMapping = {
@@ -196,10 +202,10 @@ class NotesList extends React.Component {
       <FormattedMessage id="stripes-smart-components.notes">
         {
           ([ariaLabel]) => (
-            <div className="ql-editor">
+            <div className={`ql-editor ${css.qlEditor}`}>
               <MultiColumnList
                 id="notes-list"
-                interactive
+                interactive={interactive}
                 ariaLabel={ariaLabel}
                 contentData={this.getItems()}
                 visibleColumns={Object.values(notesColumnNames)}
@@ -210,6 +216,7 @@ class NotesList extends React.Component {
                 onRowClick={onNoteClick}
                 getCellClass={this.getCellClass}
                 onHeaderClick={onHeaderClick}
+                showSortIndicator
                 sortedColumn={sortedColumn}
                 sortDirection={sortDirection}
               />


### PR DESCRIPTION
1. Be able to display notes without an edit button.
2. Be able to not redirect to note details after hitting a list item.
3. Remove a "pointer" cursor from the list items, since they will not be
  a link to redirect to note details.
4. Remove the padding of the ql-editor container.
5. Add a sort icon for the list headers.

1. Add `hideEditButton` property.
2. Add `canClickRow` property.
3. Add `interactive` property to make it configurable.
4. Increase the specificity in styles to overwrite the built-in
  ql-editor styles.
5. Set the `showSortIndicator` property.

[STSMACOM-904](https://folio-org.atlassian.net/browse/STSMACOM-904)

![image](https://github.com/user-attachments/assets/d424af55-69a1-4995-bcd3-f182520213c0)

(cherry picked from commit https://github.com/folio-org/stripes-smart-components/commit/38e71feb7f1194ac3f6f8e643c7fb7e16755f4c2)