### PR TITLE
STSMACOM-914: Settings Custom Fields View - include the `Display in accordion`, `Hidden` fields, and re-order the fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Migrate custom fields from mod-configuration to mod-settings. Fixes STSMACOM-910.
 * Migrate tags from mod-configuration to mod-settings. Refs STSMACOM-911.
 * `<ControlledVocab>` - added a new `onCreateFail` prop to allow parent components to specify custom error handling. Refs STSMACOM-913.
+* Settings Custom Fields View - include the "Display in accordion", "Hidden" fields, and re-order the fields. Refs STSMACOM-914.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -151,7 +151,7 @@ const FieldAccordion = (props) => {
       fieldNamePrefix,
       changeFieldValue,
     }
-    : { 
+    : {
       ...fieldData,
       hasDisplayInAccordionField,
       displayInAccordionOptions,

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -48,6 +48,7 @@ const propTypes = {
     type: PropTypes.oneOf(Object.values(fieldTypes)).isRequired,
   }).isRequired,
   fieldNamePrefix: PropTypes.string,
+  hasDisplayInAccordionField: PropTypes.bool,
   id: PropTypes.string.isRequired,
   isDragDisabled: PropTypes.bool,
   isEditMode: PropTypes.bool,
@@ -82,6 +83,7 @@ const FieldAccordion = (props) => {
     optionsStatsLoaded,
     onOptionDelete,
     lastAddedAccordionId,
+    hasDisplayInAccordionField,
   } = props;
   const accordionLabel = (
     <>
@@ -144,7 +146,10 @@ const FieldAccordion = (props) => {
       fieldNamePrefix,
       changeFieldValue,
     }
-    : { ...fieldData };
+    : { 
+      ...fieldData,
+      hasDisplayInAccordionField,
+    };
 
   if (fieldTypesWithOptions.includes(fieldData.type) && isEditMode) {
     contentProps.usedOptions = usedOptions;

--- a/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/FieldAccordion.js
@@ -40,6 +40,10 @@ const viewSectionsByType = {
 const propTypes = {
   changeFieldValue: PropTypes.func,
   deleteCustomField: PropTypes.func,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   dragHandleProps: PropTypes.object,
   fieldData: PropTypes.shape({
     hidden: PropTypes.bool,
@@ -84,6 +88,7 @@ const FieldAccordion = (props) => {
     onOptionDelete,
     lastAddedAccordionId,
     hasDisplayInAccordionField,
+    displayInAccordionOptions,
   } = props;
   const accordionLabel = (
     <>
@@ -149,6 +154,7 @@ const FieldAccordion = (props) => {
     : { 
       ...fieldData,
       hasDisplayInAccordionField,
+      displayInAccordionOptions,
     };
 
   if (fieldTypesWithOptions.includes(fieldData.type) && isEditMode) {

--- a/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
@@ -13,6 +13,7 @@ import {
 const propTypes = {
   displayInAccordion: PropTypes.string,
   visible: PropTypes.bool.isRequired,
+  hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
 };
@@ -21,7 +22,9 @@ const CheckboxSection = props => (
   <Row>
     <NameValue value={props.name} />
     <HelpTextValue value={props.helpText} />
-    <DisplayInAccordion value={props.displayInAccordion} />
+    {props.hasDisplayInAccordionField && (
+      <DisplayInAccordion value={props.displayInAccordion} />
+    )}
     <HiddenValue value={props.visible} />
   </Row>
 );

--- a/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
@@ -12,6 +12,10 @@ import {
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   visible: PropTypes.bool.isRequired,
   hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
@@ -23,7 +27,10 @@ const CheckboxSection = props => (
     <NameValue value={props.name} />
     <HelpTextValue value={props.helpText} />
     {props.hasDisplayInAccordionField && (
-      <DisplayInAccordion value={props.displayInAccordion} />
+      <DisplayInAccordion
+        value={props.displayInAccordion}
+        dataOptions={props.displayInAccordionOptions}
+      />
     )}
     <HiddenValue value={props.visible} />
   </Row>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/CheckboxSection.js
@@ -6,9 +6,13 @@ import { Row } from '@folio/stripes-components';
 import {
   HelpTextValue,
   NameValue,
+  DisplayInAccordion,
+  HiddenValue,
 } from './shared-values';
 
 const propTypes = {
+  displayInAccordion: PropTypes.string,
+  visible: PropTypes.bool.isRequired,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
 };
@@ -16,7 +20,9 @@ const propTypes = {
 const CheckboxSection = props => (
   <Row>
     <NameValue value={props.name} />
-    { props.helpText && <HelpTextValue value={props.helpText} /> }
+    <HelpTextValue value={props.helpText} />
+    <DisplayInAccordion value={props.displayInAccordion} />
+    <HiddenValue value={props.visible} />
   </Row>
 );
 

--- a/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
@@ -7,9 +7,15 @@ import {
   HelpTextValue,
   NameValue,
   Options,
+  DisplayInAccordion,
+  HiddenValue,
+  RequiredValue,
 } from './shared-values';
 
 const propTypes = {
+  displayInAccordion: PropTypes.string,
+  visible: PropTypes.bool.isRequired,
+  required: PropTypes.bool.isRequired,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
   selectField: PropTypes.shape({
@@ -25,11 +31,17 @@ const RadioButtonSetSections = ({
   name,
   helpText,
   selectField,
+  displayInAccordion,
+  visible,
+  required,
 }) => (
   <>
     <Row>
       <NameValue value={name} />
-      { helpText && <HelpTextValue value={helpText} /> }
+      <HelpTextValue value={helpText} />
+      <DisplayInAccordion value={displayInAccordion} />
+      <HiddenValue value={visible} />
+      <RequiredValue value={required} />
     </Row>
     <Row>
       <Options selectField={selectField} />

--- a/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
@@ -14,6 +14,10 @@ import {
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   hasDisplayInAccordionField: PropTypes.bool,
   visible: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
@@ -34,6 +38,7 @@ const RadioButtonSetSections = ({
   helpText,
   selectField,
   displayInAccordion,
+  displayInAccordionOptions,
   visible,
   required,
 }) => (
@@ -42,7 +47,10 @@ const RadioButtonSetSections = ({
       <NameValue value={name} />
       <HelpTextValue value={helpText} />
       {hasDisplayInAccordionField && (
-        <DisplayInAccordion value={displayInAccordion} />
+        <DisplayInAccordion
+          value={displayInAccordion}
+          dataOptions={displayInAccordionOptions}
+        />
       )}
       <HiddenValue value={visible} />
       <RequiredValue value={required} />

--- a/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/RadioButtonSetSections.js
@@ -14,6 +14,7 @@ import {
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  hasDisplayInAccordionField: PropTypes.bool,
   visible: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
   helpText: PropTypes.string,
@@ -29,6 +30,7 @@ const propTypes = {
 
 const RadioButtonSetSections = ({
   name,
+  hasDisplayInAccordionField,
   helpText,
   selectField,
   displayInAccordion,
@@ -39,7 +41,9 @@ const RadioButtonSetSections = ({
     <Row>
       <NameValue value={name} />
       <HelpTextValue value={helpText} />
-      <DisplayInAccordion value={displayInAccordion} />
+      {hasDisplayInAccordionField && (
+        <DisplayInAccordion value={displayInAccordion} />
+      )}
       <HiddenValue value={visible} />
       <RequiredValue value={required} />
     </Row>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
@@ -15,6 +15,7 @@ import { fieldTypes } from '../../../constants';
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool.isRequired,
@@ -37,7 +38,9 @@ const SelectDropdownSection = props => {
       <Row>
         <NameValue value={props.name} />
         <HelpTextValue value={props.helpText} />
-        <DisplayInAccordion value={props.displayInAccordion} />
+        {props.hasDisplayInAccordionField && (
+          <DisplayInAccordion value={props.displayInAccordion} />
+        )}
         <HiddenValue value={props.visible} />
         <RequiredValue value={props.required} />
       </Row>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
@@ -8,10 +8,13 @@ import {
   NameValue,
   RequiredValue,
   Options,
+  DisplayInAccordion,
+  HiddenValue,
 } from './shared-values';
 import { fieldTypes } from '../../../constants';
 
 const propTypes = {
+  displayInAccordion: PropTypes.string,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool.isRequired,
@@ -23,6 +26,7 @@ const propTypes = {
     }).isRequired,
   }),
   type: PropTypes.string.isRequired,
+  visible: PropTypes.bool.isRequired,
 };
 
 const SelectDropdownSection = props => {
@@ -32,7 +36,9 @@ const SelectDropdownSection = props => {
     <>
       <Row>
         <NameValue value={props.name} />
-        { props.helpText && <HelpTextValue value={props.helpText} /> }
+        <HelpTextValue value={props.helpText} />
+        <DisplayInAccordion value={props.displayInAccordion} />
+        <HiddenValue value={props.visible} />
         <RequiredValue value={props.required} />
       </Row>
       <Row>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/SelectDropdownSection.js
@@ -15,6 +15,10 @@ import { fieldTypes } from '../../../constants';
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
   name: PropTypes.string.isRequired,
@@ -39,7 +43,10 @@ const SelectDropdownSection = props => {
         <NameValue value={props.name} />
         <HelpTextValue value={props.helpText} />
         {props.hasDisplayInAccordionField && (
-          <DisplayInAccordion value={props.displayInAccordion} />
+          <DisplayInAccordion
+            value={props.displayInAccordion}
+            dataOptions={props.displayInAccordionOptions}
+          />
         )}
         <HiddenValue value={props.visible} />
         <RequiredValue value={props.required} />

--- a/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
@@ -13,6 +13,7 @@ import {
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
   visible: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
@@ -23,7 +24,9 @@ const TextboxSection = props => (
   <Row>
     <NameValue value={props.name} />
     <HelpTextValue value={props.helpText} />
-    <DisplayInAccordion value={props.displayInAccordion} />
+    {props.hasDisplayInAccordionField && (
+      <DisplayInAccordion value={props.displayInAccordion} />
+    )}
     <HiddenValue value={props.visible} />
     <RequiredValue value={props.required} />
   </Row>

--- a/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
@@ -7,10 +7,14 @@ import {
   HelpTextValue,
   NameValue,
   RequiredValue,
+  DisplayInAccordion,
+  HiddenValue,
 } from './shared-values';
 
 const propTypes = {
+  displayInAccordion: PropTypes.string,
   helpText: PropTypes.string,
+  visible: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool.isRequired,
 };
@@ -18,7 +22,9 @@ const propTypes = {
 const TextboxSection = props => (
   <Row>
     <NameValue value={props.name} />
-    { props.helpText && <HelpTextValue value={props.helpText} /> }
+    <HelpTextValue value={props.helpText} />
+    <DisplayInAccordion value={props.displayInAccordion} />
+    <HiddenValue value={props.visible} />
     <RequiredValue value={props.required} />
   </Row>
 );

--- a/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
@@ -29,7 +29,7 @@ const TextboxSection = props => (
     <NameValue value={props.name} />
     <HelpTextValue value={props.helpText} />
     {props.hasDisplayInAccordionField && (
-      <DisplayInAccordion 
+      <DisplayInAccordion
         value={props.displayInAccordion}
         dataOptions={props.displayInAccordionOptions}
       />

--- a/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/TextboxSection.js
@@ -13,6 +13,10 @@ import {
 
 const propTypes = {
   displayInAccordion: PropTypes.string,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   hasDisplayInAccordionField: PropTypes.bool,
   helpText: PropTypes.string,
   visible: PropTypes.bool.isRequired,
@@ -25,7 +29,10 @@ const TextboxSection = props => (
     <NameValue value={props.name} />
     <HelpTextValue value={props.helpText} />
     {props.hasDisplayInAccordionField && (
-      <DisplayInAccordion value={props.displayInAccordion} />
+      <DisplayInAccordion 
+        value={props.displayInAccordion}
+        dataOptions={props.displayInAccordionOptions}
+      />
     )}
     <HiddenValue value={props.visible} />
     <RequiredValue value={props.required} />

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
@@ -6,8 +6,8 @@ import {
   KeyValue,
 } from '@folio/stripes-components';
 
-const DisplayInAccordion = ({ 
-  value, 
+const DisplayInAccordion = ({
+  value,
   dataOptions,
 }) => {
   const label = dataOptions.find(option => option.value === value)?.label;

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
@@ -6,18 +6,27 @@ import {
   KeyValue,
 } from '@folio/stripes-components';
 
-const DisplayInAccordion = ({ value }) => {
+const DisplayInAccordion = ({ 
+  value, 
+  dataOptions,
+}) => {
+  const label = dataOptions.find(option => option.value === value)?.label;
+
   return (
     <Col xs={3}>
       <KeyValue
         label={<FormattedMessage id="stripes-smart-components.customFields.displayInAccordion" />}
-        value={value || <FormattedMessage id="stripes-smart-components.customFields.recordAccordion.defaultName" />}
+        value={label || <FormattedMessage id="stripes-smart-components.customFields.recordAccordion.defaultName" />}
       />
     </Col>
   );
 };
 
 DisplayInAccordion.propTypes = {
+  dataOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })).isRequired,
   value: PropTypes.string,
 };
 

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/DisplayInAccordion.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Col,
+  KeyValue,
+} from '@folio/stripes-components';
+
+const DisplayInAccordion = ({ value }) => {
+  return (
+    <Col xs={3}>
+      <KeyValue
+        label={<FormattedMessage id="stripes-smart-components.customFields.displayInAccordion" />}
+        value={value || <FormattedMessage id="stripes-smart-components.customFields.recordAccordion.defaultName" />}
+      />
+    </Col>
+  );
+};
+
+DisplayInAccordion.propTypes = {
+  value: PropTypes.string,
+};
+
+export default DisplayInAccordion;

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HelpTextValue.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HelpTextValue.js
@@ -10,16 +10,12 @@ import {
 const propTypes = { value: PropTypes.string.isRequired };
 
 const HelpTextValue = ({ value }) => (
-  value?.length
-    ? (
-      <Col data-test-custom-field-help-text xs={3}>
-        <KeyValue
-          label={<FormattedMessage id="stripes-smart-components.customFields.helperText" />}
-          value={value}
-        />
-      </Col>
-    )
-    : null
+  <Col data-test-custom-field-help-text xs={3}>
+    <KeyValue
+      label={<FormattedMessage id="stripes-smart-components.customFields.helperText" />}
+      value={value}
+    />
+  </Col>
 );
 
 HelpTextValue.propTypes = propTypes;

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.css
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.css
@@ -1,0 +1,3 @@
+.hiddenField {
+  min-width: 5rem;
+}

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Col,
+  Checkbox,
+} from '@folio/stripes-components';
+
+const propTypes = { value: PropTypes.bool.isRequired };
+
+const HiddenValue = ({ value }) => (
+  <Col xs={1}>
+    <Checkbox
+      checked={!value}
+      label={<FormattedMessage id="stripes-smart-components.customFields.hidden" />}
+      disabled
+      vertical
+    />
+  </Col>
+);
+
+HiddenValue.propTypes = propTypes;
+
+export default HiddenValue;

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/HiddenValue.js
@@ -6,10 +6,15 @@ import {
   Checkbox,
 } from '@folio/stripes-components';
 
+import styles from './HiddenValue.css';
+
 const propTypes = { value: PropTypes.bool.isRequired };
 
 const HiddenValue = ({ value }) => (
-  <Col xs={1}>
+  <Col
+    xs={1}
+    className={styles.hiddenField}
+  >
     <Checkbox
       checked={!value}
       label={<FormattedMessage id="stripes-smart-components.customFields.hidden" />}

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/RequiredValue.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/RequiredValue.js
@@ -4,20 +4,19 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
-  KeyValue,
+  Checkbox,
 } from '@folio/stripes-components';
 
 const propTypes = { value: PropTypes.bool.isRequired };
 
 const RequiredValue = ({ value }) => (
-  <Col data-test-custom-field-required xs={3}>
-    <KeyValue label={<FormattedMessage id="stripes-smart-components.customFields.required" />}>
-      {
-        value
-          ? <FormattedMessage id="stripes-smart-components.customFields.required.checked" />
-          : <FormattedMessage id="stripes-smart-components.customFields.required.unchecked" />
-      }
-    </KeyValue>
+  <Col data-test-custom-field-required xs={2}>
+    <Checkbox
+      checked={value}
+      label={<FormattedMessage id="stripes-smart-components.customFields.required" />}
+      disabled
+      vertical
+    />
   </Col>
 );
 

--- a/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/index.js
+++ b/lib/CustomFields/components/FieldAccordion/view-sections/shared-values/index.js
@@ -2,3 +2,5 @@ export { default as NameValue } from './NameValue';
 export { default as HelpTextValue } from './HelpTextValue';
 export { default as RequiredValue } from './RequiredValue';
 export { default as Options } from './Options';
+export { default as DisplayInAccordion } from './DisplayInAccordion';
+export { default as HiddenValue } from './HiddenValue';

--- a/lib/CustomFields/constants.js
+++ b/lib/CustomFields/constants.js
@@ -41,6 +41,7 @@ export const fieldTypesLabels = {
 };
 
 export const NO_DEFAULT_OPTIONS_VALUE = 'no-default';
+export const CUSTOM_FIELDS_SECTION_ID = 'customFields';
 
 export const defaultFieldConfigs = {
   [fieldTypes.TEXTFIELD]: {

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -5,7 +5,7 @@ import React, {
 } from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Pane,
@@ -24,12 +24,14 @@ import {
   useCustomFieldsFetch,
   useSectionTitleFetch,
   useLoadingErrorCallout,
+  getDisplayInAccordionOptions,
 } from '../../utils';
 
 import {
   selectModuleId,
   selectOkapiData,
 } from '../../selectors';
+import { CUSTOM_FIELDS_SECTION_ID } from '../../constants';
 import { permissionsShape } from '../../shapes';
 
 import styles from './ViewCustomFieldsSettings.css';
@@ -65,6 +67,8 @@ const ViewCustomFieldsSettings = ({
   hasDisplayInAccordionField = false,
   displayInAccordionOptions = [],
 }) => {
+  const intl = useIntl();
+
   const {
     customFields,
     customFieldsLoaded,
@@ -80,6 +84,7 @@ const ViewCustomFieldsSettings = ({
   const paneTitleRef = useRef(null);
 
   const noDataSaved = isEmpty(customFields) && !sectionTitle.value;
+  const sectionTitleValue = sectionTitle.value || intl.formatMessage({ id: 'stripes-smart-components.customFields.recordAccordion.defaultName' });
 
   useEffect(() => {
     if (paneTitleRef.current) {
@@ -101,6 +106,7 @@ const ViewCustomFieldsSettings = ({
             id,
             values: {
               ...formData,
+              displayInAccordion: formData.displayInAccordion || CUSTOM_FIELDS_SECTION_ID,
               hidden: !cf.visible
             },
           }
@@ -132,8 +138,7 @@ const ViewCustomFieldsSettings = ({
   const renderSectionTitle = () => (
     <KeyValue label={<FormattedMessage id="stripes-smart-components.customFields.settings.accordionTitle" />}>
       <span className={styles.sectionTitle}>
-        {sectionTitle.value ||
-          <FormattedMessage id="stripes-smart-components.customFields.recordAccordion.defaultName" />}
+        {sectionTitleValue}
       </span>
     </KeyValue>
   );
@@ -153,7 +158,7 @@ const ViewCustomFieldsSettings = ({
             fieldData={fieldData.values}
             permissions={permissions}
             hasDisplayInAccordionField={hasDisplayInAccordionField}
-            displayInAccordionOptions={displayInAccordionOptions}
+            displayInAccordionOptions={getDisplayInAccordionOptions(sectionTitleValue, displayInAccordionOptions)}
           />
         );
       })}

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -40,6 +40,7 @@ const propTypes = {
   configNamePrefix: PropTypes.string,
   editRoute: PropTypes.string.isRequired,
   entityType: PropTypes.string.isRequired,
+  hasDisplayInAccordionField: PropTypes.bool,
   okapi: PropTypes.shape({
     tenant: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
@@ -57,6 +58,7 @@ const ViewCustomFieldsSettings = ({
   permissions,
   configNamePrefix,
   scope,
+  hasDisplayInAccordionField = false,
 }) => {
   const {
     customFields,
@@ -145,6 +147,7 @@ const ViewCustomFieldsSettings = ({
             key={id}
             fieldData={fieldData.values}
             permissions={permissions}
+            hasDisplayInAccordionField={hasDisplayInAccordionField}
           />
         );
       })}

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -38,6 +38,10 @@ const propTypes = {
   backendModuleId: PropTypes.string,
   backendModuleName: PropTypes.string.isRequired,
   configNamePrefix: PropTypes.string,
+  displayInAccordionOptions: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })),
   editRoute: PropTypes.string.isRequired,
   entityType: PropTypes.string.isRequired,
   hasDisplayInAccordionField: PropTypes.bool,
@@ -59,6 +63,7 @@ const ViewCustomFieldsSettings = ({
   configNamePrefix,
   scope,
   hasDisplayInAccordionField = false,
+  displayInAccordionOptions = [],
 }) => {
   const {
     customFields,
@@ -148,6 +153,7 @@ const ViewCustomFieldsSettings = ({
             fieldData={fieldData.values}
             permissions={permissions}
             hasDisplayInAccordionField={hasDisplayInAccordionField}
+            displayInAccordionOptions={displayInAccordionOptions}
           />
         );
       })}

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -148,4 +148,23 @@ describe('ViewCustomFieldsSettings', () => {
       return HTML('Custom Fields label').exists();
     });
   });
+
+  describe('when the `hasDisplayInAccordionField` prop is not provided', () => {
+    it('should not display the "Display in accordion" field', () => {
+      return CFKeyValueInteractor('Display in accordion').absent();
+    });
+  });
+
+  describe('when the `hasDisplayInAccordionField` prop is true', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        hasDisplayInAccordionField: true,
+      });
+      await CFAccordionInteractor({ index: 0 }).clickHeader();
+    });
+
+    it('should display the "Display in accordion" field', () => {
+      return CFKeyValueInteractor('Display in accordion').exists();
+    });
+  });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -163,12 +163,19 @@ describe('ViewCustomFieldsSettings', () => {
     beforeEach(async () => {
       await renderComponent({
         hasDisplayInAccordionField: true,
+        displayInAccordionOptions: [
+          { value: 'feesFines', label: 'Fees/Fines' },
+        ],
       });
       await CFAccordionInteractor({ index: 0 }).clickHeader();
     });
 
     it('should display the "Display in accordion" field', () => {
       return CFKeyValueInteractor('Display in accordion').exists();
+    });
+
+    it('should display correct label for the "Display in accordion" field', () => {
+      return CFKeyValueInteractor('Display in accordion').has({ value: 'Fees/Fines' });
     });
   });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -67,7 +67,7 @@ describe('ViewCustomFieldsSettings', () => {
       await CFAccordionInteractor({ index: 0 }).clickHeader();
     });
 
-    it('should show "Yes" under "Required" field', () => CFKeyValueInteractor({ label: 'Required' }).has({ value: 'Yes' }));
+    it('should show a checked checkbox under "Required" field', () => CFOptionCheckbox({ label: 'Required' }).is({ disabled: true, checked: true }));
   });
 
   describe('when a custom field is not required', () => {
@@ -75,7 +75,7 @@ describe('ViewCustomFieldsSettings', () => {
       await CFAccordionInteractor({ index: 1 }).clickHeader();
     });
 
-    it('should show "No" under "Required" field', () => CFKeyValueInteractor({ label: 'Required' }).has({ value: 'No' }));
+    it('should show unchecked checkbox under "Required" field', () => CFOptionCheckbox({ label: 'Required' }).is({ disabled: true, checked: false }));
   });
 
   describe('when custom field is single select', () => {

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -166,6 +166,7 @@ describe('ViewCustomFieldsSettings', () => {
         displayInAccordionOptions: [
           { value: 'feesFines', label: 'Fees/Fines' },
         ],
+        scope: 'test-scope',
       });
       await CFAccordionInteractor({ index: 0 }).clickHeader();
     });
@@ -176,6 +177,13 @@ describe('ViewCustomFieldsSettings', () => {
 
     it('should display correct label for the "Display in accordion" field', () => {
       return CFKeyValueInteractor('Display in accordion').has({ value: 'Fees/Fines' });
+    });
+
+    describe('when the "Custom fields" option is selected in the "Display in accordion" field', () => {
+      it('should display a label, the name of which coincides with the section title ', async () => {
+        await CFAccordionInteractor({ index: 1 }).clickHeader();
+        return CFAccordionInteractor({ index: 1 }).find(CFKeyValueInteractor('Display in accordion')).has({ value: 'Custom Fields label' });
+      });
     });
   });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -150,6 +150,10 @@ describe('ViewCustomFieldsSettings', () => {
   });
 
   describe('when the `hasDisplayInAccordionField` prop is not provided', () => {
+    beforeEach(async () => {
+      await CFAccordionInteractor({ index: 0 }).clickHeader();
+    });
+
     it('should not display the "Display in accordion" field', () => {
       return CFKeyValueInteractor('Display in accordion').absent();
     });

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -41,6 +41,7 @@ Name | type | description | required
 `redirectToEdit` | func | function that redirect to route which renders `<EditCustomFieldsSettings />` |true
 `scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
 `hasDisplayInAccordionField` | boolean | used to display the `Display in accordion` field | false
+`displayInAccordionOptions` | array | a list of options `[{ value, label }]`, `value` is used to find the correct `label` and display it for the `Display in accordion` field | false
 
 # EditCustomFieldsSettings
 `EditCustomFieldsSettings` provides the functionality to create, edit and delete custom fields for the provided entity type.

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -40,6 +40,7 @@ Name | type | description | required
 `entityType` | string | used to filter custom files by particular entity type |true
 `redirectToEdit` | func | function that redirect to route which renders `<EditCustomFieldsSettings />` |true
 `scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
+`hasDisplayInAccordionField` | boolean | used to display the `Display in accordion` field | false
 
 # EditCustomFieldsSettings
 `EditCustomFieldsSettings` provides the functionality to create, edit and delete custom fields for the provided entity type.

--- a/lib/CustomFields/utils/getDisplayInAccordionOptions.js
+++ b/lib/CustomFields/utils/getDisplayInAccordionOptions.js
@@ -1,0 +1,13 @@
+import { CUSTOM_FIELDS_SECTION_ID } from '../constants';
+
+const getDisplayInAccordionOptions = (sectionTitleValue, displayInAccordionOptions) => {
+  return [
+    {
+      value: CUSTOM_FIELDS_SECTION_ID,
+      label: sectionTitleValue,
+    },
+    ...displayInAccordionOptions,
+  ].sort((a, b) => a.label.localeCompare(b.label));
+};
+
+export default getDisplayInAccordionOptions;

--- a/lib/CustomFields/utils/index.js
+++ b/lib/CustomFields/utils/index.js
@@ -6,3 +6,4 @@ export { default as validateCustomFields } from './validateCustomFields';
 export { default as useOptionsStatsFetch } from './useOptionsStatsFetch';
 export { default as useCustomFields } from './useCustomFields';
 export { default as getConfigName } from './getConfigName';
+export { default as getDisplayInAccordionOptions } from './getDisplayInAccordionOptions';

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -139,6 +139,7 @@ export default function config() {
       'required': true,
       'order': 1,
       'helpText': 'helpful text',
+      displayInAccordion: 'feesFines',
     }, {
       'id': '2',
       'name': 'Textarea 1',

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -226,6 +226,7 @@
   "customFields.fieldValue.whitespace": "Whitespace only character(s) is not allowed.",
   "customFields.helperText": "Help text",
   "customFields.helperText.description": "This will show under an information icon",
+  "customFields.displayInAccordion": "Display in accordion",
   "customFields.required": "Required",
   "customFields.required.checked": "Yes",
   "customFields.required.unchecked": "No",


### PR DESCRIPTION
## Description
Settings Custom Fields View:
- added new property `hasDisplayInAccordionField` to show/hide the new `Display in accordion` field, which is designed to store the name/id of the accordion where the custom field will be placed. Currently, BE is done only for the mod-users, mod-orders, or any other module should do some extra work to use this field;
- help text field is now always displayed instead of when value is present;
- changed fields order to `Field label`, `Help text`, `Display in accordion`, `Hidden`, `Required`;
- checkbox doesn't have `Required` field;
- created new `DisplayInAccordion` component for `Display in accordion` field;
- created new `HiddenValue` component;
- added new `displayInAccordionOptions` property, it is a list of options `[{ value, label }]`, `value` is used to find the correct `label` and display it for the `Display in accordion` field;
- the initial `Custom fields` option label in the `Display in accordion` field will be the same as section title.

## Issues
[STSMACOM-914](https://folio-org.atlassian.net/browse/STSMACOM-914)

## Screenshots

https://github.com/user-attachments/assets/ab9fb6b7-29d0-4d57-abc0-532b85fe729e

![image](https://github.com/user-attachments/assets/6fb25b59-89a1-407e-bf7d-0750784c2819)


