### PR TITLE
STSMACOM-929: `ViewCustomFieldsRecord` - make `calloutRef` available after the component is mounted to prevent a page crash when the section title fetch fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Supply Personal Data Disclosure form. Refs STSMACOM-909.
 * `<ViewCustomFieldsRecord>` - render `DATE_PICKER` values in UTC so the displayed day matches the saved value in non-UTC timezones. Fixes STSMACOM-950.
+* `ViewCustomFieldsRecord` - make `calloutRef` available after the component is mounted to prevent a page crash when the section title fetch fails. Fixes STSMACOM-929.
 
 ## 10.1.0 IN PROGRESS
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -16,7 +16,6 @@ import {
 
 import {
   Accordion,
-  Callout,
   Col,
   Row,
   InfoPopover,

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -127,7 +127,7 @@ const EditCustomFieldsRecord = ({
     scope,
   });
 
-  const { calloutRef } = useLoadingErrorCallout({
+  useLoadingErrorCallout({
     customFieldsFetchFailed,
     sectionTitleFetchFailed,
   });
@@ -138,8 +138,10 @@ const EditCustomFieldsRecord = ({
   const columnWidth = rowShapes / columnCount;
   const customFieldsAccordionTitle = sectionTitle.value || customFieldsLabel;
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent displaying
-  // an infinite loader from appearing for an accordion when the title fetch fails.
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent the accordion
+  // title from staying on the loading spinner if the section-title fetch fails. If the
+  // request fails, a callout will surface the error; checking for fetch failure here
+  // would prevent the default title from showing.
   const sectionTitleLoaded = !isLoadingSectionTitle;
 
   const [isValid, setIsValid] = useState(true);
@@ -406,7 +408,6 @@ const EditCustomFieldsRecord = ({
       {(!customFieldsLoaded || customFieldsIsVisible) && (
         renderCustomFields()
       )}
-      <Callout ref={calloutRef} />
     </>
   );
 };

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -127,14 +127,20 @@ const EditCustomFieldsRecord = ({
     scope,
   });
 
-  const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
+  const { calloutRef } = useLoadingErrorCallout({
+    customFieldsFetchFailed,
+    sectionTitleFetchFailed,
+  });
+
   const customFieldsIsVisible = !!customFields?.length && customFields?.some(customField => customField.visible);
   const visibleCustomFields = customFields?.filter(customField => customField.visible);
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const columnWidth = rowShapes / columnCount;
   const customFieldsAccordionTitle = sectionTitle.value || customFieldsLabel;
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  const sectionTitleLoaded = !isLoadingSectionTitle && !sectionTitleFetchFailed;
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent displaying
+  // an infinite loader from appearing for an accordion when the title fetch fails.
+  const sectionTitleLoaded = !isLoadingSectionTitle;
 
   const [isValid, setIsValid] = useState(true);
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/tests/EditCustomFieldsRecord-test.js
@@ -13,6 +13,7 @@ import {
   Select,
   including,
   Accordion,
+  Callout,
 } from '@folio/stripes-testing';
 
 import {
@@ -327,6 +328,27 @@ describe('EditCustomFieldsRecord', () => {
         const fieldValue = formApi.getState().values.customFields?.['single_select-1'];
         expect(fieldValue).to.be.undefined;
       });
+    });
+  });
+
+  describe('when the section title fetch fails', () => {
+    beforeEach(async function () {
+      this.server.get('/settings/entries', () => {
+        throw new Error('403 Forbidden');
+      });
+
+      await renderComponent({
+        scope: 'test-scope',
+        sectionId: 'default',
+      });
+    });
+
+    it('should display a toast error', () => {
+      return Callout().exists();
+    });
+
+    it('should display the default accordion title', () => {
+      return Accordion('Custom fields').exists();
     });
   });
 });

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -103,8 +103,10 @@ const EditCustomFieldsSettings = ({
   // This prevents unnecessary requests that can even fail if some custom fields have been deleted
   // and prevents opening an accordion when initialValues contains stale custom fields.
   const customFieldsLoaded = !isFetchingCustomFields && !customFieldsFetchFailed;
-  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent
-  // displaying an infinite loader from appearing when the title fetch fails.
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent the page
+  // from staying on the loading spinner if the section-title fetch fails. If the
+  // request fails, a callout will surface the error; checking for fetch failure here
+  // would prevent the default title from showing.
   const sectionTitleLoaded = !isLoadingSectionTitle;
   const latestCustomFields = customFieldsLoaded ? customFields : null;
 
@@ -115,7 +117,6 @@ const EditCustomFieldsSettings = ({
   } = useOptionsStatsFetch(okapi, backendModuleId, latestCustomFields, entityType);
 
   const {
-    calloutRef,
     showErrorNotification
   } = useLoadingErrorCallout({
     customFieldsFetchFailed,
@@ -363,7 +364,6 @@ const EditCustomFieldsSettings = ({
           />
         )
       }
-      <Callout ref={calloutRef} />
     </>
   );
 };

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -11,7 +11,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
   Icon,
-  Callout,
 } from '@folio/stripes-components';
 
 import { CustomFieldsForm } from '../../components';

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/EditCustomFieldsSettings.js
@@ -103,7 +103,9 @@ const EditCustomFieldsSettings = ({
   // This prevents unnecessary requests that can even fail if some custom fields have been deleted
   // and prevents opening an accordion when initialValues contains stale custom fields.
   const customFieldsLoaded = !isFetchingCustomFields && !customFieldsFetchFailed;
-  const sectionTitleLoaded = !isLoadingSectionTitle && !sectionTitleFetchFailed;
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent
+  // displaying an infinite loader from appearing when the title fetch fails.
+  const sectionTitleLoaded = !isLoadingSectionTitle;
   const latestCustomFields = customFieldsLoaded ? customFields : null;
 
   const {
@@ -115,8 +117,11 @@ const EditCustomFieldsSettings = ({
   const {
     calloutRef,
     showErrorNotification
-  } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed || optionsStatsFetchFailed);
-
+  } = useLoadingErrorCallout({
+    customFieldsFetchFailed,
+    sectionTitleFetchFailed,
+    optionsStatsFetchFailed,
+  });
 
   const [submitting, setSubmitting] = useState(false);
   const [fieldsToDelete, setFieldsToDelete] = useState([]);

--- a/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/EditCustomFieldsSettings/tests/EditCustomFieldsSettings-test.js
@@ -373,4 +373,24 @@ describe('EditCustomFieldsSettings', () => {
       });
     });
   });
+
+  describe('when the section title fetch fails', () => {
+    beforeEach(async function () {
+      this.server.get('/settings/entries', () => {
+        throw new Error('403 Forbidden');
+      });
+
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should display a toast error', () => {
+      return Callout().exists();
+    });
+
+    it('should display the default accordion title', () => {
+      return TextField('Accordion title*').has({ value: 'Custom fields' });
+    });
+  });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -241,16 +241,14 @@ const ViewCustomFieldsRecord = ({
   }
 
   return (
-    <>
-      <Accordion
-        {...accordionProps}
-      >
-        {customFieldsLoaded && formattedCustomFields.length
-          ? renderChunkedCustomFields()
-          : noCustomFieldsFoundLabel
-        }
-      </Accordion>
-    </>
+    <Accordion
+      {...accordionProps}
+    >
+      {customFieldsLoaded && formattedCustomFields.length
+        ? renderChunkedCustomFields()
+        : noCustomFieldsFoundLabel
+      }
+    </Accordion>
   );
 };
 

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -95,7 +95,7 @@ const ViewCustomFieldsRecord = ({
 
   const { formatDate } = useIntl();
 
-  const { calloutRef } = useLoadingErrorCallout({
+  useLoadingErrorCallout({
     customFieldsFetchFailed,
     sectionTitleFetchFailed,
   });
@@ -107,8 +107,10 @@ const ViewCustomFieldsRecord = ({
   });
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent displaying
-  // an infinite loader from appearing for an accordion when the title fetch fails.
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent the accordion
+  // title from staying on the loading spinner if the section-title fetch fails. If the
+  // request fails, a callout will surface the error; checking for fetch failure here
+  // would prevent the default title from showing.
   const sectionTitleLoaded = !isLoadingSectionTitle;
 
   const displayWhenClosed = (sectionTitleLoaded && customFieldsLoaded)
@@ -255,7 +257,6 @@ const ViewCustomFieldsRecord = ({
   return (
     <>
       {renderContent()}
-      <Callout ref={calloutRef} />
     </>
   );
 };

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -95,7 +95,10 @@ const ViewCustomFieldsRecord = ({
 
   const { formatDate } = useIntl();
 
-  const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
+  const { calloutRef } = useLoadingErrorCallout({
+    customFieldsFetchFailed,
+    sectionTitleFetchFailed,
+  });
   const columnWidth = rowShapes / columnCount;
 
   const visibleCustomFields = customFields?.filter(customField => {
@@ -104,7 +107,9 @@ const ViewCustomFieldsRecord = ({
   });
   const formattedCustomFields = chunk(visibleCustomFields, columnCount);
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  const sectionTitleLoaded = !isLoadingSectionTitle && !sectionTitleFetchFailed;
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent displaying
+  // an infinite loader from appearing for an accordion when the title fetch fails.
+  const sectionTitleLoaded = !isLoadingSectionTitle;
 
   const displayWhenClosed = (sectionTitleLoaded && customFieldsLoaded)
     ? (<Badge>{visibleCustomFields.length}</Badge>)
@@ -202,40 +207,40 @@ const ViewCustomFieldsRecord = ({
     ));
   };
 
-  if (sectionId || !showAccordion) {
-    if (isLoadingCustomFields) {
-      return (
-        <Col md={columnWidth}>
-          <Icon icon="spinner-ellipsis" />
-        </Col>
-      );
-    }
-
-    if (customFieldsFetchFailed || !visibleCustomFields?.length) {
-      return null;
-    }
-
-    if (sectionId) {
-      if (sectionId === CUSTOM_FIELDS_SECTION_ID && showAccordion) {
+  const renderContent = () => {
+    if (sectionId || !showAccordion) {
+      if (isLoadingCustomFields) {
         return (
-          <Accordion
-            {...accordionProps}
-          >
-            {renderChunkedCustomFields()}
-          </Accordion>
+          <Col md={columnWidth}>
+            <Icon icon="spinner-ellipsis" />
+          </Col>
         );
       }
 
-      return visibleCustomFields.map(renderCustomField);
+      if (customFieldsFetchFailed || !visibleCustomFields?.length) {
+        return null;
+      }
+
+      if (sectionId) {
+        if (sectionId === CUSTOM_FIELDS_SECTION_ID && showAccordion) {
+          return (
+            <Accordion
+              {...accordionProps}
+            >
+              {renderChunkedCustomFields()}
+            </Accordion>
+          );
+        }
+
+        return visibleCustomFields.map(renderCustomField);
+      }
+
+      if (!showAccordion) {
+        return visibleCustomFields.map(renderCustomField);
+      }
     }
 
-    if (!showAccordion) {
-      return visibleCustomFields.map(renderCustomField);
-    }
-  }
-
-  return (
-    <>
+    return (
       <Accordion
         {...accordionProps}
       >
@@ -244,6 +249,12 @@ const ViewCustomFieldsRecord = ({
           : noCustomFieldsFoundLabel
         }
       </Accordion>
+    );
+  };
+
+  return (
+    <>
+      {renderContent()}
       <Callout ref={calloutRef} />
     </>
   );

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -5,7 +5,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   Accordion,
-  Callout,
   KeyValue,
   NoValue,
   Row,

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/ViewCustomFieldsRecord.js
@@ -209,40 +209,40 @@ const ViewCustomFieldsRecord = ({
     ));
   };
 
-  const renderContent = () => {
-    if (sectionId || !showAccordion) {
-      if (isLoadingCustomFields) {
+  if (sectionId || !showAccordion) {
+    if (isLoadingCustomFields) {
+      return (
+        <Col md={columnWidth}>
+          <Icon icon="spinner-ellipsis" />
+        </Col>
+      );
+    }
+
+    if (customFieldsFetchFailed || !visibleCustomFields?.length) {
+      return null;
+    }
+
+    if (sectionId) {
+      if (sectionId === CUSTOM_FIELDS_SECTION_ID && showAccordion) {
         return (
-          <Col md={columnWidth}>
-            <Icon icon="spinner-ellipsis" />
-          </Col>
+          <Accordion
+            {...accordionProps}
+          >
+            {renderChunkedCustomFields()}
+          </Accordion>
         );
       }
 
-      if (customFieldsFetchFailed || !visibleCustomFields?.length) {
-        return null;
-      }
-
-      if (sectionId) {
-        if (sectionId === CUSTOM_FIELDS_SECTION_ID && showAccordion) {
-          return (
-            <Accordion
-              {...accordionProps}
-            >
-              {renderChunkedCustomFields()}
-            </Accordion>
-          );
-        }
-
-        return visibleCustomFields.map(renderCustomField);
-      }
-
-      if (!showAccordion) {
-        return visibleCustomFields.map(renderCustomField);
-      }
+      return visibleCustomFields.map(renderCustomField);
     }
 
-    return (
+    if (!showAccordion) {
+      return visibleCustomFields.map(renderCustomField);
+    }
+  }
+
+  return (
+    <>
       <Accordion
         {...accordionProps}
       >
@@ -251,12 +251,6 @@ const ViewCustomFieldsRecord = ({
           : noCustomFieldsFoundLabel
         }
       </Accordion>
-    );
-  };
-
-  return (
-    <>
-      {renderContent()}
     </>
   );
 };

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -7,6 +7,7 @@ import {
   HTML,
   runAxeTest,
   Accordion,
+  Callout,
 } from '@folio/stripes-testing';
 
 import {
@@ -147,5 +148,26 @@ describe('ViewCustomFieldsRecord', () => {
     });
 
     it('should display NoValue for all fields', () => viewCustomFields.has({ fieldCount: 7 }));
+  });
+
+  describe('when the section title fetch fails', () => {
+    beforeEach(async function() {
+      this.server.get('/settings/entries', () => {
+        throw new Error('403 Forbidden');
+      });
+
+      await renderComponent({
+        scope: 'test-scope',
+        sectionId: 'default',
+      });
+    });
+
+    it('should display a toast error', () => {
+      return Callout().exists();
+    });
+
+    it('should display the default accordion title', () => {
+      return Accordion('Custom fields').exists();
+    });
   });
 });

--- a/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js
@@ -151,7 +151,7 @@ describe('ViewCustomFieldsRecord', () => {
   });
 
   describe('when the section title fetch fails', () => {
-    beforeEach(async function() {
+    beforeEach(async function () {
       this.server.get('/settings/entries', () => {
         throw new Error('403 Forbidden');
       });

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -12,7 +12,6 @@ import {
   Icon,
   AccordionSet,
   KeyValue,
-  Callout,
 } from '@folio/stripes-components';
 
 import { isEmpty } from 'lodash';

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -79,13 +79,19 @@ const ViewCustomFieldsSettings = ({
     scope,
   });
 
-  const { calloutRef } = useLoadingErrorCallout(customFieldsFetchFailed || sectionTitleFetchFailed);
+  const { calloutRef } = useLoadingErrorCallout({
+    customFieldsFetchFailed,
+    sectionTitleFetchFailed,
+  });
+
   const paneTitleRef = useRef(null);
 
   const noDataSaved = isEmpty(customFields) && !sectionTitle.value;
   const sectionTitleValue = sectionTitle.value || intl.formatMessage({ id: 'stripes-smart-components.customFields.recordAccordion.defaultName' });
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  const sectionTitleLoaded = !isLoadingSectionTitle && !sectionTitleFetchFailed;
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent
+  // displaying an infinite loader from appearing when the title fetch fails.
+  const sectionTitleLoaded = !isLoadingSectionTitle;
 
   useEffect(() => {
     if (paneTitleRef.current) {

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/ViewCustomFieldsSettings.js
@@ -79,7 +79,7 @@ const ViewCustomFieldsSettings = ({
     scope,
   });
 
-  const { calloutRef } = useLoadingErrorCallout({
+  useLoadingErrorCallout({
     customFieldsFetchFailed,
     sectionTitleFetchFailed,
   });
@@ -89,8 +89,10 @@ const ViewCustomFieldsSettings = ({
   const noDataSaved = isEmpty(customFields) && !sectionTitle.value;
   const sectionTitleValue = sectionTitle.value || intl.formatMessage({ id: 'stripes-smart-components.customFields.recordAccordion.defaultName' });
   const customFieldsLoaded = !isLoadingCustomFields && !customFieldsFetchFailed;
-  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent
-  // displaying an infinite loader from appearing when the title fetch fails.
+  // Don't use `!sectionTitleFetchFailed` in sectionTitleLoaded to prevent the page
+  // from staying on the loading spinner if the section-title fetch fails. If the
+  // request fails, a callout will surface the error; checking for fetch failure here
+  // would prevent the default title from showing.
   const sectionTitleLoaded = !isLoadingSectionTitle;
 
   useEffect(() => {
@@ -193,7 +195,6 @@ const ViewCustomFieldsSettings = ({
             size="large"
           />
         )}
-      <Callout ref={calloutRef} />
     </>
   );
 };

--- a/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
+++ b/lib/CustomFields/pages/ViewCustomFieldsSettings/tests/ViewCustomFieldsSettings-test.js
@@ -4,6 +4,7 @@ import { describe, beforeEach, it } from 'mocha';
 import {
   HTML,
   runAxeTest,
+  Callout,
 } from '@folio/stripes-testing';
 
 import {
@@ -184,6 +185,26 @@ describe('ViewCustomFieldsSettings', () => {
         await CFAccordionInteractor({ index: 1 }).clickHeader();
         return CFAccordionInteractor({ index: 1 }).find(CFKeyValueInteractor('Display in accordion')).has({ value: 'Custom Fields label' });
       });
+    });
+  });
+
+  describe('when the section title fetch fails', () => {
+    beforeEach(async function () {
+      this.server.get('/settings/entries', () => {
+        throw new Error('403 Forbidden');
+      });
+
+      await renderComponent({
+        scope: 'test-scope',
+      });
+    });
+
+    it('should display the default label', () => {
+      return CFKeyValueInteractor('Accordion title').has({ value: 'Custom fields' });
+    });
+
+    it('should display a toast error', () => {
+      return Callout().exists();
     });
   });
 });

--- a/lib/CustomFields/utils/useLoadingErrorCallout.js
+++ b/lib/CustomFields/utils/useLoadingErrorCallout.js
@@ -1,22 +1,52 @@
 import React, { useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-const useLoadingErrorCallout = hasError => {
+const useLoadingErrorCallout = ({
+  customFieldsFetchFailed,
+  sectionTitleFetchFailed,
+  optionsStatsFetchFailed,
+}) => {
   const calloutRef = useRef();
-  const showErrorNotification = () => {
+
+  const showCustomFieldsUpdateErrorNotification = () => {
     calloutRef.current.sendCallout({
       type: 'error',
       message: (<FormattedMessage id="stripes-smart-components.customFields.errorOccurred" />)
     });
   };
 
-  useEffect(() => {
-    if (hasError) {
-      showErrorNotification();
-    }
-  }, [hasError]);
+  const showCustomFieldsRetrieveErrorNotification = () => {
+    calloutRef.current.sendCallout({
+      type: 'error',
+      message: (<FormattedMessage id="stripes-smart-components.customFields.error.get" />)
+    });
+  };
 
-  return { calloutRef, showErrorNotification };
+  const showSectionTitleRetrieveErrorNotification = () => {
+    calloutRef.current.sendCallout({
+      type: 'error',
+      message: (<FormattedMessage id="stripes-smart-components.customFields.sectionTitle.error.get" />)
+    });
+  };
+
+  const hasCustomFieldsRetrievalError = customFieldsFetchFailed || optionsStatsFetchFailed;
+
+  useEffect(() => {
+    if (hasCustomFieldsRetrievalError) {
+      showCustomFieldsRetrieveErrorNotification();
+    }
+  }, [hasCustomFieldsRetrievalError]);
+
+  useEffect(() => {
+    if (sectionTitleFetchFailed) {
+      showSectionTitleRetrieveErrorNotification();
+    }
+  }, [sectionTitleFetchFailed]);
+
+  return {
+    calloutRef,
+    showErrorNotification: showCustomFieldsUpdateErrorNotification,
+  };
 };
 
 export default useLoadingErrorCallout;

--- a/lib/CustomFields/utils/useLoadingErrorCallout.js
+++ b/lib/CustomFields/utils/useLoadingErrorCallout.js
@@ -1,29 +1,34 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
+
+import { useCallout } from '@folio/stripes-core';
 
 const useLoadingErrorCallout = ({
   customFieldsFetchFailed,
   sectionTitleFetchFailed,
   optionsStatsFetchFailed,
 }) => {
-  const calloutRef = useRef();
+  const callout = useCallout();
 
   const showCustomFieldsUpdateErrorNotification = () => {
-    calloutRef.current.sendCallout({
+    callout.sendCallout({
+      dedupe: true,
       type: 'error',
       message: (<FormattedMessage id="stripes-smart-components.customFields.errorOccurred" />)
     });
   };
 
   const showCustomFieldsRetrieveErrorNotification = () => {
-    calloutRef.current.sendCallout({
+    callout.sendCallout({
+      dedupe: true,
       type: 'error',
       message: (<FormattedMessage id="stripes-smart-components.customFields.error.get" />)
     });
   };
 
   const showSectionTitleRetrieveErrorNotification = () => {
-    calloutRef.current.sendCallout({
+    callout.sendCallout({
+      dedupe: true,
       type: 'error',
       message: (<FormattedMessage id="stripes-smart-components.customFields.sectionTitle.error.get" />)
     });
@@ -44,7 +49,6 @@ const useLoadingErrorCallout = ({
   }, [sectionTitleFetchFailed]);
 
   return {
-    calloutRef,
     showErrorNotification: showCustomFieldsUpdateErrorNotification,
   };
 };

--- a/lib/CustomFields/utils/useLoadingErrorCallout.js
+++ b/lib/CustomFields/utils/useLoadingErrorCallout.js
@@ -18,35 +18,27 @@ const useLoadingErrorCallout = ({
     });
   };
 
-  const showCustomFieldsRetrieveErrorNotification = () => {
-    callout.sendCallout({
-      dedupe: true,
-      type: 'error',
-      message: (<FormattedMessage id="stripes-smart-components.customFields.error.get" />)
-    });
-  };
-
-  const showSectionTitleRetrieveErrorNotification = () => {
-    callout.sendCallout({
-      dedupe: true,
-      type: 'error',
-      message: (<FormattedMessage id="stripes-smart-components.customFields.sectionTitle.error.get" />)
-    });
-  };
-
   const hasCustomFieldsRetrievalError = customFieldsFetchFailed || optionsStatsFetchFailed;
 
   useEffect(() => {
     if (hasCustomFieldsRetrievalError) {
-      showCustomFieldsRetrieveErrorNotification();
+      callout.sendCallout({
+        dedupe: true,
+        type: 'error',
+        message: (<FormattedMessage id="stripes-smart-components.customFields.error.get" />)
+      });
     }
-  }, [hasCustomFieldsRetrievalError]);
+  }, [hasCustomFieldsRetrievalError, callout]);
 
   useEffect(() => {
     if (sectionTitleFetchFailed) {
-      showSectionTitleRetrieveErrorNotification();
+      callout.sendCallout({
+        dedupe: true,
+        type: 'error',
+        message: (<FormattedMessage id="stripes-smart-components.customFields.sectionTitle.error.get" />)
+      });
     }
-  }, [sectionTitleFetchFailed]);
+  }, [sectionTitleFetchFailed, callout]);
 
   return {
     showErrorNotification: showCustomFieldsUpdateErrorNotification,

--- a/translations/stripes-smart-components/en.json
+++ b/translations/stripes-smart-components/en.json
@@ -252,6 +252,8 @@
   "customFields.helpText.lengthExceeded": "100 character limit has been exceeded. Please revise.",
   "customFields.fieldName.lengthLimit": "65 character limit has been exceeded. Please revise.",
   "customFields.errorOccurred": "Unable to update due to a module error. Please try again. If problem persists please contact your system administrator.",
+  "customFields.error.get": "Unable to retrieve custom field data due to a module error. Please try again. If problem persists please contact your system administrator.",
+  "customFields.sectionTitle.error.get": "Unable to retrieve section title due to a module error. Please try again. If problem persists please contact your system administrator.",
   "customFields.dropdown.label": "Label",
   "customFields.dropdown.code": "Code",
   "customFields.dropdown.default": "Default value",


### PR DESCRIPTION
## Purpose
If there is a failure to retrieve the custom field section title (`useSectionTitleQuery`), prevent:
1. `ViewCustomFieldsRecord` component crash (`Uncaught TypeError: Cannot read properties of undefined (reading 'sendCallout')`
2. Endlessly loading display by other components

## Approach
1. ~~Moved the guilty part of the code to the `renderContent()` function so that `<Callout ref={calloutRef} />` exists immediately.~~ Removed the `Callout` and added a `useCallout` to `useLoadingErrorCallout`.
3. Removed `sectionTitleFetchFailed` from `const sectionTitleLoaded = !isLoadingSectionTitle && !sectionTitleFetchFailed;`

## Issues
[STSMACOM-929](https://folio-org.atlassian.net/browse/STSMACOM-929)