### PR TITLE
STSMACOM-911: Migrate tags from mod-configuration to mod-settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update button label for creating new notes in NotesAccordion. Refs STSMACOM-906.
 * Add `configNamePrefix` prop to custom fields components to be able to store section titles separately for different entityTypes. Fixes STSMACOM-790.
 * Migrate custom fields from mod-configuration to mod-settings. Fixes STSMACOM-910.
+* Migrate tags from mod-configuration to mod-settings. Refs STSMACOM-911.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/Tags/tests/Tags-test.js
+++ b/lib/Tags/tests/Tags-test.js
@@ -135,5 +135,22 @@ describe('Tags smart component', () => {
     it('renders', () => HTML({ id: 'taglist' }).exists());
 
     it('renders tags as listItems', () => List().has({ count: 10 }));
+
+    it('should use mod-configuration API', () => {
+      return HTML(including('configurations/entries?query=(module==TAGS and configName==tags_enabled)')).exists();
+    });
+
+    describe('when `tagsScope` prop is passed', () => {
+      setupApplication({
+        component: (<ConnectedWithTags
+          link="dummy/entity"
+          tagsScope="scope-test"
+        />),
+      });
+
+      it('should use mod-settings API', () => {
+        return HTML(including('settings/entries?query=(scope==scope-test and key==tags_enabled)')).exists();
+      });
+    });
   });
 });

--- a/lib/Tags/tests/TagsWrapped.js
+++ b/lib/Tags/tests/TagsWrapped.js
@@ -14,6 +14,7 @@ const TagsWrapped = (
     <ul id="taglist" className="list-test">
       { tagged.records?.map(t => <li key={t.label}>{t.label}</li>) }
     </ul>
+    <div>{tagSettings.url}</div>
   </>
 );
 

--- a/lib/Tags/withTags.js
+++ b/lib/Tags/withTags.js
@@ -7,8 +7,14 @@ const withTags = WrappedComponent => class WithTagsComponent extends React.Compo
     Object.assign({}, WrappedComponent.manifest, {
       tagSettings: {
         type: 'okapi',
-        records: 'configs',
-        path: 'configurations/entries?query=(module==TAGS and configName==tags_enabled)',
+        path: (_q, _p, _r, _l, props) => {
+          const { tagsScope } = props;
+          const configName = 'tags_enabled';
+
+          return tagsScope
+            ? `settings/entries?query=(scope==${tagsScope} and key==${configName})`
+            : `configurations/entries?query=(module==TAGS and configName==${configName})`;
+        },
       },
     }),
   );
@@ -20,11 +26,19 @@ const withTags = WrappedComponent => class WithTagsComponent extends React.Compo
     resources: PropTypes.shape({
       tagSettings: PropTypes.object,
     }),
+    tagsScope: PropTypes.string,
   };
 
   areTagsEnabled() {
-    const { resources } = this.props;
-    const tagSettings = (resources.tagSettings || {}).records || [];
+    const {
+      resources,
+      tagsScope,
+    } = this.props;
+    const data = resources.tagSettings.records[0] || {};
+    const tagSettings = (tagsScope
+      ? data.items
+      : data.configs) || [];
+
     return !tagSettings.length || tagSettings[0].value === 'true';
   }
 


### PR DESCRIPTION
## Description
Added `tagsScope` property to use mod-settings API in the `withTags` HOC, otherwise mod-configuration.

## Issues
[STSMACOM-911](https://folio-org.atlassian.net/browse/STSMACOM-911)