### PR TITLE
STSMACOM-958: `<ExpandFilterPaneButton>` / `<CollapseFilterPaneButton>` - restore focus to the toggle button after the filter pane is expanded/collapsed instead of losing it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update user addresses view to support empty state. Refs STSMACOM-960.
 * `EditCustomFieldsRecord` - apply word-breaking styles to all custom field types including RadioButtonGroup labels, Select/MultiSelect options, Checkbox labels, and validation messages. Refs STSMACOM-961.
 * Fixed the issue where the Last updated field erroneously displays Unknown user. Refs STSMACOM-962.
+* `<ExpandFilterPaneButton>`/`<CollapseFilterPaneButton>` - restore focus to the toggle button after the filter pane is expanded/collapsed instead of losing it. Fixes STSMACOM-958.
 
 ## 10.1.0 IN PROGRESS
 

--- a/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
+++ b/lib/SearchAndSort/components/CollapseFilterPaneButton/CollapseFilterPaneButton.js
@@ -2,14 +2,20 @@
  * CollapseFilterPaneButton
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { PaneHeaderIconButton, Tooltip } from '@folio/stripes-components';
+import { restorePaneToggleFocus } from '../../../utils';
 import css from './CollapseFilterPaneButton.css';
 
 const CollapseFilterPaneButton = ({ onClick }) => {
   const intl = useIntl();
+
+  const handleClick = useCallback((event) => {
+    onClick?.(event);
+    restorePaneToggleFocus();
+  }, [onClick]);
 
   return (
     <Tooltip
@@ -22,7 +28,7 @@ const CollapseFilterPaneButton = ({ onClick }) => {
           aria-labelledby={ariaIds.text}
           icon="caret-left"
           iconSize="medium"
-          onClick={onClick}
+          onClick={handleClick}
           className={css.button}
           data-test-collapse-filter-pane-button
         />

--- a/lib/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.js
+++ b/lib/SearchAndSort/components/ExpandFilterPaneButton/ExpandFilterPaneButton.js
@@ -2,39 +2,47 @@
  * CollapseFilterPaneButton
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { PaneHeaderIconButton, Tooltip } from '@folio/stripes-components';
+import { restorePaneToggleFocus } from '../../../utils';
 
-const CollapseFilterPaneButton = ({ onClick, filterCount }) => (
-  <Tooltip
-    text={<FormattedMessage id="stripes-smart-components.showSearchPane" />}
-    sub={filterCount
-      ? (
-        <FormattedMessage
-          id="stripes-smart-components.numberOfFilters"
-          values={{ count: filterCount }}
+const CollapseFilterPaneButton = ({ onClick, filterCount }) => {
+  const handleClick = useCallback((event) => {
+    onClick?.(event);
+    restorePaneToggleFocus();
+  }, [onClick]);
+
+  return (
+    <Tooltip
+      text={<FormattedMessage id="stripes-smart-components.showSearchPane" />}
+      sub={filterCount
+        ? (
+          <FormattedMessage
+            id="stripes-smart-components.numberOfFilters"
+            values={{ count: filterCount }}
+          />
+        )
+        : null
+      }
+      id="expand-filter-pane-button-tooltip"
+    >
+      {({ ref, ariaIds }) => (
+        <PaneHeaderIconButton
+          ref={ref}
+          icon="caret-right"
+          iconSize="medium"
+          onClick={handleClick}
+          badgeCount={filterCount || undefined}
+          aria-labelledby={ariaIds.text}
+          aria-describedby={ariaIds.sub}
+          data-test-expand-filter-pane-button
         />
-      )
-      : null
-    }
-    id="expand-filter-pane-button-tooltip"
-  >
-    {({ ref, ariaIds }) => (
-      <PaneHeaderIconButton
-        ref={ref}
-        icon="caret-right"
-        iconSize="medium"
-        onClick={onClick}
-        badgeCount={filterCount || undefined}
-        aria-labelledby={ariaIds.text}
-        aria-describedby={ariaIds.sub}
-        data-test-expand-filter-pane-button
-      />
-    )}
-  </Tooltip>
-);
+      )}
+    </Tooltip>
+  );
+};
 
 CollapseFilterPaneButton.propTypes = {
   filterCount: PropTypes.number,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2,4 +2,5 @@ export { default as useRemoteStorageMappings } from './useRemoteStorageMappings'
 export { useSetRef } from './useSetRef';
 export { useSetRefOnFocus } from './useSetRefOnFocus';
 export { default as usePrevious } from './usePrevious';
+export { restorePaneToggleFocus } from './restorePaneToggleFocus';
 export default {};

--- a/lib/utils/restorePaneToggleFocus.js
+++ b/lib/utils/restorePaneToggleFocus.js
@@ -1,0 +1,35 @@
+/**
+ * A pane-toggle button (e.g. Expand/Collapse filter-pane) is often rendered as
+ * two separate, mutually-exclusive instances - one per toggle state - each
+ * living in a `<Pane>` that mounts/unmounts as the toggle state changes. When
+ * the button that currently has focus is removed from the DOM as a result of
+ * being clicked, the browser drops focus to `<body>`, and the next `Tab` press
+ * lands on the first focusable element on the page (e.g. a "Skip to main
+ * content" link) instead of staying near the toggle control. See STCOM-1521.
+ *
+ * Call this from within the toggle button's `onClick` handler, after
+ * triggering the toggle, to restore focus to whichever instance of the toggle
+ * button ends up in the DOM once React re-renders.
+ *
+ * @param {string} [selector] a CSS selector matching whichever toggle button
+ * instance is currently in the DOM. Defaults to the Expand/Collapse
+ * filter-pane buttons' selector; pass a custom selector to reuse this for
+ * other pane-toggle button pairs.
+ */
+const FILTER_PANE_TOGGLE_BUTTON_SELECTOR = '[data-test-expand-filter-pane-button], [data-test-collapse-filter-pane-button]';
+
+export const restorePaneToggleFocus = (selector = FILTER_PANE_TOGGLE_BUTTON_SELECTOR) => {
+  // The `onClick` handler runs before React has re-rendered/committed the
+  // resulting DOM changes, so the counterpart toggle button may not exist
+  // yet. Deferring with `requestAnimationFrame` waits until after the
+  // browser's next paint, by which point React has flushed the re-render
+  // and the counterpart button is available to receive focus.
+  //
+  // Focus is always moved to the toggle button, regardless of where it
+  // currently is, so that activating the toggle reliably keeps focus on
+  // the control rather than letting it fall through to `<body>` or get
+  // claimed by an unrelated `autoFocus`/programmatic focus elsewhere.
+  window.requestAnimationFrame(() => {
+    document.querySelector(selector)?.focus();
+  });
+};


### PR DESCRIPTION
## Purpose
In the Search & Filter pane, after clicking the ` < ` button (collapse search & filter pane), the focus should be moved to the button ` > ` (expand search & filter pane).

## Approach
Almost all apps use `<ExpandFilterPaneButton>` and `<CollapseFilterPaneButton>`, so this can be fixed globally.
After clicking the `<`, the `<CollapseFilterPaneButton>` unmounts and `<ExpandFilterPaneButton>` mounts. Defer the focus in `<CollapseFilterPaneButton>` using`requestAnimationFrame` to wait until after the browser's next paint (`restorePaneToggleFocus`):

```
window.requestAnimationFrame(() => {
    document.querySelector(selector)?.focus();
  });
```

The apps that don't use `<ExpandFilterPaneButton>` and `<CollapseFilterPaneButton>` ([ui-consortia-settings](https://folio-org.atlassian.net/browse/UICONSET-246)) will reuse `restorePaneToggleFocus`.


## Issues
[STSMACOM-958](https://folio-org.atlassian.net/browse/STSMACOM-958)

## Screencasts


https://github.com/user-attachments/assets/a8e97f6b-5508-4bd8-bbaa-22d35647ff64



