### PR TITLE
STSMACOM-913 added a new getCustomErrorMessages prop to EditableListForm (follow-up)

### DIFF
--- a/lib/ControlledVocab/ControlledVocab.js
+++ b/lib/ControlledVocab/ControlledVocab.js
@@ -134,7 +134,6 @@ class ControlledVocab extends React.Component {
     }).isRequired,
     nameKey: PropTypes.string,
     objectLabel: PropTypes.node.isRequired,
-    onCreateFail: PropTypes.func,
     parseRow: PropTypes.func,
     preCreateHook: PropTypes.func,
     preUpdateHook: PropTypes.func,
@@ -290,13 +289,6 @@ class ControlledVocab extends React.Component {
     return this.props.mutator.values.POST(this.props.preCreateHook(item))
       .then(() => {
         this.showSuccessCallout(item, ACTIONS.CREATE);
-      })
-      .catch(res => {
-        if (!this.props.onCreateFail) {
-          throw res; // throw again so handlers in EditableListForm can handle it
-        }
-
-        this.props.onCreateFail(res);
       });
   }
 

--- a/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
+++ b/lib/ControlledVocab/tests/ControlledVocabErrors-test.js
@@ -4,7 +4,6 @@ import {
   it,
 } from 'mocha';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import {
   TextField,
@@ -23,8 +22,6 @@ const CommonError = HTML.extend('ControlledVocab Error')
   .selector('[data-test-common-errors]');
 
 describe('ControlledVocabErrors', () => {
-  const mockOnCreateFail = sinon.spy();
-
   function mount(props) {
     // eslint-disable-next-line no-undef
     beforeEach(function () {
@@ -55,8 +52,6 @@ describe('ControlledVocabErrors', () => {
     });
   }
 
-  const wait = (ms = 1000) => new Promise(resolve => { setTimeout(resolve, ms); });
-
   describe('multiple errors', () => {
     setupApplication();
     mount();
@@ -64,20 +59,6 @@ describe('ControlledVocabErrors', () => {
     it('should display field error message', () => TextField({ label: 'name 0' }).has({ error: including('already exists') }));
 
     it('should display common error message', () => CommonError(translations['error.defaultSaveError']));
-  });
-
-  describe('when onCreateFail prop is passed', () => {
-    const props = {
-      onCreateFail: mockOnCreateFail,
-    };
-
-    setupApplication();
-    mount(props);
-
-    it('should call onCreateFail prop', async () => {
-      await wait();
-      expect(mockOnCreateFail.callCount).to.equal(1);
-    });
   });
 
   describe('custom error', () => {

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -99,6 +99,10 @@ const propTypes = {
   formatter: PropTypes.object,
 
   /**
+   * Function that accepts errors from a failed item creation and returns custom error messaging
+   */
+  getCustomErrorMessages: PropTypes.func,
+  /**
    * Function that returns a list of read-only fields for a specific item
    */
   getReadOnlyFieldsForItem: PropTypes.func,
@@ -197,6 +201,7 @@ const defaultProps = {
   createButtonLabel: '+ Add new',
   editable: true,
   fieldComponents: {},
+  getCustomErrorMessages: null,
   hideCreateButton: false,
   itemTemplate: {},
   uniqueField: 'id',
@@ -331,7 +336,10 @@ class EditableListForm extends React.Component {
   }
 
   onSave(fields, index) {
-    const { validate } = this.props;
+    const {
+      validate,
+      getCustomErrorMessages,
+    } = this.props;
     const item = this.getValue(fields, index);
     const errors = validate({ items: fields.value });
 
@@ -355,7 +363,7 @@ class EditableListForm extends React.Component {
         this.toggleEdit(index);
         this.setState({ creating: false });
       },
-      async (response) => this.setError(index, await processBadResponse(response, errorCodes.defaultSaveError))
+      async (response) => this.setError(index, await processBadResponse(response, errorCodes.defaultSaveError, getCustomErrorMessages)),
     );
   }
 

--- a/lib/EditableList/processBadResponse.js
+++ b/lib/EditableList/processBadResponse.js
@@ -67,10 +67,14 @@ const getDefaultErrorMessage = (defaultErrorCode) => {
   };
 };
 
-export default async function processBadResponse(response, defaultErrorCode) {
+export default async function processBadResponse(response, defaultErrorCode, getCustomErrorMessages = null) {
   if (response.status === 422) {
     try {
       const { errors } = await response.json();
+
+      if (getCustomErrorMessages) {
+        return getCustomErrorMessages(errors);
+      }
 
       return getErrorMessages(errors, defaultErrorCode);
     } catch (e) {


### PR DESCRIPTION
[Previous PR](https://github.com/folio-org/stripes-smart-components/pull/1589) involved providing a custom error handler to `<ControlledVocab>`, but it caused list of items to not refresh when an item creation failed.
Instead the new approach is to provide an error message getter via props. This way when an item creation fails - the list is still refreshed.

## Screenshots

https://github.com/user-attachments/assets/5c666a3a-9a0b-4313-9a6e-70e230bbda85

## Issues
[STSMACOM-913](https://folio-org.atlassian.net/browse/STSMACOM-913)