### PR TITLE
STSMACOM-959: Add SearchAndSort pass through for actionMenuToggleProps to Pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Supply Personal Data Disclosure form. Refs STSMACOM-909.
 * `<ViewCustomFieldsRecord>` - render `DATE_PICKER` values in UTC so the displayed day matches the saved value in non-UTC timezones. Fixes STSMACOM-950.
 * `ViewCustomFieldsRecord` - make `calloutRef` available after the component is mounted to prevent a page crash when the section title fetch fails. Fixes STSMACOM-929.
+* `SearchAndSort` - Add pass through `actionMenuToggleProps` for `Pane`. Refs STSMACOM-959.
 
 ## 10.1.0 IN PROGRESS
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -284,7 +284,6 @@ class SearchAndSort extends React.Component {
   };
 
   static defaultProps = {
-    actionMenuToggleProps: {},
     autofocusSearchField: true,
     advancedSearchIndex: 'advancedSearch',
     advancedSearchOptions: [],
@@ -1447,6 +1446,7 @@ class SearchAndSort extends React.Component {
       viewRecordPathById,
       createRecordPath,
       paneTitleRef,
+      actionMenuToggleProps,
     } = this.props;
     const { filterPaneIsVisible } = this.state;
 

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -98,6 +98,7 @@ const queryParam = (name, props) => {
 class SearchAndSort extends React.Component {
   static propTypes = {
     actionMenu: PropTypes.func, // parameter properties provided by caller
+    actionMenuToggleProps: PropTypes.object,
     advancedSearchIndex: PropTypes.string,
     advancedSearchOptions: PropTypes.arrayOf(PropTypes.object),
     advancedSearchQueryBuilder: PropTypes.func,
@@ -1458,6 +1459,7 @@ class SearchAndSort extends React.Component {
         padContent={false}
         defaultWidth="fill"
         actionMenu={this.getActionMenu(columnManagerRenderProps)}
+        actionMenuToggleProps={actionMenuToggleProps}
         appIcon={<AppIcon app={moduleName} />}
         paneTitle={title || (module && module.displayName)}
         paneSub={this.getPaneSub(source)}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -284,6 +284,7 @@ class SearchAndSort extends React.Component {
   };
 
   static defaultProps = {
+    actionMenuToggleProps: {},
     autofocusSearchField: true,
     advancedSearchIndex: 'advancedSearch',
     advancedSearchOptions: [],


### PR DESCRIPTION
Allow `SearchAndSort` uses to pass through properties to the action menu button in a `Pane`, particularly `aria-label`.

https://folio-org.atlassian.net/browse/STSMACOM-959