### PR TITLE
STSMACOM-961: EditCustomFieldsRecord - apply word-breaking styles to all custom field types including RadioButtonGroup labels, Select/MultiSelect options, Checkbox labels, and validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `ViewCustomFieldsRecord` - make `calloutRef` available after the component is mounted to prevent a page crash when the section title fetch fails. Fixes STSMACOM-929.
 * `SearchAndSort` - Add pass through `actionMenuToggleProps` for `Pane`. Refs STSMACOM-959.
 * Update user addresses view to support empty state. Refs STSMACOM-960.
+* `EditCustomFieldsRecord` - apply word-breaking styles to all custom field types including RadioButtonGroup labels, Select/MultiSelect options, Checkbox labels, and validation messages. Refs STSMACOM-961.
 
 ## 10.1.0 IN PROGRESS
 

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
@@ -1,11 +1,93 @@
+/**
+ * EditCustomFieldsRecord Styles
+ *
+ * This file handles word-breaking and text wrapping for all custom field types:
+ * - TextField (TEXTBOX_SHORT)
+ * - TextArea (TEXTBOX_LONG)
+ * - Checkbox (SINGLE_CHECKBOX)
+ * - Select (SINGLE_SELECT_DROPDOWN)
+ * - MultiSelect (MULTI_SELECT_DROPDOWN)
+ * - RadioButtonGroup (RADIO_BUTTON)
+ * - DatePicker (DATE_PICKER)
+ */
+
+/* Field label with word-breaking for all custom fields */
 .fieldLabel {
   position: relative;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 .fieldLabel legend {
   margin-bottom: 0;
 }
 
+/*
+ * Container for all custom fields to scope styles
+ * Applied to: TextField, TextArea, Checkbox, Select, MultiSelect, DatePicker
+ */
+.customFieldContainer {
+  /* Apply word-breaking to all labels in any field type */
+  & :global(label) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+
+  /* Apply word-breaking to Select and MultiSelect options */
+  & :global([class*="multiSelectOption"]),
+  & :global([class*="option"]),
+  & :global([class*="singleValue"]) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+
+  /* Apply word-breaking to Checkbox labels */
+  & :global([class*="checkbox"]) :global(label) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+
+  /* Apply word-breaking to validation error messages */
+  & :global([class*="feedbackError"]) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+}
+
+/*
+ * RadioButtonGroup container with word-breaking for all child elements
+ * Applied to: RadioButtonGroup (RADIO_BUTTON) only
+ */
+.radioButtonGroupContainer {
+  /* Apply word-breaking to radio button labels */
+  & :global(label) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+
+  /* Apply word-breaking to legends */
+  & :global(legend) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+    margin-bottom: 0;
+  }
+
+  /* Apply word-breaking to RadioButtonGroup-specific validation error messages */
+  & :global([class*="groupError"]) {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+  }
+}
+
+/* InfoPopover positioning */
 .infoPopover {
   position: absolute;
   right: -2rem;

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.css
@@ -14,8 +14,8 @@
 /* Field label with word-breaking for all custom fields */
 .fieldLabel {
   position: relative;
-  word-break: break-word;
-  overflow-wrap: break-word;
+  word-break: normal;
+  overflow-wrap: anywhere;
   hyphens: auto;
 }
 
@@ -30,8 +30,8 @@
 .customFieldContainer {
   /* Apply word-breaking to all labels in any field type */
   & :global(label) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 
@@ -39,22 +39,22 @@
   & :global([class*="multiSelectOption"]),
   & :global([class*="option"]),
   & :global([class*="singleValue"]) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 
   /* Apply word-breaking to Checkbox labels */
   & :global([class*="checkbox"]) :global(label) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 
   /* Apply word-breaking to validation error messages */
   & :global([class*="feedbackError"]) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 }
@@ -66,23 +66,23 @@
 .radioButtonGroupContainer {
   /* Apply word-breaking to radio button labels */
   & :global(label) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 
   /* Apply word-breaking to legends */
   & :global(legend) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
     margin-bottom: 0;
   }
 
   /* Apply word-breaking to RadioButtonGroup-specific validation error messages */
   & :global([class*="groupError"]) {
-    word-break: break-word;
-    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-wrap: anywhere;
     hyphens: auto;
   }
 }

--- a/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
+++ b/lib/CustomFields/pages/EditCustomFieldsRecord/EditCustomFieldsRecord.js
@@ -281,13 +281,33 @@ const EditCustomFieldsRecord = ({
     return {};
   };
 
-  const createCustomFieldRenderFunction = customField => (props = {}) => (
-    fieldComponents[customField.type] && (
+  /**
+   * Create a custom field render function with proper CSS class for word-breaking
+   *
+   * @param {Object} customField - The custom field configuration
+   * @returns {Function} A function that renders the field with appropriate props
+   *
+   * Field types handled:
+   * - TEXTFIELD, TEXTAREA, CHECKBOX, SELECT, DATE_PICKER -> .customFieldContainer
+   * - MULTISELECT -> .customFieldContainer
+   * - RADIO_BUTTON_GROUP -> .radioButtonGroupContainer (inherits .customFieldContainer)
+   */
+  const createCustomFieldRenderFunction = customField => (props = {}) => {
+    // Determine the appropriate CSS class based on field type
+    const getFieldClassName = () => {
+      if (customField.type === fieldTypes.RADIO_BUTTON_GROUP) {
+        return css.radioButtonGroupContainer;
+      }
+      return css.customFieldContainer;
+    };
+
+    return fieldComponents[customField.type] && (
       <Col
         data-test-record-edit-custom-field
         key={customField.refId}
         md={columnWidth}
         xs={rowShapes}
+        className={getFieldClassName()}
       >
         <Field
           component={fieldComponents[customField.type]}
@@ -311,8 +331,8 @@ const EditCustomFieldsRecord = ({
           </OnChange>
         }
       </Col>
-    )
-  );
+    );
+  };
 
   const getRadioButtonSetChildren = customField => {
     return customField.selectField.options.values.map(option => (


### PR DESCRIPTION
## Purpose
EditCustomFieldsRecord - apply word-breaking styles to all custom field types including RadioButtonGroup labels, Select/MultiSelect options, Checkbox labels, and validation messages

# Approach 
<img width="1918" height="902" alt="image" src="https://github.com/user-attachments/assets/1140efd9-f531-47f8-a93d-336b32ccdf24" />

# Refs
https://issues.folio.org/browse/STSMACOM-961
