### PR TITLE
STSMACOM-953 test tightening for ProfilePicure, ViewMetaData

### DIFF
--- a/lib/ProfilePicture/tests/ProfilePicture-test.js
+++ b/lib/ProfilePicture/tests/ProfilePicture-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { describe, beforeEach, afterEach, it } from 'mocha';
-import sinon from 'sinon';
+import { describe, beforeEach, it } from 'mocha';
 import {
   HTML,
   runAxeTest
@@ -9,7 +8,6 @@ import {
 import {
   mount,
   setupApplication,
-  wait,
 } from '../../../tests/helpers';
 
 import ProfilePicture from '../ProfilePicture';
@@ -30,35 +28,18 @@ describe('ProfilePicture', () => {
     );
   };
 
-  beforeEach(() => {
-    const stub = sinon.stub(window, 'fetch');
-    stub.onCall(0).returns(Promise.resolve(new window.Response(JSON.stringify({
-      profile_picture_blob: 'blob',
-    }), {
-      status: 200,
-      headers: {
-        'Content-type': 'application/json'
-      },
-    })));
-  });
-
-  afterEach(() => {
-    window.fetch.restore();
-  });
-
-  describe('render Profile Picture with profile picture UUID or URL', () => {
+  describe('render Profile Picture given URL', () => {
     beforeEach(async () => {
       await renderComponent({
         profilePictureLink: 'https://url-to/image.jpg'
       });
-      await wait(200);
     });
 
     it('should not have any a11y issues', () => runAxeTest());
 
     // This test fails in CI, as the element may be present, but not visible.
     // It's dependably visible locally.
-    it.skip('should render and display Profile Picture component with correct Props', () => profilePicture.exists());
+    it('should render and display Profile Picture component with correct Props', () => profilePicture.exists());
   });
 
   describe('render Profile Picture without profile picture UUID or URL', () => {

--- a/lib/ProfilePicture/tests/ProfilePicture-test.js
+++ b/lib/ProfilePicture/tests/ProfilePicture-test.js
@@ -37,8 +37,6 @@ describe('ProfilePicture', () => {
 
     it('should not have any a11y issues', () => runAxeTest());
 
-    // This test fails in CI, as the element may be present, but not visible.
-    // It's dependably visible locally.
     it('should render and display Profile Picture component with correct Props', () => profilePicture.exists());
   });
 

--- a/lib/ProfilePicture/utils/useProfilePicture.js
+++ b/lib/ProfilePicture/utils/useProfilePicture.js
@@ -25,6 +25,11 @@ const useProfilePicture = ({ profilePictureId, isProfilePictureAUUID }, options 
   const ky = useOkapiKy();
   const stripes = useStripes();
   const [namespace] = useNamespace({ key: 'get-profile-picture-of-a-user' });
+
+  // react-query won't coerce enabled to a boolean
+  // https://open-libr-foundation.slack.com/archives/C210UCHQ9/p1718897723266479
+  const enabled = Boolean(stripes.hasInterface('users', '16.1') && Boolean(profilePictureId) && isProfilePictureAUUID);
+
   const {
     isFetching,
     isLoading,
@@ -35,7 +40,7 @@ const useProfilePicture = ({ profilePictureId, isProfilePictureAUUID }, options 
       return ky.get(`${API}/${profilePictureId}`).json();
     },
     {
-      enabled: stripes.hasInterface('users', '16.1') && Boolean(profilePictureId) && isProfilePictureAUUID,
+      enabled,
       ...options,
     }
   );

--- a/tests/network/config.js
+++ b/tests/network/config.js
@@ -340,4 +340,21 @@ export default function config() {
 
     return { items: [] };
   });
+
+  this.get('/users', {
+    'users': [
+      {
+        'username': 'username',
+        'id': 'SYSTEM_USER',
+        'active': true,
+        'personal': {
+          'lastName': 'ADMINISTRATOR',
+          'firstName': 'DIKU',
+          'email': 'admin@diku.example.org',
+          'addresses': [
+          ]
+        }
+      }
+    ]
+  });
 }


### PR DESCRIPTION
* Correctly coerce `enabled` to a boolean as required by react-query
* Supply `/users` as a mirage endpoint to assist tests

`enabled` was the main thing here, causing related to tests to fail reliably such that they were disabled with the comment "works locally". They never ran locally for me. All of this came to a head when trying to publish a release branch with dependencies installed against production releases. The same tests ran fine when built against npm-folioci, which doesn't make any sense to me, but there it is. Anyway. Now they run against CI, and they run against prod. 

Refs [STSMACOM-953](https://folio-org.atlassian.net/browse/STSMACOM-953)