### PR TITLE
STSMACOM-922: Improve custom fields default value handling for create vs edit modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * ConfigManager - added new `lastMenu` prop and pass it to `<Pane>`. Refs STSMACOM-918.
 * `EditCustomFieldsRecord` - add `sectionId` prop support for accordion-specific field rendering; Add new `useCustomFieldsQuery` and `useSectionTitleQuery` hooks to avoid duplicate requests. Refs STSMACOM-920.
 * `ViewCustomFieldsRecord` - add `sectionId` prop support for accordion-specific field rendering. Refs STSMACOM-921.
+* `EditCustomFieldsRecord` - Improve custom fields default value handling for create vs edit modes. Refs STSMACOM-922.
 
 ## [10.0.0](https://github.com/folio-org/stripes-smart-components/tree/v10.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-smart-components/compare/v9.2.0...v10.0.0)

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -191,29 +191,33 @@ const EditCustomFieldsRecord = ({
         }
       });
 
-      if (hasDefaultValues) {
-        if (isReduxForm) {
-          Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
-            changeReduxFormField(`customFields.${refId}`, value);
-          });
-        } else if (isCreateMode && finalFormInstance?.restart) {
-          // For create scenarios, use restart to set as initial values (won't mark form dirty)
-          const currentValues = finalFormInstance.getState().values;
-          const newInitialValues = {
-            ...currentValues,
-            customFields: {
-              ...currentValues.customFields,
-              ...fieldsToInitialize
-            }
-          };
+      if (!hasDefaultValues) return;
 
-          finalFormInstance.restart(newInitialValues);
-        } else {
-          // For edit scenarios or fallback, use change method (will mark form dirty as expected)
-          Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
-            changeFinalFormField(`customFields.${refId}`, value);
-          });
-        }
+      if (isReduxForm) {
+        Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
+          changeReduxFormField(`customFields.${refId}`, value);
+        });
+
+        return;
+      }
+
+      // For create scenarios, use restart to set as initial values (won't mark form dirty)
+      if (isCreateMode && finalFormInstance?.restart) {
+        const currentValues = finalFormInstance.getState().values;
+        const newInitialValues = {
+          ...currentValues,
+          customFields: {
+            ...currentValues.customFields,
+            ...fieldsToInitialize
+          }
+        };
+
+        finalFormInstance.restart(newInitialValues);
+      } else {
+        // For edit scenarios or fallback, use change method (will mark form dirty as expected)
+        Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
+          changeFinalFormField(`customFields.${refId}`, value);
+        });
       }
     };
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -196,25 +196,23 @@ const EditCustomFieldsRecord = ({
           Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
             changeReduxFormField(`customFields.${refId}`, value);
           });
-        } else {
-          if (isCreateMode && finalFormInstance?.restart) {
-            // For create scenarios, use restart to set as initial values (won't mark form dirty)
-            const currentValues = finalFormInstance.getState().values;
-            const newInitialValues = {
-              ...currentValues,
-              customFields: {
-                ...currentValues.customFields,
-                ...fieldsToInitialize
-              }
-            };
+        } else if (isCreateMode && finalFormInstance?.restart) {
+          // For create scenarios, use restart to set as initial values (won't mark form dirty)
+          const currentValues = finalFormInstance.getState().values;
+          const newInitialValues = {
+            ...currentValues,
+            customFields: {
+              ...currentValues.customFields,
+              ...fieldsToInitialize
+            }
+          };
 
-            finalFormInstance.restart(newInitialValues);
-          } else {
-            // For edit scenarios or fallback, use change method (will mark form dirty as expected)
-            Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
-              changeFinalFormField(`customFields.${refId}`, value);
-            });
-          }
+          finalFormInstance.restart(newInitialValues);
+        } else {
+          // For edit scenarios or fallback, use change method (will mark form dirty as expected)
+          Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
+            changeFinalFormField(`customFields.${refId}`, value);
+          });
         }
       }
     };

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -235,6 +235,8 @@ const EditCustomFieldsRecord = ({
     isReduxForm,
     reduxFormCustomFieldsValues,
     finalFormCustomFieldsValues,
+    finalFormInstance,
+    isCreateMode,
     onComponentLoad
   ]);
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -11,6 +11,7 @@ import {
   chunk,
   hasIn,
   get,
+  isEqual,
 } from 'lodash';
 
 import {
@@ -69,7 +70,9 @@ const propTypes = {
   //   of value `` supplied to `EditCustomFieldsRecord`, expected one of [null,null].
   // so we're stuck with something less precise, but at least it doesn't warn:
   finalFormCustomFieldsValues: PropTypes.object,
+  finalFormInstance: PropTypes.object,
   formName: PropTypes.string,
+  isCreateMode: PropTypes.bool,
   isReduxForm: PropTypes.bool,
   onComponentLoad: PropTypes.func,
   onToggle: PropTypes.func,
@@ -89,6 +92,7 @@ const EditCustomFieldsRecord = ({
   backendModuleName,
   entityType,
   columnCount = 4,
+  isCreateMode = false,
   isReduxForm = false,
   formName,
   changeFinalFormField,
@@ -96,6 +100,7 @@ const EditCustomFieldsRecord = ({
   fieldComponent: Field,
   reduxFormCustomFieldsValues,
   finalFormCustomFieldsValues,
+  finalFormInstance,
   configNamePrefix,
   scope,
   sectionId,
@@ -157,6 +162,9 @@ const EditCustomFieldsRecord = ({
 
   useEffect(() => {
     const initializeFields = () => {
+      const fieldsToInitialize = {};
+      let hasDefaultValues = false;
+
       customFields.forEach(cf => {
         const fieldHasOptions = (
           cf.type === fieldTypes.SELECT ||
@@ -175,13 +183,40 @@ const EditCustomFieldsRecord = ({
             ? cf.selectField.options.values.filter(option => option.default).map(option => option.id)
             : cf.selectField.options.values.find(option => option.default)?.id;
 
-          if (isReduxForm) {
-            changeReduxFormField(`customFields.${cf.refId}`, valueToSet);
-          } else {
-            changeFinalFormField(`customFields.${cf.refId}`, valueToSet);
+          // Only set value if there are default options
+          if (valueToSet !== undefined && (Array.isArray(valueToSet) ? valueToSet.length > 0 : true)) {
+            fieldsToInitialize[cf.refId] = valueToSet;
+            hasDefaultValues = true;
           }
         }
       });
+
+      if (hasDefaultValues) {
+        if (isReduxForm) {
+          Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
+            changeReduxFormField(`customFields.${refId}`, value);
+          });
+        } else {
+          if (isCreateMode && finalFormInstance?.restart) {
+            // For create scenarios, use restart to set as initial values (won't mark form dirty)
+            const currentValues = finalFormInstance.getState().values;
+            const newInitialValues = {
+              ...currentValues,
+              customFields: {
+                ...currentValues.customFields,
+                ...fieldsToInitialize
+              }
+            };
+
+            finalFormInstance.restart(newInitialValues);
+          } else {
+            // For edit scenarios or fallback, use change method (will mark form dirty as expected)
+            Object.entries(fieldsToInitialize).forEach(([refId, value]) => {
+              changeFinalFormField(`customFields.${refId}`, value);
+            });
+          }
+        }
+      }
     };
 
     if (customFieldsLoaded && sectionTitleLoaded) {
@@ -303,6 +338,7 @@ const EditCustomFieldsRecord = ({
           value: option,
           label: customField.selectField.options.values.find(_option => _option.id === option)?.value || option,
         })),
+        isEqual,
       });
     } else if (customField.type === fieldTypes.CHECKBOX) {
       return createCustomFieldRenderFunction(customField)({ type: 'checkbox' });

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -35,11 +35,11 @@ describe('EditCustomFieldsRecord', () => {
 
   const renderComponent = (props = {}) => {
     mockFinalFormInstance = {
-      getState: sinon.stub().returns({ 
-        values: { 
+      getState: sinon.stub().returns({
+        values: {
           customFields: {},
           existingField: 'existing-value'
-        } 
+        }
       }),
       restart: sinon.spy(),
     };
@@ -93,7 +93,7 @@ describe('EditCustomFieldsRecord', () => {
   });
 
   describe('when custom fields are loaded', () => {
-    beforeEach(async function () {
+    beforeEach(async () => {
       await renderComponent();
     });
 
@@ -184,7 +184,7 @@ describe('EditCustomFieldsRecord', () => {
 
   describe('Create mode vs Edit mode behavior', () => {
     describe('when isCreateMode is true', () => {
-      beforeEach(async function () {
+      beforeEach(async () => {
         await renderComponent({
           isCreateMode: true,
         });
@@ -199,7 +199,7 @@ describe('EditCustomFieldsRecord', () => {
       it('should merge existing form values with new default values when restarting', () => {
         return converge(() => {
           const newInitialValues = mockFinalFormInstance.restart.getCall(0).args[0];
-          
+
           expect(newInitialValues.existingField).to.equal('existing-value');
           expect(newInitialValues.customFields).to.be.an('object');
         });
@@ -207,7 +207,7 @@ describe('EditCustomFieldsRecord', () => {
     });
 
     describe('when isCreateMode is false (edit mode)', () => {
-      beforeEach(async function () {
+      beforeEach(async () => {
         await renderComponent({
           isCreateMode: false,
         });
@@ -222,7 +222,7 @@ describe('EditCustomFieldsRecord', () => {
     });
 
     describe('when finalFormInstance is not available', () => {
-      beforeEach(async function () {
+      beforeEach(async () => {
         await renderComponent({
           isCreateMode: true,
           finalFormInstance: null,

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -31,8 +31,19 @@ describe('EditCustomFieldsRecord', () => {
   const changeReduxFormField = sinon.spy();
   const onComponentLoad = sinon.spy();
   const onToggle = sinon.spy();
+  let mockFinalFormInstance;
 
   const renderComponent = (props = {}) => {
+    mockFinalFormInstance = {
+      getState: sinon.stub().returns({ 
+        values: { 
+          customFields: {},
+          existingField: 'existing-value'
+        } 
+      }),
+      restart: sinon.spy(),
+    };
+
     const FormComponent = () => (
       <Form onSubmit={() => {}}>
         {({ form: { getState } }) => (
@@ -41,6 +52,7 @@ describe('EditCustomFieldsRecord', () => {
             backendModuleName="users-test"
             changeFinalFormField={changeFinalFormField}
             finalFormCustomFieldsValues={getState().values.customFields}
+            finalFormInstance={mockFinalFormInstance}
             entityType="user"
             expanded
             formName="custom-fields-test"
@@ -63,8 +75,7 @@ describe('EditCustomFieldsRecord', () => {
     changeFinalFormField.resetHistory();
     changeReduxFormField.resetHistory();
     onToggle.resetHistory();
-
-    await renderComponent();
+    onComponentLoad.resetHistory();
   });
 
   describe('when there are no custom fields', () => {
@@ -72,6 +83,8 @@ describe('EditCustomFieldsRecord', () => {
       this.server.get('/custom-fields', {
         'customFields': [],
       });
+
+      await renderComponent();
     });
 
     it('should not have any a11y issues', () => runAxeTest());
@@ -80,6 +93,10 @@ describe('EditCustomFieldsRecord', () => {
   });
 
   describe('when custom fields are loaded', () => {
+    beforeEach(async function () {
+      await renderComponent();
+    });
+
     it('should not have any a11y issues', () => runAxeTest());
 
     it('should label and set id of accordion', () => CustomFieldsRecordForm('Custom Fields Test').has({ id: 'test-accordion-id' }));
@@ -87,7 +104,9 @@ describe('EditCustomFieldsRecord', () => {
     it('should show all visible custom fields', () => CustomFieldsRecordForm('Custom Fields Test').has({ fieldCount: 7 }));
 
     it('should call onComponentLoad', () => {
-      expect(onComponentLoad.called).to.be.true;
+      return converge(() => {
+        expect(onComponentLoad.called).to.be.true;
+      });
     });
 
     describe('when Single Select field has a default option', () => {
@@ -160,6 +179,104 @@ describe('EditCustomFieldsRecord', () => {
 
     it('should display only fields with `displayInAccordion` missing or equal to "default"', () => {
       return CustomFieldsRecordForm('Custom Fields label').has({ fieldCount: 6 });
+    });
+  });
+
+  describe('Create mode vs Edit mode behavior', () => {
+    describe('when isCreateMode is true', () => {
+      beforeEach(async function () {
+        await renderComponent({
+          isCreateMode: true,
+        });
+      });
+
+      it('should use finalFormInstance.restart to set initial values without marking form dirty', () => {
+        return converge(() => {
+          expect(mockFinalFormInstance.restart.called).to.be.true;
+        });
+      });
+
+      it('should merge existing form values with new default values when restarting', () => {
+        return converge(() => {
+          const newInitialValues = mockFinalFormInstance.restart.getCall(0).args[0];
+          
+          expect(newInitialValues.existingField).to.equal('existing-value');
+          expect(newInitialValues.customFields).to.be.an('object');
+        });
+      });
+    });
+
+    describe('when isCreateMode is false (edit mode)', () => {
+      beforeEach(async function () {
+        await renderComponent({
+          isCreateMode: false,
+        });
+      });
+
+      it('should use changeFinalFormField instead of restart for edit scenarios', () => {
+        return converge(() => {
+          expect(mockFinalFormInstance.restart.called).to.be.false;
+          expect(changeFinalFormField.called).to.be.true;
+        });
+      });
+    });
+
+    describe('when finalFormInstance is not available', () => {
+      beforeEach(async function () {
+        await renderComponent({
+          isCreateMode: true,
+          finalFormInstance: null,
+        });
+      });
+
+      it('should fallback to changeFinalFormField even in create mode', () => {
+        return converge(() => {
+          expect(changeFinalFormField.called).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('when no default values are present', () => {
+    beforeEach(async function () {
+      this.server.get('/custom-fields', {
+        customFields: [
+          {
+            id: '3',
+            name: 'Single select',
+            refId: 'single_select-1',
+            type: 'SINGLE_SELECT_DROPDOWN',
+            entityType: 'user',
+            visible: true,
+            required: false,
+            order: 3,
+            helpText: '',
+            selectField: {
+              multiSelect: false,
+              options: {
+                values: [{
+                  id: 'opt_0',
+                  value: 'option 1',
+                  default: false,
+                }, {
+                  id: 'opt_1',
+                  value: 'option 2',
+                  default: false,
+                }],
+              }
+            }
+          },
+        ],
+      });
+
+      await renderComponent();
+    });
+
+    it('should not initialize fields', () => {
+      return converge(() => {
+        expect(mockFinalFormInstance.restart.called).to.be.false;
+        expect(changeFinalFormField.called).to.be.false;
+      });
     });
   });
 });

--- a/lib/CustomFields/readme.md
+++ b/lib/CustomFields/readme.md
@@ -175,6 +175,8 @@ import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
     <EditCustomFieldsRecord
       changeFinalFormField={change}
       finalFormCustomFieldsValues={getState().values.customFields}
+      finalFormInstance={form}
+      isCreateMode={!initialValues.id}
       entityType="user"
       backendModuleName="users"
       accordionId="customFields"
@@ -201,6 +203,7 @@ Name | type | description | required | default
 `entityType` | string | used to filter custom files by particular entity type |true
 `expanded` | boolean | indicates if the accordion is open | true |
 `fieldComponent` | func | Field component | true |
+`isCreateMode` | boolean | indicates if the component is being used in create mode. When true, default values are set as initial values without marking the form dirty. When false, default values mark the form as dirty (edit mode behavior) | false | false
 `onComponentLoad` | func | callback function invoked when all form fields have been rendered | false |
 `onToggle` | func | callback for toggling the accordion open/closed | true |
 `scope` | string | used to use mod-settings API instead of mod-configuration                                  |false
@@ -218,3 +221,4 @@ Name | type | description | required | default
 --- | --- | --- | --- | ---
 `changeFinalFormField` | func | a function used to change `final-form` field value | required when final-form is used |
 `finalFormCustomFieldsValues` | object | custom fields values stored in final-form state. Can be retrieved using `<Form>` render props: `{form.getState().values.customFields}` | required when final-form is used
+`finalFormInstance` | object | the final-form instance object. Used for advanced form operations like `restart()` when `isCreateMode` is true. Can be retrieved using `<Form>` render props: `{form}` | false |


### PR DESCRIPTION
## Purpose

Improve the handling of custom fields default values in `EditCustomFieldsRecord` component to distinguish between create and edit modes, ensuring proper form behavior:

When a **Multi-select**, **Radio button set**, or **Single select** field exists in the custom field settings:

**Create page**:
* No default option selected in the custom field -> “Save & close” **disabled**. <- **is fixed in this PR**
* Default option selected in the custom field -> “Save & close“ **disabled**.  <- **is fixed in this PR**

**Edit page**: 
* No default option selected in the custom field -> “Save & close“ **disabled**.  <- **is fixed in this PR**
* Default option selected in the custom field & custom field value is populated on existing record -> “Save & close“ **disabled**.
* Default option selected in the custom field & custom field value is **not** populated on existing record -> “Save & close“ **enabled**.

## Description

This PR introduces several key improvements to the `EditCustomFieldsRecord` component:

### Key Changes:
1. **Added `isCreateMode` prop**: A new boolean prop that indicates whether the component is being used in create or edit mode
2. **Added `finalFormInstance` prop**: Allows access to the final-form instance for operations like `restart()`
3. **Changed initialization logic**: 
   - In **create mode**: Uses `finalFormInstance.restart()` to set default values as initial values without marking the form dirty
4. **Improved value existence checking**: Only sets default values when fields have a default option selected

This enhancement ensures that custom fields behave correctly in different contexts:
- **Create forms**: Default values are set without marking the form dirty
- **Edit forms**: Default values (when needed) appropriately mark the form as dirty, indicating changes to be saved

The changes are backward compatible and only affect behavior when the new props are explicitly provided.

## Issues
[STSMACOM-922](https://folio-org.atlassian.net/browse/STSMACOM-922)

## Sceencasts

https://github.com/user-attachments/assets/82f78e25-28bb-4b6c-82ee-af189367c38c


