### PR TITLE
STSMACOM-913 `<ControlledVocab>` - added a new `onCreateFail` prop to allow parent components to specify custom error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `configNamePrefix` prop to custom fields components to be able to store section titles separately for different entityTypes. Fixes STSMACOM-790.
 * Migrate custom fields from mod-configuration to mod-settings. Fixes STSMACOM-910.
 * Migrate tags from mod-configuration to mod-settings. Refs STSMACOM-911.
+* `<ControlledVocab>` - added a new `onCreateFail` prop to allow parent components to specify custom error handling. Refs STSMACOM-913.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -134,6 +134,7 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
+    onCreateFail: PropTypes.func,
     parseRow: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
@@ -224,6 +225,7 @@ class ControlledVocab extends React.Component {
     actuatorType: 'rest',
     canCreate: true,
     translations: {},
+    onCreateFail: noop,
   };
 
   constructor(props) {
@@ -289,7 +291,8 @@ class ControlledVocab extends React.Component {
     return this.props.mutator.values.POST(this.props.preCreateHook(item))
       .then(() => {
         this.showSuccessCallout(item, ACTIONS.CREATE);
-      });
+      })
+      .catch(res => this.props.onCreateFail(res));
   }
 
   onDeleteItem() {

--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -225,7 +225,6 @@ class ControlledVocab extends React.Component {
     actuatorType: 'rest',
     canCreate: true,
     translations: {},
-    onCreateFail: noop,
   };
 
   constructor(props) {
@@ -292,7 +291,13 @@ class ControlledVocab extends React.Component {
       .then(() => {
         this.showSuccessCallout(item, ACTIONS.CREATE);
       })
-      .catch(res => this.props.onCreateFail(res));
+      .catch(res => {
+        if (!this.props.onCreateFail) {
+          throw res; // throw again so handlers in EditableListForm can handle it
+        }
+
+        this.props.onCreateFail(res);
+      });
   }
 
   onDeleteItem() {

--- a/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
@@ -3,6 +3,8 @@ import {
   beforeEach,
   it,
 } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 import {
   TextField,
@@ -21,10 +23,16 @@ const CommonError = HTML.extend('ControlledVocab Error')
   .selector('[data-test-common-errors]');
 
 describe('ControlledVocabErrors', () => {
+  const mockOnCreateFail = sinon.spy();
+
+  const props = {
+    onCreateFail: mockOnCreateFail,
+  };
+
   function mount() {
     // eslint-disable-next-line no-undef
     beforeEach(function () {
-      mountComponent(true, this.server);
+      mountComponent(true, this.server, props);
       this.server.post('location-units/institutions', {
         'errors': [{
           'message': 'Cannot create entity; name is not unique',
@@ -51,9 +59,16 @@ describe('ControlledVocabErrors', () => {
     });
   }
 
+  const wait = (ms = 1000) => new Promise(resolve => { setTimeout(resolve, ms); });
+
   describe('multiple errors', () => {
     setupApplication();
     mount();
+
+    it('should call onCreateFail prop', async () => {
+      await wait();
+      expect(mockOnCreateFail.callCount).to.equal(1);
+    });
 
     it('should display field error message', () => TextField({ label: 'name 0' }).has({ error: including('already exists') }));
 

--- a/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
@@ -22,7 +22,7 @@ import mountComponent from './mountComponent';
 const CommonError = HTML.extend('ControlledVocab Error')
   .selector('[data-test-common-errors]');
 
-describe.only('ControlledVocabErrors', () => {
+describe('ControlledVocabErrors', () => {
   const mockOnCreateFail = sinon.spy();
 
   function mount(props) {

--- a/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
@@ -22,14 +22,10 @@ import mountComponent from './mountComponent';
 const CommonError = HTML.extend('ControlledVocab Error')
   .selector('[data-test-common-errors]');
 
-describe('ControlledVocabErrors', () => {
+describe.only('ControlledVocabErrors', () => {
   const mockOnCreateFail = sinon.spy();
 
-  const props = {
-    onCreateFail: mockOnCreateFail,
-  };
-
-  function mount() {
+  function mount(props) {
     // eslint-disable-next-line no-undef
     beforeEach(function () {
       mountComponent(true, this.server, props);
@@ -65,14 +61,23 @@ describe('ControlledVocabErrors', () => {
     setupApplication();
     mount();
 
+    it('should display field error message', () => TextField({ label: 'name 0' }).has({ error: including('already exists') }));
+
+    it('should display common error message', () => CommonError(translations['error.defaultSaveError']));
+  });
+
+  describe('when onCreateFail prop is passed', () => {
+    const props = {
+      onCreateFail: mockOnCreateFail,
+    };
+
+    setupApplication();
+    mount(props);
+
     it('should call onCreateFail prop', async () => {
       await wait();
       expect(mockOnCreateFail.callCount).to.equal(1);
     });
-
-    it('should display field error message', () => TextField({ label: 'name 0' }).has({ error: including('already exists') }));
-
-    it('should display common error message', () => CommonError(translations['error.defaultSaveError']));
   });
 
   describe('custom error', () => {


### PR DESCRIPTION
## Description
Note Types settings requires custom error handling of create fails, which is currently not supported.
This PR adds a new `onCreateFail` prop to `<ControlledVocab>` to allow parent components to specify custom error handling.

## Issues
[STSMACOM-913](https://folio-org.atlassian.net/browse/STSMACOM-913)