### PR TITLE
STSMACOM-906: Update button label for creating new notes in `NotesAccordion`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `ConfigManager` - Add `userId` property to retrieve the user's own settings from mod-settings. Refs STSMACOM-902.
 * Pass props for rendering aside content for `<EditCustomFieldsRecord>`'s accordion. Refs STSMACOM-903.
 * Add `hideEditButton`, `interactive` and `canClickRow` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
+* Update button label for creating new notes in NotesAccordion. Refs STSMACOM-906.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/Notes/components/NotesAccordion/NotesAccordion.js
+++ b/lib/Notes/components/NotesAccordion/NotesAccordion.js
@@ -97,7 +97,7 @@ export default class NotesAccordion extends Component {
                 onClick={this.props.onNoteCreateButtonClick}
                 data-test-notes-accordion-new-button
               >
-                <FormattedMessage id="stripes-smart-components.new" />
+                <FormattedMessage id="stripes-smart-components.notes.newNote" />
               </Button>
             </IfPermission>
           )

--- a/lib/Notes/tests/interactors.js
+++ b/lib/Notes/tests/interactors.js
@@ -106,12 +106,12 @@ export const NoteCreateFormInteractor = HTML.extend('Note create form')
 export const NoteSmartAccordionInteractor = Accordion.extend('notes accordion')
   .filters({
     noteCount: MultiColumnList().rowCount(),
-    newButton: Button('New').exists(),
+    newButton: Button('New note').exists(),
     assignButton: Button(including('Assign')).exists(),
     editButton: Button(including('Edit')).exists(),
   })
   .actions({
-    clickNew: ({ find }) => find(Button('New')).click(),
+    clickNew: ({ find }) => find(Button('New note')).click(),
     clickNote: ({ find }, index) => find(MultiColumnListRow({ index })).click(),
     clickAssign: ({ find }) => find(Button(including('Assign'))).click(),
   });


### PR DESCRIPTION
## Purpose
Rename the "New" button to "New note" when creating a note.

## Issues
[STSMACOM-906](https://folio-org.atlassian.net/browse/STSMACOM-906)

## Screenshots
![image](https://github.com/user-attachments/assets/d3ddff3f-28c6-4002-97da-0695f2c9e3ba)
