### PR TITLE
STSMACOM-790: Add `configNamePrefix` prop to custom fields components to be able to store section titles separately for different `entityType`s.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Pass props for rendering aside content for `<EditCustomFieldsRecord>`'s accordion. Refs STSMACOM-903.
 * Add `hideEditButton`, `interactive` and `canClickRow` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
 * Update button label for creating new notes in NotesAccordion. Refs STSMACOM-906.
+* Add `configNamePrefix` prop to custom fields components to be able to store section titles separately for different entityTypes. Fixes STSMACOM-790.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -56,6 +56,7 @@ const propTypes = {
   changeFinalFormField: PropTypes.func,
   changeReduxFormField: PropTypes.func,
   columnCount: PropTypes.number,
+  configNamePrefix: PropTypes.string,
   customFieldsLabel: PropTypes.node,
   displayWhenClosed: PropTypes.node,
   displayWhenOpen: PropTypes.node,
@@ -104,6 +105,7 @@ const EditCustomFieldsRecord = ({
   fieldComponent: Field,
   reduxFormCustomFieldsValues,
   finalFormCustomFieldsValues,
+  configNamePrefix,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -117,7 +119,7 @@ const EditCustomFieldsRecord = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -25,6 +25,7 @@ import {
   useLoadingErrorCallout,
   useSectionTitleFetch,
   useOptionsStatsFetch,
+  getConfigName,
 } from '../../utils';
 import { permissionsShape } from '../../shapes';
 import { fieldTypesWithOptions } from '../../constants';
@@ -33,6 +34,7 @@ import { fieldTypesWithOptions } from '../../constants';
 const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
+  configNamePrefix: PropTypes.string,
   entityType: PropTypes.string.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
   intl: PropTypes.object,
@@ -53,6 +55,7 @@ const EditCustomFieldsSettings = ({
   intl,
   permissions,
   history,
+  configNamePrefix,
 }) => {
   const makeOkapiRequest = useCallback((url) => makeRequest(okapi)(backendModuleId)(url), [okapi, backendModuleId]);
   const makeTitleRequest = useCallback((url) => makeRequest(okapi)()(url), [okapi]);
@@ -68,7 +71,7 @@ const EditCustomFieldsSettings = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
 
   const {
     optionsStats,
@@ -169,9 +172,11 @@ const EditCustomFieldsSettings = ({
   };
 
   const updateTitle = data => {
+    const configName = getConfigName(configNamePrefix);
+
     const body = JSON.stringify({
       module: backendModuleName.toUpperCase(),
-      configName: 'custom_fields_label',
+      configName,
       value: data,
     });
 

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -35,6 +35,7 @@ describe('EditCustomFieldsSettings', () => {
   const saveButton = form.find(Button(including('Save')));
   const cancelButton = form.find(Button(including('Cancel')));
   const updateCustomFieldsHandler = sinon.spy();
+  const updateConfigurationHandler = sinon.spy();
 
   const renderComponent = (props = {}) => {
     return mount(
@@ -47,6 +48,7 @@ describe('EditCustomFieldsSettings', () => {
           canDelete: true,
         }}
         viewRoute="/custom-fields-view"
+        configNamePrefix="prefix"
         {...props}
       />
     );
@@ -55,7 +57,7 @@ describe('EditCustomFieldsSettings', () => {
   beforeEach(async function () {
     this.server.put('/custom-fields', updateCustomFieldsHandler);
 
-    this.server.put('/configurations/entries/tested-custom-field-label', () => ({}));
+    this.server.put('/configurations/entries/tested-custom-field-label', updateConfigurationHandler);
 
     await renderComponent();
 
@@ -239,6 +241,14 @@ describe('EditCustomFieldsSettings', () => {
           }
 
           if (body.entityType !== 'user') throw new Error(`expected body entityType to be user, got ${body.entityType}`);
+        });
+      });
+
+      it('should use correct configName format with configNamePrefix', () => {
+        return converge(() => {
+          const body = JSON.parse(updateConfigurationHandler.args[0][1].requestBody);
+
+          if (body.configName !== 'prefix_custom_fields_label') throw new Error(`expected body configName to be prefix_custom_fields_label, got ${body.configName}`);
         });
       });
     });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -47,6 +47,7 @@ const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
   columnCount: PropTypes.number,
+  configNamePrefix: PropTypes.string,
   customFieldsLabel: PropTypes.node,
   customFieldsValues: PropTypes.object.isRequired,
   entityType: PropTypes.string.isRequired,
@@ -71,6 +72,7 @@ const ViewCustomFieldsRecord = ({
   columnCount = 4,
   customFieldsLabel = <FormattedMessage id="stripes-smart-components.customFields" />,
   noCustomFieldsFoundLabel = <FormattedMessage id="stripes-smart-components.customFields.noCustomFieldsFound" />,
+  configNamePrefix,
 }) => {
   const {
     customFields,
@@ -82,7 +84,7 @@ const ViewCustomFieldsRecord = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
 
   const { formatDate } = useIntl();
 

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -37,6 +37,7 @@ import styles from './ViewCustomFieldsSettings.css';
 const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
+  configNamePrefix: PropTypes.string,
   editRoute: PropTypes.string.isRequired,
   entityType: PropTypes.string.isRequired,
   okapi: PropTypes.shape({
@@ -53,6 +54,7 @@ const ViewCustomFieldsSettings = ({
   entityType,
   backendModuleName,
   permissions,
+  configNamePrefix,
 }) => {
   const {
     customFields,
@@ -63,7 +65,7 @@ const ViewCustomFieldsSettings = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase());
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const paneTitleRef = useRef(null);

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -78,6 +78,7 @@ export default EditCustomFields;
 Name | type | description | required
 --- | --- | --- | ---
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
+`configNamePrefix` | string | used to extend `configName` to use different storage for the section title when making requests to `mod-configuration` | false
 `entityType` | string | used to filter custom files by particular entity type |true
 `redirectToView` | func | function that redirect to route which renders `<ViewCustomFieldsSettings />` |true
 
@@ -110,6 +111,7 @@ Name | type | description | required | default
 `accordionId` | string | used to set accordion id | true |
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true |
 `columnCount` | number | grid display in the same menner as other accordions in current page | false | 4
+`configNamePrefix` | string | used to extend `configName` to use different storage for the section title when making requests to `mod-configuration` | false
 `customFieldsLabel` | node | default accordion label | false | `<FormattedMessage id="stripes-smart-components.customFields" />`
 `customFieldsValues` | object | values for the custom fields | true |
 `entityType` | string | used to filter custom files by particular entity type | true |
@@ -180,6 +182,7 @@ Name | type | description | required | default
 `accordionId` | string | used to set accordion id | true |
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
 `columnCount` | number | grid display in the same manner as other accordions in current page | false | 4
+`configNamePrefix` | string | used to extend `configName` to use different storage for the section title when making requests to `mod-configuration` | false
 `customFieldsLabel` | node | default accordion label | false | `<FormattedMessage id="stripes-smart-components.customFields" />`
 `entityType` | string | used to filter custom files by particular entity type |true
 `expanded` | boolean | indicates if the accordion is open | true |

--- a/lib/CustomFields/utils/getConfigName.js
+++ b/lib/CustomFields/utils/getConfigName.js
@@ -1,0 +1,5 @@
+const getConfigName = (configNamePrefix) => {
+  return [configNamePrefix, 'custom_fields_label'].filter(Boolean).join('_');
+};
+
+export default getConfigName;

--- a/lib/CustomFields/utils/index.js
+++ b/lib/CustomFields/utils/index.js
@@ -5,3 +5,4 @@ export { default as useSectionTitleFetch } from './useSectionTitleFetch';
 export { default as validateCustomFields } from './validateCustomFields';
 export { default as useOptionsStatsFetch } from './useOptionsStatsFetch';
 export { default as useCustomFields } from './useCustomFields';
+export { default as getConfigName } from './getConfigName';

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 
 import makeRequest from './makeRequest';
+import getConfigName from './getConfigName';
 
-const useSectionTitleFetch = (okapi, moduleName) => {
+const useSectionTitleFetch = (okapi, moduleName, configNamePrefix) => {
   const [sectionTitleLoaded, setSectionTitleLoaded] = useState(false);
   const [sectionTitle, setSectionTitle] = useState({});
   const [sectionTitleFetchFailed, setSectionTitleFetchFailed] = useState(false);
@@ -14,7 +15,9 @@ const useSectionTitleFetch = (okapi, moduleName) => {
 
   useEffect(() => {
     let isMounted = true;
-    const url = `configurations/entries?query=(module==${moduleName} and configName==custom_fields_label)`;
+    const configName = getConfigName(configNamePrefix);
+    const url = `configurations/entries?query=(module==${moduleName} and configName==${configName})`;
+
     const fetchCustomFields = async () => {
       const response = await makeOkapiRequest(url)({
         method: 'GET',


### PR DESCRIPTION
## Description
When multiple instances of the `EditCustomFieldsSettings`/ `EditCustomFieldsRecord`/ `ViewCustomFieldsRecord`/ `ViewCustomFieldsSettings` UI component, each associated with a distinct `entityType`, are used within a single application, then modifying the accordion label in one component results in an unintended change to the label in all other components. This behavior contradicts the expected functionality, causing inconsistency in the labeling of accordion sections based on entityTypes.

The issue arises due to the request sent to the configurations API to store the accordion label, which utilizes a single `configName` for all entityTypes.

Using a single `configName` for multiple entityTypes, leads to a universal change in the accordion label across all instances of the `EditCustomFieldsSettings` components, regardless of their associated entityTypes.

## Approach
Use an optional `configNamePrefix` property to extend `configName`.

## Issues
[STSMACOM-790](https://folio-org.atlassian.net/browse/STSMACOM-790)

## Screencasts


https://github.com/user-attachments/assets/fa6adc9f-cb8d-4b70-83b1-ac87f53aee48

