### PR TITLE
STSMACOM-910: Migrate custom fields from mod-configuration to mod-settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `hideEditButton`, `interactive` and `canClickRow` props to `NotesSmartAccordion` components, add a sort icon for the list headers, and remove the padding of the ql-editor container. Refs STSMACOM-904.
 * Update button label for creating new notes in NotesAccordion. Refs STSMACOM-906.
 * Add `configNamePrefix` prop to custom fields components to be able to store section titles separately for different entityTypes. Fixes STSMACOM-790.
+* Migrate custom fields from mod-configuration to mod-settings. Fixes STSMACOM-910.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -83,6 +83,7 @@ const propTypes = {
   onComponentLoad: PropTypes.func,
   onToggle: PropTypes.func,
   reduxFormCustomFieldsValues: PropTypes.objectOf(PropTypes.string),
+  scope: PropTypes.string,
 };
 
 const EditCustomFieldsRecord = ({
@@ -106,6 +107,7 @@ const EditCustomFieldsRecord = ({
   reduxFormCustomFieldsValues,
   finalFormCustomFieldsValues,
   configNamePrefix,
+  scope,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -119,7 +121,7 @@ const EditCustomFieldsRecord = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix, scope);
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -118,7 +118,7 @@ describe('EditCustomFieldsRecord', () => {
   });
 
   describe('when there is a `scope` prop', () => {
-    beforeEach(async function ()  {
+    beforeEach(async () => {
       await renderComponent({
         scope: 'test-scope',
       });

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -7,10 +7,12 @@ import { Form, Field } from 'react-final-form';
 import {
   runAxeTest,
   converge,
+  HTML,
 } from '@folio/stripes-testing';
 
 import {
   setupApplication,
+  mount,
 } from '../../../../../tests/helpers';
 
 import EditCustomFieldsRecord from '../EditCustomFieldsRecord';
@@ -19,6 +21,8 @@ import {
 } from '../../../tests/interactors';
 
 describe('EditCustomFieldsRecord', () => {
+  setupApplication();
+
   const changeFinalFormField = sinon.spy();
   const changeReduxFormField = sinon.spy();
   const onComponentLoad = sinon.spy();
@@ -46,22 +50,20 @@ describe('EditCustomFieldsRecord', () => {
       </Form>
     );
 
-    setupApplication({
-      component: <FormComponent />
-    });
+    return mount(
+      <FormComponent />
+    );
   };
-
-  renderComponent();
 
   beforeEach(async () => {
     changeFinalFormField.resetHistory();
     changeReduxFormField.resetHistory();
     onToggle.resetHistory();
+
+    await renderComponent();
   });
 
   describe('when there are no custom fields', () => {
-    renderComponent();
-
     beforeEach(async function () {
       this.server.get('/custom-fields', {
         'customFields': [],
@@ -74,10 +76,6 @@ describe('EditCustomFieldsRecord', () => {
   });
 
   describe('when custom fields are loaded', () => {
-    beforeEach(async () => {
-      await renderComponent();
-    });
-
     it('should not have any a11y issues', () => runAxeTest());
 
     it('should label and set id of accordion', () => CustomFieldsRecordForm('Custom Fields Test').has({ id: 'test-accordion-id' }));
@@ -116,6 +114,18 @@ describe('EditCustomFieldsRecord', () => {
       });
 
       it('should show default accordion label', () => CustomFieldsRecordForm('Custom fields').exists());
+    });
+  });
+
+  describe('when there is a `scope` prop', () => {
+    beforeEach(async function ()  {
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should retrieve the accordion label from the /settings/entries API', () => {
+      return HTML('Custom Fields label').exists();
     });
   });
 });

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -7,6 +7,7 @@ import {
 } from 'react-intl';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { cloneDeep } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   Icon,
@@ -44,6 +45,7 @@ const propTypes = {
   }).isRequired,
   permissions: permissionsShape.isRequired,
   viewRoute: PropTypes.string.isRequired,
+  scope: PropTypes.string,
 };
 
 const EditCustomFieldsSettings = ({
@@ -56,6 +58,7 @@ const EditCustomFieldsSettings = ({
   permissions,
   history,
   configNamePrefix,
+  scope,
 }) => {
   const makeOkapiRequest = useCallback((url) => makeRequest(okapi)(backendModuleId)(url), [okapi, backendModuleId]);
   const makeTitleRequest = useCallback((url) => makeRequest(okapi)()(url), [okapi]);
@@ -71,7 +74,7 @@ const EditCustomFieldsSettings = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix, scope);
 
   const {
     optionsStats,
@@ -173,21 +176,33 @@ const EditCustomFieldsSettings = ({
 
   const updateTitle = data => {
     const configName = getConfigName(configNamePrefix);
+    const path = scope
+      ? `settings/entries`
+      : `configurations/entries`;
 
-    const body = JSON.stringify({
-      module: backendModuleName.toUpperCase(),
-      configName,
-      value: data,
-    });
+    const payload = scope
+      ? {
+        id: sectionTitle.id || uuidv4(),
+        scope,
+        key: configName,
+        value: data,
+      }
+      : {
+        module: backendModuleName.toUpperCase(),
+        configName,
+        value: data,
+      };
+
+    const body = JSON.stringify(payload);
 
     if (sectionTitle.id) {
-      return makeTitleRequest(`configurations/entries/${sectionTitle.id}`)({
+      return makeTitleRequest(`${path}/${sectionTitle.id}`)({
         method: 'PUT',
         body,
       });
     }
 
-    return makeTitleRequest('configurations/entries')({
+    return makeTitleRequest(path)({
       method: 'POST',
       body,
     });

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -177,8 +177,8 @@ const EditCustomFieldsSettings = ({
   const updateTitle = data => {
     const configName = getConfigName(configNamePrefix);
     const path = scope
-      ? `settings/entries`
-      : `configurations/entries`;
+      ? 'settings/entries'
+      : 'configurations/entries';
 
     const payload = scope
       ? {

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -256,7 +256,7 @@ describe('EditCustomFieldsSettings', () => {
   });
 
   describe('when there is a `scope` prop', () => {
-    beforeEach(async function ()  {
+    beforeEach(async function () {
       this.server.put('/settings/entries/tested-custom-field-label', updateSettingsHandler);
 
       await renderComponent({

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -36,6 +36,7 @@ describe('EditCustomFieldsSettings', () => {
   const cancelButton = form.find(Button(including('Cancel')));
   const updateCustomFieldsHandler = sinon.spy();
   const updateConfigurationHandler = sinon.spy();
+  const updateSettingsHandler = sinon.spy();
 
   const renderComponent = (props = {}) => {
     return mount(
@@ -250,6 +251,39 @@ describe('EditCustomFieldsSettings', () => {
 
           if (body.configName !== 'prefix_custom_fields_label') throw new Error(`expected body configName to be prefix_custom_fields_label, got ${body.configName}`);
         });
+      });
+    });
+  });
+
+  describe('when there is a `scope` prop', () => {
+    beforeEach(async function ()  {
+      this.server.put('/settings/entries/tested-custom-field-label', updateSettingsHandler);
+
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should show correct section title', () => sectionTitle.has({ value: 'Custom Fields label' }));
+
+    it('should use the correct body for PUT /settings/entries ', async () => {
+      await form.addField('Multi-select');
+      await TextField('Field label*').fillIn('Test field');
+      await CFSettingsRowInteractor({ index: 0 }).fillLabel('beta');
+      await CFSettingsRowInteractor({ index: 1 }).fillLabel('alpha');
+      await saveButton.click();
+
+      const expectedBody = {
+        id: 'tested-custom-field-label',
+        key: 'prefix_custom_fields_label',
+        scope: 'test-scope',
+        value: 'Custom Fields label',
+      };
+
+      return converge(() => {
+        const body = JSON.parse(updateSettingsHandler.args[0][1].requestBody);
+
+        if (!isEqual(body, expectedBody)) throw new Error('the expected body is in the incorrect format');
       });
     });
   });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -58,6 +58,7 @@ const propTypes = {
     url: PropTypes.string.isRequired,
   }).isRequired,
   onToggle: PropTypes.func,
+  scope: PropTypes.string,
 };
 
 const ViewCustomFieldsRecord = ({
@@ -73,6 +74,7 @@ const ViewCustomFieldsRecord = ({
   customFieldsLabel = <FormattedMessage id="stripes-smart-components.customFields" />,
   noCustomFieldsFoundLabel = <FormattedMessage id="stripes-smart-components.customFields.noCustomFieldsFound" />,
   configNamePrefix,
+  scope,
 }) => {
   const {
     customFields,
@@ -84,7 +86,7 @@ const ViewCustomFieldsRecord = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix, scope);
 
   const { formatDate } = useIntl();
 

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
+  HTML,
   runAxeTest,
 } from '@folio/stripes-testing';
 
@@ -73,6 +74,18 @@ describe('ViewCustomFieldsRecord', () => {
 
     it('should call onToggle', () => {
       expect(onToggle.calledOnce).to.be.true;
+    });
+  });
+
+  describe('when there is a `scope` prop', () => {
+    beforeEach(async function ()  {
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should retrieve the accordion label from the /settings/entries API', () => {
+      return HTML('Custom Fields label').exists();
     });
   });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -78,7 +78,7 @@ describe('ViewCustomFieldsRecord', () => {
   });
 
   describe('when there is a `scope` prop', () => {
-    beforeEach(async function ()  {
+    beforeEach(async () => {
       await renderComponent({
         scope: 'test-scope',
       });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -45,6 +45,7 @@ const propTypes = {
     url: PropTypes.string.isRequired,
   }).isRequired,
   permissions: permissionsShape.isRequired,
+  scope: PropTypes.string,
 };
 
 const ViewCustomFieldsSettings = ({
@@ -55,6 +56,7 @@ const ViewCustomFieldsSettings = ({
   backendModuleName,
   permissions,
   configNamePrefix,
+  scope,
 }) => {
   const {
     customFields,
@@ -65,7 +67,7 @@ const ViewCustomFieldsSettings = ({
     sectionTitle,
     sectionTitleLoaded,
     sectionTitleFetchFailed,
-  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix);
+  } = useSectionTitleFetch(okapi, backendModuleName.toUpperCase(), configNamePrefix, scope);
 
   const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
   const paneTitleRef = useRef(null);

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 
 import {
+  HTML,
   runAxeTest,
 } from '@folio/stripes-testing';
 
@@ -134,5 +135,17 @@ describe('ViewCustomFieldsSettings', () => {
     it('should display checkbox name', () => CFKeyValueInteractor('Field label').has({ value: 'Checkbox' }));
 
     it('should show help text section', () => CFKeyValueInteractor('Help text').has({ value: 'checkbox help text' }));
+  });
+
+  describe('when there is a `scope` prop', () => {
+    beforeEach(async function ()  {
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should retrieve the accordion label from the /settings/entries API', () => {
+      return HTML('Custom Fields label').exists();
+    });
   });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -138,7 +138,7 @@ describe('ViewCustomFieldsSettings', () => {
   });
 
   describe('when there is a `scope` prop', () => {
-    beforeEach(async function ()  {
+    beforeEach(async () => {
       await renderComponent({
         scope: 'test-scope',
       });

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -24,6 +24,7 @@ class CustomFieldsSettings extends Component {
         backendModuleName="users"
         entityType="user"
         redirectToEdit={this.redirectToEdit}
+        scope="ui-users.custom-fields.manage"
       />
     );
   }
@@ -38,6 +39,7 @@ Name | type | description | required
 `backendModuleName` | string | used to set correct `x-okapi-module-id` header when making requests to `mod-custom-fields`| true
 `entityType` | string | used to filter custom files by particular entity type |true
 `redirectToEdit` | func | function that redirect to route which renders `<EditCustomFieldsSettings />` |true
+`scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
 
 # EditCustomFieldsSettings
 `EditCustomFieldsSettings` provides the functionality to create, edit and delete custom fields for the provided entity type.
@@ -66,6 +68,7 @@ class EditCustomFields extends Component {
         backendModuleName="users"
         entityType="user"
         redirectToView={this.redirectToView}
+        scope="ui-users.custom-fields.manage"
       />
     );
   }
@@ -81,7 +84,7 @@ Name | type | description | required
 `configNamePrefix` | string | used to extend `configName` to use different storage for the section title when making requests to `mod-configuration` | false
 `entityType` | string | used to filter custom files by particular entity type |true
 `redirectToView` | func | function that redirect to route which renders `<ViewCustomFieldsSettings />` |true
-
+`scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
 
 # ViewCustomFieldsRecord
 `ViewCustomFieldsRecord`'s responsibilities are basically fetching custom fields configuration data for displaying accordions with them.
@@ -102,6 +105,7 @@ import { ViewCustomFieldsRecord } from '@folio/stripes/smart-components';
   entityType="user"
   expanded={this.state.sections.customFields}
   onToggle={this.handleSectionToggle}
+  scope="ui-users.custom-fields.manage"
 />
 ```
 
@@ -117,7 +121,7 @@ Name | type | description | required | default
 `entityType` | string | used to filter custom files by particular entity type | true |
 `expanded` | boolean | accordion open or closed | true |
 `onToggle` | func | callback for toggling the accordion open/closed | true |
-
+`scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
 
 
 # EditCustomFieldsRecord
@@ -143,6 +147,7 @@ import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
   onToggle={this.toggleSection}
   expanded={sections.customFields}
   fieldComponent={Field}
+  scope="ui-users.custom-fields.manage"
 />
 ```
 
@@ -169,6 +174,7 @@ import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
       onToggle={this.toggleSection}
       expanded={sections.customFields}
       fieldComponent={Field}
+      scope="ui-users.custom-fields.manage"
     />
  </Form>
 ```
@@ -189,7 +195,7 @@ Name | type | description | required | default
 `fieldComponent` | func | Field component | true |
 `onComponentLoad` | func | callback function invoked when all form fields have been rendered | false |
 `onToggle` | func | callback for toggling the accordion open/closed | true |
-
+`scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
 
 ### redux-form specific props
 Name | type | description | required | default

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -47,7 +47,7 @@ const useSectionTitleFetch = (okapi, moduleName, configNamePrefix, scope) => {
     return () => {
       isMounted = false;
     };
-  }, [makeOkapiRequest, moduleName, sectionTitleLoaded, scope]);
+  }, [makeOkapiRequest, moduleName, sectionTitleLoaded, configNamePrefix, scope]);
 
   return {
     sectionTitle,

--- a/lib/CustomFields/utils/useSectionTitleFetch.js
+++ b/lib/CustomFields/utils/useSectionTitleFetch.js
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import makeRequest from './makeRequest';
 import getConfigName from './getConfigName';
 
-const useSectionTitleFetch = (okapi, moduleName, configNamePrefix) => {
+const useSectionTitleFetch = (okapi, moduleName, configNamePrefix, scope) => {
   const [sectionTitleLoaded, setSectionTitleLoaded] = useState(false);
   const [sectionTitle, setSectionTitle] = useState({});
   const [sectionTitleFetchFailed, setSectionTitleFetchFailed] = useState(false);
@@ -16,7 +16,9 @@ const useSectionTitleFetch = (okapi, moduleName, configNamePrefix) => {
   useEffect(() => {
     let isMounted = true;
     const configName = getConfigName(configNamePrefix);
-    const url = `configurations/entries?query=(module==${moduleName} and configName==${configName})`;
+    const url = scope
+      ? `settings/entries?query=(scope==${scope} and key==${configName})`
+      : `configurations/entries?query=(module==${moduleName} and configName==${configName})`;
 
     const fetchCustomFields = async () => {
       const response = await makeOkapiRequest(url)({
@@ -25,7 +27,10 @@ const useSectionTitleFetch = (okapi, moduleName, configNamePrefix) => {
 
       if (isMounted) {
         if (response.ok) {
-          const { configs } = await response.json();
+          const data = await response.json();
+          const configs = scope
+            ? data.items
+            : data.configs;
 
           if (isMounted) {
             setSectionTitle({ ...configs[0] });
@@ -42,7 +47,7 @@ const useSectionTitleFetch = (okapi, moduleName, configNamePrefix) => {
     return () => {
       isMounted = false;
     };
-  }, [makeOkapiRequest, moduleName, sectionTitleLoaded]);
+  }, [makeOkapiRequest, moduleName, sectionTitleLoaded, scope]);
 
   return {
     sectionTitle,

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -312,4 +312,19 @@ export default function config() {
 
     this.create('tag', tagData);
   });
+
+  this.get('/settings/entries', (schema, request) => {
+    if (request.url.includes('custom_fields_label')) {
+      return {
+        items: [{
+          id: 'tested-custom-field-label',
+          key: 'custom_fields_label',
+          scope: 'ui-users.custom-fields.manage',
+          value: 'Custom Fields label',
+        }],
+      };
+    }
+
+    return { items: [] };
+  });
 }


### PR DESCRIPTION
## Description
Provided a `scope` property, which specifies that the `mod-settings` API should be used, otherwise `mod-configuration` will be used.

## Issues
[STSMACOM-910](https://folio-org.atlassian.net/browse/STSMACOM-910)

