### PR TITLE
STSMACOM-957 Handle undefined response in processBadResponse

### DIFF
--- a/lib/EditableList/processBadResponse.js
+++ b/lib/EditableList/processBadResponse.js
@@ -23,7 +23,7 @@ const getErrorMessage = (errorCode, values = {}) => {
 const handleError = (errorMessages, message, values) => {
   const updatedErrorMessages = { ...errorMessages };
 
-  if (values && values.fieldLabel) {
+  if (values?.fieldLabel) {
     if (updatedErrorMessages.fieldErrors[values.fieldLabel]) {
       updatedErrorMessages.fieldErrors[values.fieldLabel].push(message);
     } else {
@@ -68,17 +68,7 @@ const getDefaultErrorMessage = (defaultErrorCode) => {
 };
 
 export default async function processBadResponse(response, defaultErrorCode, getCustomErrorMessages = null) {
-  // ControlledVocab rejects its delete promise with no
-  // argument when the DELETE fails (e.g. a 403), so `response` arrives here as
-  // undefined and `response.status` throws, crashing the whole app instead of
-  // surfacing the failure. Guard against a non-Response reason and fall back to
-  // the default error message. See stripes-smart-components ControlledVocab
-  // onDeleteItem -> deleteItemReject().
-  if (!response || typeof response.status !== 'number') {
-    return getDefaultErrorMessage(defaultErrorCode);
-  }
-
-  if (response.status === 422) {
+  if (response?.status === 422) {
     try {
       const { errors } = await response.json();
 
@@ -88,11 +78,12 @@ export default async function processBadResponse(response, defaultErrorCode, get
 
       return getErrorMessages(errors, defaultErrorCode);
     } catch (e) {
-      return getDefaultErrorMessage(defaultErrorCode);
+      // eslint-disable-next-line no-console
+      console.error('Response code was 422 but content could not be parsed.', e);
     }
   }
 
-  if (response.status === 409) {
+  if (response?.status === 409) {
     return getDefaultErrorMessage(errorCodes.conflict);
   }
 

--- a/lib/EditableList/processBadResponse.js
+++ b/lib/EditableList/processBadResponse.js
@@ -68,6 +68,16 @@ const getDefaultErrorMessage = (defaultErrorCode) => {
 };
 
 export default async function processBadResponse(response, defaultErrorCode, getCustomErrorMessages = null) {
+  // ControlledVocab rejects its delete promise with no
+  // argument when the DELETE fails (e.g. a 403), so `response` arrives here as
+  // undefined and `response.status` throws, crashing the whole app instead of
+  // surfacing the failure. Guard against a non-Response reason and fall back to
+  // the default error message. See stripes-smart-components ControlledVocab
+  // onDeleteItem -> deleteItemReject().
+  if (!response || typeof response.status !== 'number') {
+    return getDefaultErrorMessage(defaultErrorCode);
+  }
+
   if (response.status === 422) {
     try {
       const { errors } = await response.json();

--- a/lib/EditableList/processBadResponse.test.js
+++ b/lib/EditableList/processBadResponse.test.js
@@ -1,0 +1,121 @@
+import processBadResponse from './processBadResponse';
+import { errorCodes } from './constants';
+
+const createResponse = (status, json = jest.fn()) => ({
+  status,
+  json,
+});
+
+describe('processBadResponse', () => {
+  it('maps 422 duplicate-name errors into field and common error messages', async () => {
+    const response = createResponse(422, jest.fn().mockResolvedValue({
+      errors: [
+        {
+          code: errorCodes.nameDuplicate,
+          parameters: [
+            { key: 'fieldLabel', value: 'Name' },
+            { key: 'duplicateValue', value: 'alpha' },
+          ],
+        },
+        {
+          code: errorCodes.nameDuplicate,
+          parameters: [
+            { key: 'fieldLabel', value: 'Name' },
+          ],
+        },
+        {
+          code: 'some.other.error',
+        },
+      ],
+    }));
+
+    const result = await processBadResponse(response, errorCodes.defaultSaveError);
+
+    expect(response.json).toHaveBeenCalledTimes(1);
+    expect(result.fieldErrors.Name).toHaveLength(2);
+    expect(result.fieldErrors.Name[0].props).toMatchObject({
+      id: 'stripes-smart-components.error.name.duplicate',
+      values: {
+        fieldLabel: 'Name',
+        duplicateValue: 'alpha',
+      },
+    });
+    expect(result.fieldErrors.Name[1].props).toMatchObject({
+      id: 'stripes-smart-components.error.name.duplicate',
+      values: {
+        fieldLabel: 'Name',
+      },
+    });
+    expect(result.commonErrors).toHaveLength(1);
+    expect(result.commonErrors[0].props).toMatchObject({
+      id: 'stripes-smart-components.error.defaultSaveError',
+      values: {},
+    });
+  });
+
+  it('uses a custom error mapper when provided for 422 responses', async () => {
+    const customErrorMessages = { custom: true };
+    const getCustomErrorMessages = jest.fn(() => customErrorMessages);
+    const response = createResponse(422, jest.fn().mockResolvedValue({
+      errors: [
+        {
+          code: errorCodes.nameDuplicate,
+          parameters: [{ key: 'fieldLabel', value: 'Name' }],
+        },
+      ],
+    }));
+
+    const result = await processBadResponse(
+      response,
+      errorCodes.defaultSaveError,
+      getCustomErrorMessages,
+    );
+
+    expect(response.json).toHaveBeenCalledTimes(1);
+    expect(getCustomErrorMessages).toHaveBeenCalledWith([
+      {
+        code: errorCodes.nameDuplicate,
+        parameters: [{ key: 'fieldLabel', value: 'Name' }],
+      },
+    ]);
+    expect(result).toBe(customErrorMessages);
+  });
+
+  it('falls back to the default error message when 422 JSON parsing fails', async () => {
+    const response = createResponse(422, jest.fn().mockRejectedValue(new Error('bad json')));
+
+    const result = await processBadResponse(response, errorCodes.defaultSaveError);
+
+    expect(response.json).toHaveBeenCalledTimes(1);
+    expect(result.fieldErrors).toEqual({});
+    expect(result.commonErrors).toHaveLength(1);
+    expect(result.commonErrors[0].props).toMatchObject({
+      id: 'stripes-smart-components.error.defaultSaveError',
+      values: {},
+    });
+  });
+
+  it('returns the conflict error for 409 responses', async () => {
+    const response = createResponse(409);
+
+    const result = await processBadResponse(response, errorCodes.defaultSaveError);
+
+    expect(result.fieldErrors).toEqual({});
+    expect(result.commonErrors).toHaveLength(1);
+    expect(result.commonErrors[0].props).toMatchObject({
+      id: 'stripes-smart-components.error.conflict',
+      values: {},
+    });
+  });
+
+  it('returns the default error message for missing or unsupported responses', async () => {
+    const result = await processBadResponse(undefined, errorCodes.defaultRemoveError);
+
+    expect(result.fieldErrors).toEqual({});
+    expect(result.commonErrors).toHaveLength(1);
+    expect(result.commonErrors[0].props).toMatchObject({
+      id: 'stripes-smart-components.error.defaultRemoveError',
+      values: {},
+    });
+  });
+});


### PR DESCRIPTION
Add guard clause to handle undefined response in processBadResponse function.

I ran across this while developing ui-cyclops, and running against a server that had not yet had the new permissions inserted. Obviously that's a bit of an edge-case as it's unlikely to happen on a well-managed production system. But I do think that no permissions state should ever cause an actual crash.

New jest tests cover this condition; existing BT suite allowed it to slip through.

Refs [STSMACOM-957](https://folio-org.atlassian.net/browse/STSMACOM-957)